### PR TITLE
fix(sessions): show a distinguishable time in fallback session titles

### DIFF
--- a/src/renderer/src/components/context-menu.tsx
+++ b/src/renderer/src/components/context-menu.tsx
@@ -14,6 +14,7 @@ import {
   NotebookPen,
 } from 'lucide-react'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
+import { getSessionTitle } from '../utils/session-title'
 
 interface ContextMenuItem {
   id: string
@@ -352,7 +353,7 @@ export function buildSessionContextMenu(
   isArchived: boolean,
   actions: SessionContextMenuActions
 ): ContextMenuItem[] {
-  const displayName = session.name || session.sessionId.slice(0, 12)
+  const displayName = getSessionTitle(session.name, session.sessionId)
   return [
     {
       id: 'session-open',

--- a/src/renderer/src/components/home-screen.tsx
+++ b/src/renderer/src/components/home-screen.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { getSessionTitle } from '../utils/session-title'
 import { clsx } from 'clsx'
 import {
   SquareTerminal,
@@ -307,7 +308,7 @@ export function HomeScreen(): React.JSX.Element {
                       <Clock size={13} className="shrink-0 text-neutral-600" />
                       <div className="min-w-0 flex-1">
                         <div className="truncate text-sm text-neutral-300">
-                          {session.name || session.sessionId.slice(0, 12)}
+                          {getSessionTitle(session.name, session.sessionId)}
                         </div>
                         <div className="truncate text-[11px] text-neutral-600">{session.projectName}</div>
                       </div>

--- a/src/renderer/src/components/session-panel.tsx
+++ b/src/renderer/src/components/session-panel.tsx
@@ -1,4 +1,5 @@
 import { useAppStore } from '../store'
+import { getSessionTitle } from '../utils/session-title'
 import { FolderOpen, Plus, Clock, Search, ChevronRight, ChevronDown, FolderTree, Tag, X, MoreVertical, Archive, ArchiveRestore, Trash2, Sparkles } from 'lucide-react'
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
@@ -456,7 +457,7 @@ function SessionEntry({
         <Clock size={12} className="shrink-0 text-neutral-600" />
         <div className="min-w-0 flex-1">
           <div className={clsx('text-sm truncate', isActive ? 'text-blue-300' : 'text-neutral-400')}>
-            {session.name || session.sessionId.slice(0, 12)}
+            {getSessionTitle(session.name, session.sessionId)}
           </div>
           {(tags.length > 0 || autoTag) && (
             <div className="flex flex-wrap gap-1 mt-1">

--- a/src/renderer/src/components/sidebar-session-labels.ts
+++ b/src/renderer/src/components/sidebar-session-labels.ts
@@ -1,4 +1,5 @@
 import type { SessionListItem } from '../../../shared/ipc-contracts'
+import { getSessionTitle } from '../utils/session-title'
 
 type SessionRowLabelInput = Pick<SessionListItem, 'name' | 'sessionId' | 'projectName' | 'projectPath'>
 
@@ -11,7 +12,7 @@ export function getSessionRowLabels(session: SessionRowLabelInput): SessionRowLa
   const subtitle = session.projectName.trim()
 
   return {
-    title: session.name || session.sessionId.slice(0, 12),
+    title: getSessionTitle(session.name, session.sessionId),
     subtitle: subtitle || null,
   }
 }

--- a/src/renderer/src/components/status-popover.tsx
+++ b/src/renderer/src/components/status-popover.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import { getSessionTitle } from '../utils/session-title'
 import { useAppStore } from '../store'
 import type { InstalledSkill } from '../../../shared/ipc-contracts'
 import { clsx } from 'clsx'
@@ -198,7 +199,7 @@ export function StatusPopover(): React.JSX.Element {
                 />
               )}
               {sessionState?.sessionId && (
-                <StatusRow label="Session" value={sessionState.sessionName || sessionState.sessionId.slice(0, 12)} />
+                <StatusRow label="Session" value={getSessionTitle(sessionState.sessionName, sessionState.sessionId)} />
               )}
             </StatusSection>
 

--- a/src/renderer/src/utils/session-title.test.ts
+++ b/src/renderer/src/utils/session-title.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { getSessionTitle } from './session-title'
+
+test('prefers an explicit session name', () => {
+  assert.equal(getSessionTitle('My session', '2026-07-04T13-58-32-590Z_019f2d6c'), 'My session')
+  assert.equal(getSessionTitle('  Trimmed  ', 'x'), 'Trimmed')
+})
+
+test('formats a Pi timestamp id with a distinguishable time', () => {
+  // Regression: same-day sessions used to collapse to "2026-07-04T1".
+  assert.equal(
+    getSessionTitle(null, '2026-07-04T13-34-18-375Z_019f2d56-4d07-7856-b0e0-df198d5d34ef'),
+    '2026-07-04 13:34:18'
+  )
+  assert.equal(
+    getSessionTitle(null, '2026-07-04T13-58-32-590Z_019f2d6c-7d8e-7e90-8c65-fa9a3f38fc32'),
+    '2026-07-04 13:58:32'
+  )
+})
+
+test('two same-day sessions get distinct titles', () => {
+  const a = getSessionTitle(null, '2026-07-04T13-34-18-375Z_019f2d56')
+  const b = getSessionTitle(null, '2026-07-04T13-58-32-590Z_019f2d6c')
+  assert.notEqual(a, b)
+})
+
+test('falls back to a short id for a bare UUID', () => {
+  assert.equal(getSessionTitle(null, '019f2d6c-7d8e-7e90-8c65-fa9a3f38fc32'), '019f2d6c-7d8')
+})
+
+test('falls back to a short id when name is empty/whitespace', () => {
+  assert.equal(getSessionTitle('', '019f2d6c-7d8e'), '019f2d6c-7d8')
+  assert.equal(getSessionTitle('   ', '019f2d6c-7d8e'), '019f2d6c-7d8')
+})

--- a/src/renderer/src/utils/session-title.ts
+++ b/src/renderer/src/utils/session-title.ts
@@ -1,0 +1,29 @@
+/**
+ * Human-readable title for a session.
+ *
+ * Pi names session files `<timestamp>_<uuid>.jsonl`, so a filesystem-listed
+ * session has no display name and a `sessionId` like
+ * `2026-07-04T13-58-32-590Z_019f2d6c-...`. The previous fallback of
+ * `sessionId.slice(0, 12)` was meant for short UUID prefixes; applied to a
+ * timestamp id it yields `2026-07-04T1` for *every* session created the same
+ * day (the slice stops mid-hour), making sessions indistinguishable.
+ *
+ * So: prefer an explicit name; otherwise, if the id carries Pi's timestamp
+ * prefix, format it as `YYYY-MM-DD HH:MM:SS` (using the wall-clock recorded in
+ * the filename); otherwise fall back to the short id (e.g. a bare UUID).
+ */
+
+// Matches the leading "YYYY-MM-DDTHH-MM-SS" of a Pi session filename stem.
+const SESSION_TIMESTAMP_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})-(\d{2})-(\d{2})/
+
+export function getSessionTitle(name: string | null | undefined, sessionId: string): string {
+  if (name && name.trim()) return name.trim()
+
+  const m = SESSION_TIMESTAMP_RE.exec(sessionId)
+  if (m) {
+    const [, year, month, day, hour, minute, second] = m
+    return `${year}-${month}-${day} ${hour}:${minute}:${second}`
+  }
+
+  return sessionId.slice(0, 12)
+}


### PR DESCRIPTION
## Problem

Sessions without an explicit name fall back to a title derived from the session id. For filesystem-listed sessions the id is Pi's filename stem (e.g. `2026-07-04T13-58-32-590Z_019f2d6c-...`), and the fallback used `sessionId.slice(0, 12)` — which for any timestamp id yields `2026-07-04T1`. Every session created on the same day therefore showed the **same** title (`2026-07-04T1`), making them impossible to tell apart.

## Fix

Added a small shared helper `getSessionTitle(name, sessionId)` and applied it at the five places that previously duplicated `name || sessionId.slice(0, 12)` (sidebar labels, home screen, session panel, session context menu, status popover):

- prefer an explicit session name;
- else, if the id carries Pi's `YYYY-MM-DDTHH-MM-SS` prefix, format it as `YYYY-MM-DD HH:MM:SS`;
- else fall back to the short id (bare UUID) as before.

Same-day sessions now show distinct titles, e.g. `2026-07-04 13:34:18` vs `2026-07-04 13:58:32`.

## Testing

- New unit tests in `src/renderer/src/utils/session-title.test.ts` (5 cases: name passthrough, timestamp formatting, same-day distinctness, UUID fallback, empty/whitespace name).
- `npm run build`, `tsc -b --noEmit`, and `eslint` all pass.
- Manually verified in the running app: same-day sessions are now distinguishable.