### PR TITLE
fix(ui): font size settings, chat width, and terminal crash

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1537,6 +1537,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   defaultProvider: null,
   defaultCwd: null,
   fontSize: 14,
+  terminalFontSize: 12,
+  codeEditorFontSize: 12,
   showThinking: true,
   autoScroll: true,
   permissionMode: 'ask-edits',

--- a/src/main/terminal-service.ts
+++ b/src/main/terminal-service.ts
@@ -8,6 +8,7 @@ type TerminalExitHandler = (event: { exitCode: number; signal?: number }) => voi
 
 export class TerminalService {
   private terminal: IPty | null = null
+  private disposables: { dispose(): void }[] = []
   private cwd = os.homedir()
 
   start(
@@ -28,7 +29,7 @@ export class TerminalService {
     // node-pty's `encoding` option calls setEncoding() under the hood,
     // which Windows (conpty/winpty) does not support and logs a warning
     // for. Only pass it on POSIX platforms.
-    this.terminal = pty.spawn(shell, [], {
+    const terminal = pty.spawn(shell, [], {
       name: 'xterm-256color',
       cols: options.cols ?? 80,
       rows: options.rows ?? 24,
@@ -36,15 +37,20 @@ export class TerminalService {
       env,
       ...(process.platform === 'win32' ? {} : { encoding: 'utf8' }),
     })
+    this.terminal = terminal
 
-    this.terminal.onData(onData)
-    this.terminal.onExit(({ exitCode, signal }) => {
-      this.terminal = null
-      onExit({ exitCode, signal })
-    })
+    this.disposables.push(terminal.onData(onData))
+    this.disposables.push(
+      terminal.onExit(({ exitCode, signal }) => {
+        // Guard against a stale exit from a killed pty clobbering a terminal
+        // that has since been recreated (e.g. after a view round-trip).
+        if (this.terminal === terminal) this.terminal = null
+        onExit({ exitCode, signal })
+      })
+    )
 
     return {
-      pid: this.terminal.pid,
+      pid: terminal.pid,
       shell,
       cwd,
     }
@@ -62,8 +68,14 @@ export class TerminalService {
 
   stop(): void {
     if (!this.terminal) return
-    this.terminal.kill()
+    // Detach handlers before killing so the resulting exit event neither
+    // broadcasts a spurious "process exited" into a freshly-created terminal
+    // nor nulls it out. See the identity guard in start().
+    for (const d of this.disposables) d.dispose()
+    this.disposables = []
+    const terminal = this.terminal
     this.terminal = null
+    terminal.kill()
   }
 
   getCwd(): string {

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -102,7 +102,7 @@ export function ChatPanel(): React.JSX.Element {
             {messages.length === 0 && !isStreaming ? (
               <EmptyState piStatus={piStatus} />
             ) : (
-              <div className="mx-auto max-w-3xl px-4 py-6">
+              <div className="mx-auto max-w-5xl px-4 py-6">
                 {messages.map((message) => (
                   <MessageBubble key={message.id} message={message} onRetry={handleRetry} />
                 ))}
@@ -119,7 +119,7 @@ export function ChatPanel(): React.JSX.Element {
 
           {/* Input area */}
           <div className="border-t border-neutral-800 bg-neutral-950">
-            <div className="mx-auto w-full max-w-3xl px-4">
+            <div className="mx-auto w-full max-w-5xl px-4">
               <CouncilPanels />
             </div>
             <ChatInput />

--- a/src/renderer/src/components/code-editor.tsx
+++ b/src/renderer/src/components/code-editor.tsx
@@ -24,6 +24,7 @@ export function CodeEditor({
   const onChangeRef = useRef(onChange)
   const theme = useAppStore((state) => state.settings?.theme)
   const lightTheme = isLightTheme(theme)
+  const fontSize = useAppStore((state) => state.codeEditorFontSizePreview ?? state.settings?.codeEditorFontSize)
 
   useEffect(() => {
     onChangeRef.current = onChange
@@ -60,7 +61,7 @@ export function CodeEditor({
             height: '100%',
             backgroundColor: 'var(--color-bg-primary)',
             color: 'var(--color-text-primary)',
-            fontSize: '12px',
+            fontSize: `${fontSize ?? 12}px`,
           },
           '.cm-editor': {
             height: '100%',
@@ -100,7 +101,7 @@ export function CodeEditor({
       view.destroy()
       viewRef.current = null
     }
-  }, [filePath, readOnly, lightTheme])
+  }, [filePath, readOnly, lightTheme, fontSize])
 
   useEffect(() => {
     const view = viewRef.current

--- a/src/renderer/src/components/file-tree.tsx
+++ b/src/renderer/src/components/file-tree.tsx
@@ -178,7 +178,7 @@ function TreeNodeComponent({
       <div>
         <button
           onClick={() => setExpanded(!expanded)}
-          className="flex w-full items-center gap-1 py-0.5 px-2 text-xs text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300 transition-colors"
+          className="flex w-full items-center gap-1 py-0.5 px-2 text-sm text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300 transition-colors"
           style={{ paddingLeft: `${depth * 12 + 8}px` }}
         >
           {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
@@ -207,7 +207,7 @@ function TreeNodeComponent({
     <button
       onClick={() => onFileClick(node.path, node.relativePath)}
       className={clsx(
-        'flex w-full items-center gap-1.5 py-0.5 px-2 text-xs transition-colors',
+        'flex w-full items-center gap-1.5 py-0.5 px-2 text-sm transition-colors',
         isSelected
           ? 'bg-blue-900/30 text-blue-300'
           : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300'

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -282,7 +282,7 @@ function AssistantMessage({
         <div className="min-w-0 flex-1">
           {/* Model info */}
           {message.model && (
-            <div className="mb-1 flex items-center gap-2 text-xs text-neutral-500">
+            <div className="mb-1 flex items-center gap-2 text-sm text-neutral-500">
               <span>{message.provider}</span>
               <span className="text-neutral-700">·</span>
               <span>{message.model}</span>
@@ -300,14 +300,14 @@ function AssistantMessage({
             <div className="mb-2">
               <button
                 onClick={onToggleThinking}
-                className="flex items-center gap-1 text-xs text-neutral-500 hover:text-neutral-400 transition-colors"
+                className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-400 transition-colors"
               >
                 <Brain size={12} />
                 {showThinking ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
                 Thinking
               </button>
               {showThinking && (
-                <div className="mt-1 rounded-lg border border-neutral-800 bg-neutral-900/50 p-3 text-xs text-neutral-400">
+                <div className="markdown-body mt-1 rounded-lg border border-neutral-800 bg-neutral-900/50 p-3 text-neutral-400">
                   <MarkdownRenderer content={message.thinking} />
                 </div>
               )}
@@ -360,16 +360,16 @@ function ToolCallBadge({
     <div className="rounded-lg border border-neutral-800 bg-neutral-900/50">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-xs text-neutral-400 hover:text-neutral-300 transition-colors"
+        className="flex w-full items-center gap-2 px-3 py-2 text-sm text-neutral-400 hover:text-neutral-300 transition-colors"
       >
         <Icon size={12} className="shrink-0" />
         <span className="font-medium">{toolCall.name}</span>
         {toolCall.durationMs !== undefined && !toolCall.isExecuting && (
-          <span className="text-[10px] text-neutral-600">{formatDuration(toolCall.durationMs)}</span>
+          <span className="text-xs text-neutral-600">{formatDuration(toolCall.durationMs)}</span>
         )}
         {toolCall.isError !== undefined && (
           <span className={clsx(
-            'ml-auto rounded px-1.5 py-0.5 text-[10px]',
+            'ml-auto rounded px-1.5 py-0.5 text-xs',
             toolCall.isError ? 'bg-red-900/30 text-red-400' : 'bg-emerald-900/30 text-emerald-400'
           )}>
             {toolCall.isError ? 'error' : 'done'}
@@ -382,12 +382,12 @@ function ToolCallBadge({
       </button>
       {expanded && (
         <div className="border-t border-neutral-800 px-3 py-2">
-          <pre className="overflow-x-auto text-xs text-neutral-500">
+          <pre className="overflow-x-auto text-sm text-neutral-500">
             {formatToolCallArgs(toolCall.arguments)}
           </pre>
           {toolCall.result && (
             <div className="mt-2 border-t border-neutral-800 pt-2">
-              <pre className="overflow-x-auto text-xs text-neutral-400">
+              <pre className="overflow-x-auto text-sm text-neutral-400">
                 {toolCall.result}
               </pre>
             </div>
@@ -409,7 +409,7 @@ function ToolResultMessage({ message }: { message: DisplayMessage }): React.JSX.
         </div>
         <div className="min-w-0 flex-1">
           <div className="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
-            <pre className="overflow-x-auto text-xs text-neutral-400">
+            <pre className="overflow-x-auto text-sm text-neutral-400">
               {message.content.slice(0, 500)}
               {message.content.length > 500 && '...'}
             </pre>

--- a/src/renderer/src/components/settings-panel.tsx
+++ b/src/renderer/src/components/settings-panel.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from '../store'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import type { AppSettings, PermissionMode, CouncilConfig } from '../../../shared/ipc-contracts'
 import { Settings, Save, RotateCcw, FolderOpen, Check } from 'lucide-react'
 import { DEFAULT_PERMISSION_MODE } from './permission-mode'
@@ -16,10 +16,19 @@ export function SettingsPanel(): React.JSX.Element {
   const settings = useAppStore((state) => state.settings)
   const setCurrentView = useAppStore((state) => state.setCurrentView)
   const loadSettings = useAppStore((state) => state.loadSettings)
+  const setFontSizePreview = useAppStore((state) => state.setFontSizePreview)
 
   const [piPath, setPiPath] = useState(settings?.piExecutablePath ?? 'pi')
   const [theme, setTheme] = useState(settings?.theme ?? 'dark')
-  const [fontSize, setFontSize] = useState(settings?.fontSize ?? 14)
+  const [fontSize, setFontSize] = useState(
+    useAppStore.getState().uiFontSizePreview ?? settings?.fontSize ?? 14,
+  )
+  const [terminalFontSize, setTerminalFontSize] = useState(
+    useAppStore.getState().terminalFontSizePreview ?? settings?.terminalFontSize ?? 12,
+  )
+  const [codeEditorFontSize, setCodeEditorFontSize] = useState(
+    useAppStore.getState().codeEditorFontSizePreview ?? settings?.codeEditorFontSize ?? 12,
+  )
   const [showThinking, setShowThinking] = useState(settings?.showThinking ?? true)
   const [autoScroll, setAutoScroll] = useState(settings?.autoScroll ?? true)
   const [resumeLastSession, setResumeLastSession] = useState(settings?.resumeLastSession ?? true)
@@ -70,18 +79,26 @@ export function SettingsPanel(): React.JSX.Element {
     await loadSettings()
   }
 
-  // Sync from store when settings load
+  // Populate the form once, when settings first load. We deliberately do NOT
+  // re-sync on every settings change: the UI font previews live and the
+  // terminal/editor sizes are staged in store state, so re-syncing would
+  // clobber other unsaved edits. Save/Reset set local state directly, so the
+  // form stays correct without a re-sync.
+  const didInitRef = useRef(false)
   useEffect(() => {
-    if (settings) {
-      setPiPath(settings.piExecutablePath)
-      setTheme(settings.theme)
-      setFontSize(settings.fontSize)
-      setShowThinking(settings.showThinking)
-      setAutoScroll(settings.autoScroll)
-      setResumeLastSession(settings.resumeLastSession)
-      setOpenToHomeOnLaunch(settings.openToHomeOnLaunch)
-      setPermissionMode(settings.permissionMode)
-    }
+    if (!settings || didInitRef.current) return
+    didInitRef.current = true
+    const store = useAppStore.getState()
+    setPiPath(settings.piExecutablePath)
+    setTheme(settings.theme)
+    setFontSize(store.uiFontSizePreview ?? settings.fontSize)
+    setTerminalFontSize(store.terminalFontSizePreview ?? settings.terminalFontSize)
+    setCodeEditorFontSize(store.codeEditorFontSizePreview ?? settings.codeEditorFontSize)
+    setShowThinking(settings.showThinking)
+    setAutoScroll(settings.autoScroll)
+    setResumeLastSession(settings.resumeLastSession)
+    setOpenToHomeOnLaunch(settings.openToHomeOnLaunch)
+    setPermissionMode(settings.permissionMode)
   }, [settings])
 
   const handleSelectPath = async () => {
@@ -94,6 +111,8 @@ export function SettingsPanel(): React.JSX.Element {
       piExecutablePath: piPath,
       theme: theme as AppSettings['theme'],
       fontSize,
+      terminalFontSize,
+      codeEditorFontSize,
       showThinking,
       autoScroll,
       resumeLastSession,
@@ -110,6 +129,10 @@ export function SettingsPanel(): React.JSX.Element {
     // Reload settings in store
     await loadSettings()
 
+    // Persisted now — drop the live previews so terminal/editor read the saved
+    // settings (which loadSettings just refreshed).
+    setFontSizePreview({ ui: null, terminal: null, editor: null })
+
     // Show saved indicator
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
@@ -120,6 +143,8 @@ export function SettingsPanel(): React.JSX.Element {
       piExecutablePath: 'pi',
       theme: 'dark',
       fontSize: 14,
+      terminalFontSize: 12,
+      codeEditorFontSize: 12,
       showThinking: true,
       autoScroll: true,
       resumeLastSession: true,
@@ -130,6 +155,8 @@ export function SettingsPanel(): React.JSX.Element {
     setPiPath(defaults.piExecutablePath!)
     setTheme(defaults.theme!)
     setFontSize(defaults.fontSize!)
+    setTerminalFontSize(defaults.terminalFontSize!)
+    setCodeEditorFontSize(defaults.codeEditorFontSize!)
     setShowThinking(defaults.showThinking!)
     setAutoScroll(defaults.autoScroll!)
     setResumeLastSession(defaults.resumeLastSession!)
@@ -138,7 +165,9 @@ export function SettingsPanel(): React.JSX.Element {
 
     const result = await window.piDesktop.settings.save(defaults)
     applyTheme(result.theme)
+    document.documentElement.style.fontSize = `${result.fontSize}px`
     await loadSettings()
+    setFontSizePreview({ ui: null, terminal: null, editor: null })
 
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
@@ -146,7 +175,7 @@ export function SettingsPanel(): React.JSX.Element {
 
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-2xl px-6 py-8">
+      <div className="mx-auto max-w-5xl px-6 py-8">
         {/* Header */}
         <div className="mb-8 flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -203,7 +232,7 @@ export function SettingsPanel(): React.JSX.Element {
             </select>
           </SettingsRow>
 
-          <SettingsRow label="Font Size" description="Base font size in pixels">
+          <SettingsRow label="UI Font Size" description="Chat, panels, and sidebar — not the terminal or code editor">
             <div className="flex items-center gap-3">
               <input
                 type="range"
@@ -214,10 +243,47 @@ export function SettingsPanel(): React.JSX.Element {
                   const size = Number(e.target.value)
                   setFontSize(size)
                   document.documentElement.style.fontSize = `${size}px`
+                  setFontSizePreview({ ui: size })
                 }}
                 className="flex-1 accent-blue-500"
               />
               <span className="w-8 text-right text-sm text-neutral-400">{fontSize}</span>
+            </div>
+          </SettingsRow>
+
+          <SettingsRow label="Terminal Font Size" description="Font size for the terminal panel">
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min={10}
+                max={20}
+                value={terminalFontSize}
+                onChange={(e) => {
+                  const size = Number(e.target.value)
+                  setTerminalFontSize(size)
+                  setFontSizePreview({ terminal: size })
+                }}
+                className="flex-1 accent-blue-500"
+              />
+              <span className="w-8 text-right text-sm text-neutral-400">{terminalFontSize}</span>
+            </div>
+          </SettingsRow>
+
+          <SettingsRow label="Code Editor Font Size" description="Font size for the code editor / file viewer">
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min={10}
+                max={20}
+                value={codeEditorFontSize}
+                onChange={(e) => {
+                  const size = Number(e.target.value)
+                  setCodeEditorFontSize(size)
+                  setFontSizePreview({ editor: size })
+                }}
+                className="flex-1 accent-blue-500"
+              />
+              <span className="w-8 text-right text-sm text-neutral-400">{codeEditorFontSize}</span>
             </div>
           </SettingsRow>
         </SettingsSection>

--- a/src/renderer/src/components/streaming-bubble.tsx
+++ b/src/renderer/src/components/streaming-bubble.tsx
@@ -25,11 +25,11 @@ export function StreamingBubble({ content, thinking, toolCalls }: StreamingBubbl
           {/* Thinking */}
           {thinking && (
             <div className="mb-2 rounded-lg border border-purple-900/30 bg-purple-900/10 p-3">
-              <div className="flex items-center gap-1 text-xs text-purple-400 mb-1">
+              <div className="flex items-center gap-1 text-sm text-purple-400 mb-1">
                 <Brain size={12} />
                 Thinking...
               </div>
-              <div className="text-xs text-neutral-500 line-clamp-3">
+              <div className="text-sm text-neutral-500 line-clamp-3">
                 {thinking.slice(-200)}
               </div>
             </div>
@@ -42,7 +42,7 @@ export function StreamingBubble({ content, thinking, toolCalls }: StreamingBubbl
                 <div
                   key={id}
                   className={clsx(
-                    'flex items-center gap-2 rounded-lg border px-3 py-2 text-xs',
+                    'flex items-center gap-2 rounded-lg border px-3 py-2 text-sm',
                     tc.isExecuting
                       ? 'border-yellow-900/30 bg-yellow-900/10 text-yellow-400'
                       : 'border-neutral-800 bg-neutral-900/50 text-neutral-400'
@@ -55,7 +55,7 @@ export function StreamingBubble({ content, thinking, toolCalls }: StreamingBubbl
                   )}
                   <span className="font-medium">{tc.name}</span>
                   {tc.isExecuting && (
-                    <span className="ml-auto text-[10px] text-yellow-500">executing</span>
+                    <span className="ml-auto text-xs text-yellow-500">executing</span>
                   )}
                 </div>
               ))}

--- a/src/renderer/src/components/terminal.tsx
+++ b/src/renderer/src/components/terminal.tsx
@@ -69,7 +69,14 @@ export function TerminalPanel(): React.JSX.Element | null {
       cursorBlink: true,
       convertEol: true,
       fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-      fontSize: 12,
+      // Use the Terminal Font Size setting (or the unsaved settings-panel
+      // preview), read once at creation. Applied on the next mount — i.e. when
+      // the user returns to chat — rather than live, to avoid resizing a hidden
+      // pty. Falls back to the default.
+      fontSize:
+        useAppStore.getState().terminalFontSizePreview ??
+        useAppStore.getState().settings?.terminalFontSize ??
+        12,
       theme: buildTerminalTheme(),
     })
     const fit = new FitAddon()

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -101,6 +101,13 @@ interface AppState {
   sidebarOpen: boolean
   terminalOpen: boolean
   settings: AppSettings | null
+  // Staged (unsaved) font-size values from the Settings sliders. When non-null
+  // they take priority over the persisted setting and survive view switches, so
+  // the sliders reflect the staged value on reopen and terminal/editor pick it
+  // up on remount — all without touching (or persisting) `settings`.
+  uiFontSizePreview: number | null
+  terminalFontSizePreview: number | null
+  codeEditorFontSizePreview: number | null
   commands: PiCommand[]
 
   // Extension UI
@@ -218,6 +225,11 @@ interface AppActions {
   toggleSidebar: () => void
   toggleTerminal: () => void
   loadSettings: () => Promise<void>
+  setFontSizePreview: (patch: {
+    ui?: number | null
+    terminal?: number | null
+    editor?: number | null
+  }) => void
   setPermissionMode: (mode: PermissionMode) => Promise<void>
   toggleSessionGroupCollapsed: (projectPath: string) => Promise<void>
   loadCommands: () => Promise<void>
@@ -356,6 +368,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   sidebarOpen: true,
   terminalOpen: false,
   settings: null,
+  uiFontSizePreview: null,
+  terminalFontSizePreview: null,
+  codeEditorFontSizePreview: null,
   commands: [],
 
   extensionUiRequest: null,
@@ -863,6 +878,16 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       // Silent failure
     }
   },
+
+  setFontSizePreview: (patch) =>
+    set((state) => ({
+      uiFontSizePreview:
+        patch.ui !== undefined ? patch.ui : state.uiFontSizePreview,
+      terminalFontSizePreview:
+        patch.terminal !== undefined ? patch.terminal : state.terminalFontSizePreview,
+      codeEditorFontSizePreview:
+        patch.editor !== undefined ? patch.editor : state.codeEditorFontSizePreview,
+    })),
 
   setPermissionMode: async (mode) => {
     const updated = await window.piDesktop.settings.save({ permissionMode: mode })

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -609,7 +609,12 @@ export interface AppSettings {
   defaultModel: string | null
   defaultProvider: string | null
   defaultCwd: string | null
+  // UI font size in px (chat, panels, sidebar). Applied to the document root.
   fontSize: number
+  // Terminal (xterm) font size in px — independent of the UI font size.
+  terminalFontSize: number
+  // Code editor (CodeMirror) font size in px — independent of the UI font size.
+  codeEditorFontSize: number
   showThinking: boolean
   autoScroll: boolean
   permissionMode: PermissionMode


### PR DESCRIPTION
## Summary

Reworks font sizing into three independent controls and fixes several chat/terminal UI issues.

### Settings
- **Split the single font size into three sliders**: **UI Font Size** (chat, panels, sidebar — applied to the document root; default 14), **Terminal Font Size** (xterm; default 12), and **Code Editor Font Size** (CodeMirror; default 12). Terminal/editor sizes are independent of the UI font.
- Unsaved slider values are **staged in the store** so they survive view switches: the UI font previews live, terminal/editor apply on the next return to Chat, and reopening Settings shows the staged values. **Save** persists all three and clears the staging; **Reset** restores 14/12/12.

### Terminal crash fix
- Fixed a pty lifecycle race where navigating Settings → Chat with the terminal open printed `[process exited with code -1073741510]` and left the terminal unresponsive until toggled. The killed pty's late exit event was clobbering the freshly-created terminal. Now the old pty's data/exit handlers are disposed **before** `kill()`, and the exit handler is guarded against nulling a replacement terminal.

### Readability
- Widened the chat message/input columns and the Settings column (`max-w-3xl` → `max-w-5xl`).
- Enlarged the thinking block, tool/label text, and badges so they respect the UI font size instead of hardcoded tiny sizes.
- File tree rows now use `text-sm` so they track the UI Font Size.

## Testing
- Drag each slider → Back to chat applies; reopen Settings shows staged values; Save persists across reload; Reset returns to 14/12/12.
- Open terminal, round-trip through Settings repeatedly → no crash, stays responsive.
- Typecheck, lint, and production build all pass.