### PR TITLE
feat(ui): align Notes/Skills panel headers to h-12

### DIFF
--- a/src/renderer/src/components/notes-panel.tsx
+++ b/src/renderer/src/components/notes-panel.tsx
@@ -104,7 +104,7 @@ export function NotesPanel(): React.JSX.Element {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+      <div className="flex h-12 items-center justify-between border-b border-neutral-800 px-4">
         <div className="flex items-center gap-3">
           <button
             onClick={() => setCurrentView('chat')}

--- a/src/renderer/src/components/skills-panel.tsx
+++ b/src/renderer/src/components/skills-panel.tsx
@@ -62,7 +62,7 @@ export function SkillsPanel(): React.JSX.Element {
   return (
     <div className="flex flex-1 overflow-hidden">
       <div className="flex w-72 shrink-0 flex-col border-r border-neutral-800">
-        <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+        <div className="flex h-12 items-center justify-between border-b border-neutral-800 px-4">
           <div className="flex items-center gap-2">
             <Sparkles size={16} className="text-neutral-400" />
             <h2 className="text-sm font-medium text-neutral-200">Skills</h2>
@@ -112,7 +112,7 @@ export function SkillsPanel(): React.JSX.Element {
       <div className="flex flex-1 flex-col overflow-hidden">
         {selected ? (
           <>
-            <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+            <div className="flex h-12 items-center justify-between border-b border-neutral-800 px-4">
               <div className="min-w-0">
                 <h3 className="truncate text-sm font-medium text-neutral-200">{selected.name}</h3>
                 <p className="truncate text-xs text-neutral-600">{selected.path}</p>


### PR DESCRIPTION
## Summary

Aligns the Notes and Skills panel headers with the sidebar's fixed `h-12` header, so their bottom borders line up with the "Pi Desktop" header. Content stays vertically centered. Theme-agnostic.

## Scope change
This PR has been trimmed to **just the header alignment** — the clean, theme-agnostic win. The Breeze Dark chat-background recolor and the border-hiding rules have been removed from here; per the discussion, that styling will ship as a separate **derived theme ("Breeze Claudius")** so Breeze Dark stays untouched.

## Notes
- Other panels (Sessions, Timeline, Packages) use multi-row/section headers rather than a single-row title bar, so they were intentionally left unchanged.
- Rebased onto current `Dev` (Electron 43).