### PR TITLE
feat(sessions): show session names and rename them in-place

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -7,6 +7,7 @@ import { TerminalService } from './terminal-service'
 import { NotesManager } from './notes-manager'
 import { getGuiDataPath } from './app-data-paths'
 import { getSessionsRoot } from './pi-paths'
+import { readSessionName } from './session-name'
 import { activityHeatmapReader } from './activity-heatmap'
 import type {
   PiStartOptions,
@@ -1126,6 +1127,26 @@ interface SessionEntry {
   projectName: string
 }
 
+// How many session files to read names from in parallel. Mirrors Pi's own
+// bounded concurrency so a large session store doesn't spawn hundreds of reads.
+const SESSION_NAME_READ_CONCURRENCY = 10
+
+/** Populate `entry.name` from each session file's latest `session_info`, bounded. */
+async function fillSessionNames(entries: SessionEntry[]): Promise<void> {
+  let cursor = 0
+  async function worker(): Promise<void> {
+    while (cursor < entries.length) {
+      const entry = entries[cursor++]
+      entry.name = await readSessionName(entry.path)
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(SESSION_NAME_READ_CONCURRENCY, entries.length) },
+    () => worker()
+  )
+  await Promise.all(workers)
+}
+
 function createListSessions(wm: WorkspaceManager) {
   return async function listSessions(_cwd: string): Promise<SessionEntry[]> {
     try {
@@ -1133,7 +1154,11 @@ function createListSessions(wm: WorkspaceManager) {
       const entries: SessionEntry[] = []
       await collectSessionFiles(sessionsDir, entries, sessionsDir, wm)
       entries.sort((a, b) => b.lastModified - a.lastModified)
-      return entries.slice(0, MAX_SESSION_LIST)
+      // Only read names for the sessions we actually return (avoids reading the
+      // whole store), then surface each session's latest session_info name.
+      const top = entries.slice(0, MAX_SESSION_LIST)
+      await fillSessionNames(top)
+      return top
     } catch {
       return []
     }

--- a/src/main/session-name.test.ts
+++ b/src/main/session-name.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { sessionInfoNameFromLine, latestSessionName } from './session-name'
+
+const info = (name: string): string =>
+  JSON.stringify({ type: 'session_info', id: 'a1', parentId: 'b2', timestamp: '2026-07-04T00:00:00Z', name })
+
+test('sessionInfoNameFromLine extracts a trimmed name', () => {
+  assert.equal(sessionInfoNameFromLine(info('  Refactor auth  ')), 'Refactor auth')
+})
+
+test('sessionInfoNameFromLine returns null for a cleared (empty) name', () => {
+  assert.equal(sessionInfoNameFromLine(info('   ')), null)
+})
+
+test('sessionInfoNameFromLine ignores non-session_info lines', () => {
+  assert.equal(sessionInfoNameFromLine(JSON.stringify({ type: 'message', message: {} })), undefined)
+  assert.equal(sessionInfoNameFromLine(JSON.stringify({ type: 'session', version: 3 })), undefined)
+  assert.equal(sessionInfoNameFromLine(''), undefined)
+  assert.equal(sessionInfoNameFromLine('not json'), undefined)
+})
+
+test('latestSessionName returns the last session_info name', () => {
+  const lines = [
+    JSON.stringify({ type: 'session', version: 3 }),
+    JSON.stringify({ type: 'message' }),
+    info('First title'),
+    JSON.stringify({ type: 'message' }),
+    info('Renamed later'),
+  ]
+  assert.equal(latestSessionName(lines), 'Renamed later')
+})
+
+test('latestSessionName is null when never named', () => {
+  const lines = [
+    JSON.stringify({ type: 'session', version: 3 }),
+    JSON.stringify({ type: 'message' }),
+  ]
+  assert.equal(latestSessionName(lines), null)
+})
+
+test('latestSessionName reflects a clear after a name', () => {
+  assert.equal(latestSessionName([info('Named'), info('')]), null)
+})

--- a/src/main/session-name.ts
+++ b/src/main/session-name.ts
@@ -1,0 +1,62 @@
+import { createReadStream } from 'fs'
+import { createInterface } from 'readline'
+
+/**
+ * Reads a session's display name out of its `.jsonl`.
+ *
+ * Pi stores the name as `{ "type": "session_info", "name": "…" }` records
+ * appended over the session's life (via `/name`, the CLI `--name`, or an
+ * auto-title extension). The **latest** record wins, and an empty name clears
+ * the title. We only read — never write — so this degrades gracefully across Pi
+ * format changes (worst case: no name found → caller falls back to the id).
+ */
+
+/**
+ * Extract a `session_info` name from a single JSONL line.
+ * Returns the trimmed name, `null` if it's a session_info that clears the name
+ * (empty), or `undefined` if the line isn't a session_info record at all.
+ */
+export function sessionInfoNameFromLine(line: string): string | null | undefined {
+  const trimmed = line.trim()
+  // Cheap prefilter so we don't JSON.parse every message line in large files.
+  if (!trimmed || !trimmed.includes('"session_info"')) return undefined
+  try {
+    const record = JSON.parse(trimmed) as { type?: unknown; name?: unknown }
+    if (record?.type !== 'session_info') return undefined
+    const name = typeof record.name === 'string' ? record.name.trim() : ''
+    return name || null
+  } catch {
+    return undefined
+  }
+}
+
+/** Reduce a list of JSONL lines to the latest session_info name (or null). */
+export function latestSessionName(lines: string[]): string | null {
+  let name: string | null = null
+  for (const line of lines) {
+    const result = sessionInfoNameFromLine(line)
+    if (result !== undefined) name = result
+  }
+  return name
+}
+
+/**
+ * Stream a session file and return its current name, or null if unnamed.
+ * Streams line-by-line (bounded memory) and never throws.
+ */
+export async function readSessionName(filePath: string): Promise<string | null> {
+  let name: string | null = null
+  try {
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    })
+    for await (const line of rl) {
+      const result = sessionInfoNameFromLine(line)
+      if (result !== undefined) name = result
+    }
+  } catch {
+    return null
+  }
+  return name
+}

--- a/src/renderer/src/components/context-menu.tsx
+++ b/src/renderer/src/components/context-menu.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
   MessageSquare,
   NotebookPen,
+  Pencil,
 } from 'lucide-react'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
 
@@ -345,6 +346,9 @@ export interface SessionContextMenuActions {
   onArchive: (sessionId: string) => void
   onUnarchive: (sessionId: string) => void
   onDelete: (session: SessionListItem) => void
+  // Optional: when provided, a "Rename…" item is shown (above Delete). Callers
+  // pass this only for the active session, since Pi's rename targets it.
+  onRename?: (session: SessionListItem) => void
 }
 
 export function buildSessionContextMenu(
@@ -353,7 +357,7 @@ export function buildSessionContextMenu(
   actions: SessionContextMenuActions
 ): ContextMenuItem[] {
   const displayName = session.name || session.sessionId.slice(0, 12)
-  return [
+  const items: ContextMenuItem[] = [
     {
       id: 'session-open',
       label: 'Open Session',
@@ -379,21 +383,33 @@ export function buildSessionContextMenu(
           icon: <Archive size={14} />,
           action: () => actions.onArchive(session.sessionId),
         },
-    {
-      id: 'session-delete',
-      label: 'Delete…',
-      icon: <Trash2 size={14} />,
-      action: () => {
-        // Confirm before destructive action. Trash is recoverable when
-        // installed; without it, delete is permanent. The wording is
-        // honest about that.
-        const ok = window.confirm(
-          `Delete session "${displayName}"?\n\nWill use the system 'trash' CLI if installed (recoverable); otherwise the .jsonl session file is permanently removed.`
-        )
-        if (ok) actions.onDelete(session)
-      },
-    },
   ]
+
+  if (actions.onRename) {
+    items.push({
+      id: 'session-rename',
+      label: 'Rename…',
+      icon: <Pencil size={14} />,
+      action: () => actions.onRename!(session),
+    })
+  }
+
+  items.push({
+    id: 'session-delete',
+    label: 'Delete…',
+    icon: <Trash2 size={14} />,
+    action: () => {
+      // Confirm before destructive action. Trash is recoverable when
+      // installed; without it, delete is permanent. The wording is
+      // honest about that.
+      const ok = window.confirm(
+        `Delete session "${displayName}"?\n\nWill use the system 'trash' CLI if installed (recoverable); otherwise the .jsonl session file is permanently removed.`
+      )
+      if (ok) actions.onDelete(session)
+    },
+  })
+
+  return items
 }
 
 export function buildLinkContextMenu(url: string): ContextMenuItem[] {

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -19,7 +19,7 @@ import {
   Sparkles,
   Pencil,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { StatusPopover } from './status-popover'
 import { useContextMenu, buildSessionContextMenu } from './context-menu'
 import { getSessionRowLabels } from './sidebar-session-labels'
@@ -40,10 +40,60 @@ export function Sidebar(): React.JSX.Element {
   const archiveSession = useAppStore((state) => state.archiveSession)
   const unarchiveSession = useAppStore((state) => state.unarchiveSession)
   const deleteSession = useAppStore((state) => state.deleteSession)
+  const setSessionName = useAppStore((state) => state.setSessionName)
 
   const { show: showMenu, ContextMenuComponent: SessionMenu } = useContextMenu()
 
   const [archivedOpen, setArchivedOpen] = useState(false)
+
+  // Inline session rename. Only the active session can be renamed (Pi's rename
+  // targets it), and it's reachable from two spots — the Current Session panel
+  // (`'current'`) and its highlighted row in Recent Sessions (`'recent'`).
+  const [renamingWhere, setRenamingWhere] = useState<'current' | 'recent' | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const renameCancelRef = useRef(false)
+
+  const startSessionRename = (where: 'current' | 'recent'): void => {
+    renameCancelRef.current = false
+    // Prefill with the explicit name only; a timestamp/guid is not a name.
+    setRenameValue(sessionState?.sessionName ?? '')
+    setRenamingWhere(where)
+  }
+
+  // Single commit path (both Enter and Escape blur the input, which lands here).
+  const finishSessionRename = (): void => {
+    const cancelled = renameCancelRef.current
+    renameCancelRef.current = false
+    setRenamingWhere(null)
+    // Pi's set_session_name RPC rejects an empty name ("cannot be empty"), so an
+    // empty commit is a no-op (keeps the current name) rather than a doomed call.
+    const trimmed = renameValue.trim()
+    if (!cancelled && trimmed) setSessionName(trimmed)
+  }
+
+  const renderRenameInput = (): React.JSX.Element => (
+    <input
+      type="text"
+      value={renameValue}
+      onChange={(e) => setRenameValue(e.target.value)}
+      onFocus={(e) => e.target.select()}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          e.currentTarget.blur()
+        } else if (e.key === 'Escape') {
+          e.preventDefault()
+          renameCancelRef.current = true
+          e.currentTarget.blur()
+        }
+      }}
+      onBlur={finishSessionRename}
+      placeholder="Session name"
+      autoFocus
+      className="min-w-0 flex-1 rounded border border-neutral-700 bg-neutral-800 px-2 py-0.5 text-sm text-neutral-200 placeholder:text-neutral-600 focus:border-blue-500 focus:outline-none"
+    />
+  )
 
   // Archived sessions live in their own collapsible section; Recent excludes them.
   const recentSessions = sessionList.filter((s) => !(s.sessionId in archivedSessions)).slice(0, 20)
@@ -71,6 +121,7 @@ export function Sidebar(): React.JSX.Element {
     // React's synthetic stopPropagation isn't enough — that handler is
     // attached to `document` and fires on native bubbling.
     e.nativeEvent.stopPropagation()
+    const isActive = sessionState?.sessionFile === session.path
     showMenu(
       e,
       buildSessionContextMenu(session, session.sessionId in archivedSessions, {
@@ -78,22 +129,55 @@ export function Sidebar(): React.JSX.Element {
         onArchive: (id) => archiveSession(id),
         onUnarchive: (id) => unarchiveSession(id),
         onDelete: (s) => { deleteSession(s) },
+        // Rename only offered for the active session (Pi renames the active one).
+        onRename: isActive ? () => startSessionRename('recent') : undefined,
       })
     )
   }
 
+  // Right-click menu for the Current Session panel — same active session, so
+  // just the rename affordance.
+  const handleCurrentSessionRightClick = (e: React.MouseEvent): void => {
+    e.nativeEvent.stopPropagation()
+    showMenu(e, [
+      {
+        id: 'current-session-rename',
+        label: 'Rename…',
+        icon: <Pencil size={14} />,
+        action: () => startSessionRename('current'),
+      },
+    ])
+  }
+
   const renderSessionRow = (session: SessionListItem): React.JSX.Element => {
     const labels = getSessionRowLabels(session)
+    const isActive = sessionState?.sessionFile === session.path
+
+    // Inline rename for the active row.
+    if (isActive && renamingWhere === 'recent') {
+      return (
+        <div
+          key={session.path}
+          className="flex w-full items-center gap-2 rounded bg-neutral-800 px-2 py-1.5"
+        >
+          <Clock size={12} className="shrink-0 text-neutral-400" />
+          {renderRenameInput()}
+        </div>
+      )
+    }
 
     return (
       <button
         key={session.path}
         onClick={() => openSession(session)}
+        onDoubleClick={() => { if (isActive) startSessionRename('recent') }}
         onContextMenu={(e) => handleSessionRightClick(e, session)}
-        title="Click to open · right-click for actions"
+        title={isActive
+          ? 'Click to open · double-click to rename · right-click for actions'
+          : 'Click to open · right-click for actions'}
         className={clsx(
           'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
-          sessionState?.sessionFile === session.path
+          isActive
             ? 'bg-neutral-800 text-neutral-200'
             : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300'
         )}
@@ -195,25 +279,38 @@ export function Sidebar(): React.JSX.Element {
 
       {/* Current session info */}
       {sessionState && (
-        <button
-          type="button"
-          onClick={() => setCurrentView('chat')}
-          className="mx-3 mt-2 rounded-md bg-neutral-900 p-3 text-left transition-colors hover:bg-neutral-800 focus:outline-none focus:ring-1 focus:ring-neutral-600"
-          title="Open current session in chat"
-        >
-          <div className="text-xs font-medium text-neutral-400 uppercase tracking-wider">Current Session</div>
-          <div className="mt-1.5 text-sm text-neutral-200 truncate">
-            {sessionState.sessionName || sessionState.sessionId || 'Unnamed'}
+        renamingWhere === 'current' ? (
+          <div className="mx-3 mt-2 rounded-md bg-neutral-900 p-3">
+            <div className="text-xs font-medium text-neutral-400 uppercase tracking-wider">Current Session</div>
+            <div className="mt-1.5 flex">{renderRenameInput()}</div>
+            {sessionState.model && (
+              <div className="mt-1 text-xs text-neutral-500">{sessionState.model.name}</div>
+            )}
+            <div className="mt-1 text-xs text-neutral-500">{sessionState.messageCount} messages</div>
           </div>
-          {sessionState.model && (
-            <div className="mt-1 text-xs text-neutral-500">
-              {sessionState.model.name}
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCurrentView('chat')}
+            onDoubleClick={() => startSessionRename('current')}
+            onContextMenu={handleCurrentSessionRightClick}
+            className="mx-3 mt-2 rounded-md bg-neutral-900 p-3 text-left transition-colors hover:bg-neutral-800 focus:outline-none focus:ring-1 focus:ring-neutral-600"
+            title="Open current session in chat · double-click to rename"
+          >
+            <div className="text-xs font-medium text-neutral-400 uppercase tracking-wider">Current Session</div>
+            <div className="mt-1.5 text-sm text-neutral-200 truncate">
+              {sessionState.sessionName || sessionState.sessionId || 'Unnamed'}
             </div>
-          )}
-          <div className="mt-1 text-xs text-neutral-500">
-            {sessionState.messageCount} messages
-          </div>
-        </button>
+            {sessionState.model && (
+              <div className="mt-1 text-xs text-neutral-500">
+                {sessionState.model.name}
+              </div>
+            )}
+            <div className="mt-1 text-xs text-neutral-500">
+              {sessionState.messageCount} messages
+            </div>
+          </button>
+        )
       )}
 
       {/* Recent sessions */}

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -747,7 +747,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   setSessionName: async (name) => {
     try {
       await window.piDesktop.session.setName(name)
-      get().refreshSessionState()
+      // No manual refresh: Pi emits `session_info_changed` after setting the
+      // name, and handlePiEvent applies it to the Current Session panel and the
+      // Recent row — the same path used by auto-title extensions.
     } catch {
       // Silent failure
     }
@@ -1023,6 +1025,26 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       case 'extension_ui_request':
         set({ extensionUiRequest: event as PiExtensionUiRequest })
         break
+
+      case 'session_info_changed': {
+        // Live title update (auto-title extension, /name, or our rename).
+        // Apply the new name directly to the active session's state + list row
+        // so both the Current Session panel and its Recent row update instantly,
+        // with no file read or RPC round-trip.
+        const newName = (typeof event.name === 'string' && event.name.trim()) || null
+        set((state) => {
+          const activeFile = state.sessionState?.sessionFile ?? null
+          return {
+            sessionState: state.sessionState
+              ? { ...state.sessionState, sessionName: newName }
+              : state.sessionState,
+            sessionList: activeFile
+              ? state.sessionList.map((s) => (s.path === activeFile ? { ...s, name: newName } : s))
+              : state.sessionList,
+          }
+        })
+        break
+      }
 
       case 'status_change': {
         const statusEvent = event as unknown as PiStatus

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -340,6 +340,14 @@ export interface PiStatusChangeEvent {
   error: string | null
 }
 
+// Emitted by Pi when the session title changes — e.g. an auto-title extension,
+// the `/name` command, or our own rename. `name` is the new title (null/empty
+// when cleared).
+export interface PiSessionInfoChangedEvent {
+  type: 'session_info_changed'
+  name?: string | null
+}
+
 export type PiRpcEvent =
   | PiAgentStartEvent
   | PiAgentEndEvent
@@ -360,6 +368,7 @@ export type PiRpcEvent =
   | PiResponseEvent
   | PiExtensionUiRequest
   | PiStatusChangeEvent
+  | PiSessionInfoChangedEvent
 
 // ─── Model Types ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Surfaces Pi session names in the GUI and lets you rename the active session in-place. Pi stays the source of truth for names — the GUI just relays and edits them.

## What it does

**Relay names into the list.** `collectSessionFiles` now reads each session's latest `session_info` name (Pi stores names as `session_info` records in the `.jsonl`) and populates `SessionEntry.name`. So names set via `/name`, the CLI, or an auto-title extension appear in the sidebar. Names are read for the top-N listed sessions with bounded concurrency (10); unnamed sessions keep their existing fallback title.

**Inline rename (active session).** A "Rename…" item is added to the session context menu (above Delete), plus double-click — shown for the active session in both places it appears: the Current Session panel and its highlighted Recent Sessions row. Editing swaps the title to an inline input (Enter/blur commits, Esc cancels), mirroring the existing workspace-rename UX. Rename goes through the `set_session_name` RPC (active session only), so there's no coupling to Pi's on-disk session format.

**Live updates.** Added handling for Pi's `session_info_changed` event, so a rename — or an auto-title extension re-titling mid-conversation — updates the Current Session panel and the Recent row instantly, with no file read or refresh.

## Notes

- Empty rename is a no-op: Pi's `set_session_name` RPC rejects empty names ("cannot be empty"), so clearing isn't offered.
- Reading names is non-destructive and degrades gracefully (no name found → existing fallback), so it's robust across Pi session-format changes.

## Testing

- New unit tests for the name reader (`src/main/session-name.test.ts`, 6 cases: latest-wins, cleared/empty, non-session_info lines).
- `npm run build`, `tsc -b --noEmit`, and `eslint` all pass.
- Manually verified: rename from both entry points (menu + double-click), live update via `/name` in the terminal, and names showing in the list.