### PR TITLE
fix(build): unset NoDefaultCurrentDirectoryInExePath for node-pty rebuild on Windows

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -30,12 +30,37 @@ function log(msg) {
   console.log(`[postinstall] ${msg}`)
 }
 
+/**
+ * Build the environment for native-rebuild child processes.
+ *
+ * On Windows, node-pty's bundled winpty.gyp shells out with
+ * `cmd /c "cd shared && GetCommitHash.bat"`. When the machine has the
+ * `NoDefaultCurrentDirectoryInExePath` environment variable set (common on
+ * locked-down / enterprise Windows), cmd.exe stops searching the current
+ * directory for executables, so the batch file is "not recognized" and the
+ * gyp configure step fails before the compiler is ever invoked. Removing the
+ * variable for our child processes restores the default lookup behavior.
+ */
+function buildEnv() {
+  if (!IS_WINDOWS) return process.env
+  const env = { ...process.env }
+  // process.env keys are case-insensitive on Windows, but a plain object copy
+  // is not — delete every casing so the child never inherits it.
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'nodefaultcurrentdirectoryinexepath') {
+      delete env[key]
+    }
+  }
+  return env
+}
+
 function rebuildNativeModules() {
   log('running electron-builder install-app-deps...')
   const result = spawnSync('npx', ['electron-builder', 'install-app-deps'], {
     cwd: ROOT,
     stdio: 'inherit',
     shell: IS_WINDOWS,
+    env: buildEnv(),
   })
   if (result.status !== 0) {
     if (IS_WINDOWS) {


### PR DESCRIPTION
## Problem

On Windows machines that set the `NoDefaultCurrentDirectoryInExePath` environment variable (common on locked-down / enterprise systems), `npm install` fails during the native rebuild:

```
'GetCommitHash.bat' is not recognized as an internal or external command
gyp: Call to 'cmd /c "cd shared && GetCommitHash.bat"' returned exit status 1
      while in deps\winpty\src\winpty.gyp
```

## Root cause

`NoDefaultCurrentDirectoryInExePath` stops `cmd.exe` from searching the current directory for executables. node-pty's bundled `winpty.gyp` shells out with `cmd /c "cd shared && GetCommitHash.bat"` — a bare batch filename — so after `cd shared`, cmd can't find `GetCommitHash.bat` even though it's right there, and the gyp *configure* step fails before the compiler runs.

This is unrelated to the Spectre-libs cause the postinstall script currently guesses for Windows rebuild failures; it happens earlier, at configure time.

## Fix

`scripts/postinstall.js` now strips `NoDefaultCurrentDirectoryInExePath` (case-insensitively) from the environment it passes to the native-rebuild child processes, restoring cmd's default current-directory lookup. It's a no-op on non-Windows and on machines without the variable set.

## Testing

- Reproduced the failure on a Windows machine with the variable set; `npm install` failed at the winpty configure step.
- With the fix, node-pty rebuilds successfully and `npm run build` / `electron-builder --win` complete.