### PR TITLE
fix(ui): replace native delete confirm with themed in-app dialog

### DIFF
--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -11,7 +11,7 @@ import { NotesPanel } from './components/notes-panel'
 import { SkillsPanel } from './components/skills-panel'
 import { NotePicker } from './components/note-picker'
 import { CommandPalette } from './components/command-palette'
-import { ExtensionUiDialog } from './components/extension-ui-dialog'
+import { ExtensionUiDialog, AppConfirmDialog } from './components/extension-ui-dialog'
 import { ReviewRail } from './components/review-rail'
 import { useContextMenu, buildDefaultContextMenu } from './components/context-menu'
 import { usePiEvents, useMenuActions, useInitialize, useNotePickerShortcut } from './hooks'
@@ -123,6 +123,7 @@ export function App(): React.JSX.Element {
 
       {!isHome && <StatusBar />}
       <ExtensionUiDialog />
+      <AppConfirmDialog />
       <NotePicker />
       <CommandPalette />
       {ContextMenuComponent}

--- a/src/renderer/src/components/context-menu.tsx
+++ b/src/renderer/src/components/context-menu.tsx
@@ -14,6 +14,7 @@ import {
   NotebookPen,
 } from 'lucide-react'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
+import { useAppStore } from '../store'
 
 interface ContextMenuItem {
   id: string
@@ -383,13 +384,17 @@ export function buildSessionContextMenu(
       id: 'session-delete',
       label: 'Delete…',
       icon: <Trash2 size={14} />,
-      action: () => {
-        // Confirm before destructive action. Trash is recoverable when
-        // installed; without it, delete is permanent. The wording is
-        // honest about that.
-        const ok = window.confirm(
-          `Delete session "${displayName}"?\n\nWill use the system 'trash' CLI if installed (recoverable); otherwise the .jsonl session file is permanently removed.`
-        )
+      action: async () => {
+        // Confirm before destructive action via an in-app themed dialog (not the
+        // native window.confirm, which mismatches the theme and leaves the
+        // Electron window without keyboard focus). Trash is recoverable when
+        // installed; without it, delete is permanent — the wording is honest.
+        const ok = await useAppStore.getState().requestConfirm({
+          title: 'Delete session',
+          message: `Delete session "${displayName}"?\n\nWill use the system 'trash' CLI if installed (recoverable); otherwise the .jsonl session file is permanently removed.`,
+          confirmLabel: 'Delete',
+          danger: true,
+        })
         if (ok) actions.onDelete(session)
       },
     },

--- a/src/renderer/src/components/extension-ui-dialog.tsx
+++ b/src/renderer/src/components/extension-ui-dialog.tsx
@@ -250,6 +250,57 @@ function EditorDialog({
   )
 }
 
+// ─── App Confirmation Dialog ─────────────────────────────────────────────────
+
+// Themed replacement for window.confirm(), driven by store.requestConfirm().
+// Using a real in-app modal (instead of the native dialog) also avoids an
+// Electron quirk where window.confirm leaves the window without keyboard focus.
+export function AppConfirmDialog(): React.JSX.Element | null {
+  const request = useAppStore((state) => state.confirmRequest)
+  const resolveConfirm = useAppStore((state) => state.resolveConfirm)
+
+  useEffect(() => {
+    if (!request) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        resolveConfirm(false)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [request, resolveConfirm])
+
+  if (!request) return null
+
+  return (
+    <DialogOverlay onCancel={() => resolveConfirm(false)}>
+      <DialogBox title={request.title ?? 'Confirm'} onCancel={() => resolveConfirm(false)}>
+        <p className="mb-4 whitespace-pre-line text-sm text-neutral-400">{request.message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => resolveConfirm(false)}
+            autoFocus={request.danger}
+            className="rounded-md border border-neutral-700 px-4 py-2 text-sm text-neutral-400 hover:bg-neutral-800 transition-colors"
+          >
+            {request.cancelLabel ?? 'Cancel'}
+          </button>
+          <button
+            onClick={() => resolveConfirm(true)}
+            autoFocus={!request.danger}
+            className={clsx(
+              'rounded-md px-4 py-2 text-sm text-white transition-colors',
+              request.danger ? 'bg-red-600 hover:bg-red-500' : 'bg-blue-600 hover:bg-blue-500'
+            )}
+          >
+            {request.confirmLabel ?? 'Confirm'}
+          </button>
+        </div>
+      </DialogBox>
+    </DialogOverlay>
+  )
+}
+
 // ─── Shared Dialog Components ────────────────────────────────────────────────
 
 function DialogOverlay({

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -64,6 +64,21 @@ export interface CouncilRunState {
   reason?: string
 }
 
+// ─── Confirmation Dialog ─────────────────────────────────────────────────────
+
+export interface ConfirmOptions {
+  title?: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  // Style the confirm button as destructive (red).
+  danger?: boolean
+}
+
+export interface ConfirmRequest extends ConfirmOptions {
+  resolve: (confirmed: boolean) => void
+}
+
 // ─── Store Shape ─────────────────────────────────────────────────────────────
 
 interface AppState {
@@ -105,6 +120,9 @@ interface AppState {
 
   // Extension UI
   extensionUiRequest: PiExtensionUiRequest | null
+
+  // App-level confirmation dialog (themed replacement for window.confirm)
+  confirmRequest: ConfirmRequest | null
 
   // Workspaces
   workspaces: Workspace[]
@@ -228,6 +246,10 @@ interface AppActions {
   // Extension UI
   respondExtensionUi: (id: string, response: Record<string, unknown>) => void
   dismissExtensionUi: () => void
+
+  // App confirmation dialog (promise-based; resolves true on confirm)
+  requestConfirm: (options: ConfirmOptions) => Promise<boolean>
+  resolveConfirm: (confirmed: boolean) => void
 
   // Workspaces
   loadWorkspaces: () => Promise<void>
@@ -359,6 +381,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   commands: [],
 
   extensionUiRequest: null,
+  confirmRequest: null,
 
   workspaces: [],
   activeWorkspace: null,
@@ -1063,6 +1086,20 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       }
       set({ extensionUiRequest: null })
     }
+  },
+
+  requestConfirm: (options) =>
+    new Promise<boolean>((resolve) => {
+      // Resolve any dialog already open (treated as cancelled) before showing.
+      const pending = get().confirmRequest
+      if (pending) pending.resolve(false)
+      set({ confirmRequest: { ...options, resolve } })
+    }),
+
+  resolveConfirm: (confirmed) => {
+    const req = get().confirmRequest
+    if (req) req.resolve(confirmed)
+    set({ confirmRequest: null })
   },
 
   // ─── Workspaces ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

After deleting a session, the "Ask Pi anything" composer would not accept keyboard input. Switching sessions didn't help; only alt-tabbing away and back to the window restored typing.

## Root cause

The session "Delete…" action used `window.confirm()`. In Electron, that native modal leaves the `BrowserWindow`'s web contents without keyboard focus after it closes, so inputs stop accepting typing until the window is re-focused. (The Pi process/`piStatus` was never involved — the composer was enabled the whole time; it just couldn't receive keystrokes.)

## Fix

Replace the native `window.confirm` with an in-app, themed confirmation dialog — which removes the focus-stealing native modal entirely (and also matches the app's look, unlike the OS dialog):

- Added promise-based `requestConfirm()` / `resolveConfirm()` and `confirmRequest` state to the store.
- Added `AppConfirmDialog`, reusing the existing `DialogOverlay` / `DialogBox` primitives in `extension-ui-dialog.tsx`; supports a `danger` (destructive) style and dismisses on Escape / overlay click / Cancel.
- The session-delete action now `await`s `requestConfirm({ danger: true, … })` instead of `window.confirm`.

This was the only remaining `window.confirm` in the renderer; the new dialog is reusable for future confirmations and standardizes destructive-action prompts on the app's own dialog.

## Testing

- Manually verified on Windows: right-click a session → Delete… shows the themed dialog; after confirming, the composer accepts typing immediately (no alt-tab). Escape / clicking outside / Cancel dismiss without deleting.
- `npm run build`, `tsc -b --noEmit`, and `eslint` all pass.