### PR TITLE
fix(ui): round context-usage percent so it doesn't overflow the status popover

### DIFF
--- a/src/renderer/src/components/status-popover.tsx
+++ b/src/renderer/src/components/status-popover.tsx
@@ -54,6 +54,13 @@ export function StatusPopover(): React.JSX.Element {
   const isCompacting = sessionState?.isCompacting ?? false
   const ref = useRef<HTMLDivElement>(null)
 
+  // Some providers (e.g. lmstudio) return a fractional context-usage percent
+  // like 1.077270; round + clamp so it fits the fixed-width label instead of
+  // overflowing the popover.
+  const contextPct = sessionStats?.contextUsage
+    ? Math.min(100, Math.max(0, Math.round(sessionStats.contextUsage.percent ?? 0)))
+    : 0
+
   // Load data when opened
   useEffect(() => {
     if (!isOpen) return
@@ -219,17 +226,17 @@ export function StatusPopover(): React.JSX.Element {
                             <div
                               className={clsx(
                                 'h-full rounded-full transition-all',
-                                (sessionStats.contextUsage.percent ?? 0) > 80
+                                contextPct > 80
                                   ? 'bg-red-500'
-                                  : (sessionStats.contextUsage.percent ?? 0) > 60
+                                  : contextPct > 60
                                     ? 'bg-yellow-500'
                                     : 'bg-emerald-500'
                               )}
-                              style={{ width: `${sessionStats.contextUsage.percent ?? 0}%` }}
+                              style={{ width: `${contextPct}%` }}
                             />
                           </div>
-                          <span className="text-xs w-8 text-right">
-                            {sessionStats.contextUsage.percent ?? 0}%
+                          <span className="text-xs w-8 shrink-0 text-right tabular-nums">
+                            {contextPct}%
                           </span>
                         </div>
                       }


### PR DESCRIPTION
## Summary

In the System Status popover, the **Context Usage → Usage** percent is rendered verbatim in a fixed-width (`w-8`) label. Most providers return a clean integer, but some (e.g. lmstudio) return a raw float like `1.077270`, so `"1.077270%"` overflows the label and spills past the edge of the popover.

## Fix

Compute the percent once, rounded to a whole number and clamped to `0–100`, and use it for the label, the bar width, and the color thresholds:

```tsx
const contextPct = sessionStats?.contextUsage
  ? Math.min(100, Math.max(0, Math.round(sessionStats.contextUsage.percent ?? 0)))
  : 0
```

`"100%"` still fits `w-8`, so no layout change. Also added `tabular-nums` (and `shrink-0`) to the label so it stays put as the value updates.

## Testing
- Typecheck, lint, and production build pass.
- Verified the label shows a whole-number percent and no longer overflows.