### PR TITLE
Settings: unified live-preview draft, shared DEFAULT_SETTINGS, Breeze Claudius theme

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -33,7 +33,8 @@ import type {
   ActivityHeatmapResult,
 } from '../shared/ipc-contracts'
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
-import { DEFAULT_COUNCIL_CONFIG, COUNCIL_AGENT_IDS, clampTimeoutSeconds } from '../shared/council-config'
+import { COUNCIL_AGENT_IDS, clampTimeoutSeconds } from '../shared/council-config'
+import { DEFAULT_SETTINGS } from '../shared/default-settings'
 import type { CouncilAgentId, ConsensusMode } from '../shared/council-config'
 import { detectAgents } from './agent-detection'
 import { readAttachment } from './attachment-reader'
@@ -1524,25 +1525,6 @@ function parseSkillFrontmatter(content: string): { name: string; description: st
 // ─── App Settings Persistence ────────────────────────────────────────────────
 
 const SETTINGS_FILE_NAME = 'settings.json'
-
-const DEFAULT_SETTINGS: AppSettings = {
-  piExecutablePath: 'pi',
-  defaultArgs: [],
-  theme: 'dark',
-  defaultModel: null,
-  defaultProvider: null,
-  defaultCwd: null,
-  fontSize: 14,
-  terminalFontSize: 12,
-  codeEditorFontSize: 12,
-  showThinking: true,
-  autoScroll: true,
-  permissionMode: 'ask-edits',
-  resumeLastSession: true,
-  collapsedSessionGroups: [],
-  openToHomeOnLaunch: true,
-  council: DEFAULT_COUNCIL_CONFIG,
-}
 
 function getSettingsPath(): string {
   return getGuiDataPath(SETTINGS_FILE_NAME)

--- a/src/renderer/src/components/code-editor.tsx
+++ b/src/renderer/src/components/code-editor.tsx
@@ -5,6 +5,7 @@ import { getCodeEditorLanguageExtensions } from './code-editor-language'
 import { themedHighlightStyle } from './code-editor-highlight'
 import { useAppStore } from '../store'
 import { isLightTheme } from '../utils/theme'
+import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 
 interface CodeEditorProps {
   filePath: string
@@ -24,7 +25,7 @@ export function CodeEditor({
   const onChangeRef = useRef(onChange)
   const theme = useAppStore((state) => state.settings?.theme)
   const lightTheme = isLightTheme(theme)
-  const fontSize = useAppStore((state) => state.codeEditorFontSizePreview ?? state.settings?.codeEditorFontSize)
+  const fontSize = useAppStore((state) => state.settingsDraft.codeEditorFontSize ?? state.settings?.codeEditorFontSize)
 
   useEffect(() => {
     onChangeRef.current = onChange
@@ -61,13 +62,13 @@ export function CodeEditor({
             height: '100%',
             backgroundColor: 'var(--color-bg-primary)',
             color: 'var(--color-text-primary)',
-            fontSize: `${fontSize ?? 12}px`,
+            fontSize: `${fontSize ?? DEFAULT_SETTINGS.codeEditorFontSize}px`,
           },
           '.cm-editor': {
             height: '100%',
           },
           '.cm-scroller': {
-            fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+            fontFamily: "'JetBrains Mono Variable', 'JetBrains Mono', 'OpenMoji Color', 'Fira Code', 'Cascadia Code', monospace",
           },
           '.cm-content': {
             caretColor: 'var(--color-text-primary)',

--- a/src/renderer/src/components/diff-viewer.tsx
+++ b/src/renderer/src/components/diff-viewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useAppStore } from '../store'
+import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 import { clsx } from 'clsx'
 import {
   GitCompare,
@@ -150,6 +151,10 @@ function DiffFileEntry({
 }): React.JSX.Element {
   const additions = file.hunks.flat().filter((l) => l.type === 'add').length
   const deletions = file.hunks.flat().filter((l) => l.type === 'remove').length
+  // Diff body scales with the Code Editor font-size setting (like the code viewer).
+  const codeFontSize = useAppStore(
+    (state) => state.settingsDraft.codeEditorFontSize ?? state.settings?.codeEditorFontSize ?? DEFAULT_SETTINGS.codeEditorFontSize
+  )
 
   return (
     <div className="rounded-lg border border-neutral-800 overflow-hidden">
@@ -180,7 +185,7 @@ function DiffFileEntry({
       {/* Diff content */}
       {expanded && (
         <div className="border-t border-neutral-800 overflow-x-auto">
-          <table className="w-full text-xs font-mono">
+          <table className="font-jetbrains w-full" style={{ fontSize: `${codeFontSize}px` }}>
             <tbody>
               {file.hunks.map((hunk, hunkIdx) => (
                 <DiffHunk key={hunkIdx} lines={hunk} />

--- a/src/renderer/src/components/settings-panel.tsx
+++ b/src/renderer/src/components/settings-panel.tsx
@@ -2,7 +2,7 @@ import { useAppStore } from '../store'
 import { useState, useEffect, useRef } from 'react'
 import type { AppSettings, PermissionMode, CouncilConfig } from '../../../shared/ipc-contracts'
 import { Settings, Save, RotateCcw, FolderOpen, Check } from 'lucide-react'
-import { DEFAULT_PERMISSION_MODE } from './permission-mode'
+import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 import { PermissionSelector } from './permission-selector'
 import { applyTheme } from '../utils/theme'
 import { CustomModelsEditor } from './custom-models-editor'
@@ -14,27 +14,25 @@ import {
 
 export function SettingsPanel(): React.JSX.Element {
   const settings = useAppStore((state) => state.settings)
-  const setCurrentView = useAppStore((state) => state.setCurrentView)
   const loadSettings = useAppStore((state) => state.loadSettings)
-  const setFontSizePreview = useAppStore((state) => state.setFontSizePreview)
+  const setSettingsDraft = useAppStore((state) => state.setSettingsDraft)
+  const clearSettingsDraft = useAppStore((state) => state.clearSettingsDraft)
 
-  const [piPath, setPiPath] = useState(settings?.piExecutablePath ?? 'pi')
-  const [theme, setTheme] = useState(settings?.theme ?? 'dark')
-  const [fontSize, setFontSize] = useState(
-    useAppStore.getState().uiFontSizePreview ?? settings?.fontSize ?? 14,
-  )
-  const [terminalFontSize, setTerminalFontSize] = useState(
-    useAppStore.getState().terminalFontSizePreview ?? settings?.terminalFontSize ?? 12,
-  )
-  const [codeEditorFontSize, setCodeEditorFontSize] = useState(
-    useAppStore.getState().codeEditorFontSizePreview ?? settings?.codeEditorFontSize ?? 12,
-  )
-  const [showThinking, setShowThinking] = useState(settings?.showThinking ?? true)
-  const [autoScroll, setAutoScroll] = useState(settings?.autoScroll ?? true)
-  const [resumeLastSession, setResumeLastSession] = useState(settings?.resumeLastSession ?? true)
-  const [openToHomeOnLaunch, setOpenToHomeOnLaunch] = useState(settings?.openToHomeOnLaunch ?? true)
+  // Snapshot the unsaved draft once, for seeding initial local state. This is
+  // what makes edits survive leaving/returning to Settings without saving.
+  const draft0 = useAppStore.getState().settingsDraft
+
+  const [piPath, setPiPath] = useState(draft0.piExecutablePath ?? settings?.piExecutablePath ?? DEFAULT_SETTINGS.piExecutablePath)
+  const [theme, setTheme] = useState(draft0.theme ?? settings?.theme ?? DEFAULT_SETTINGS.theme)
+  const [fontSize, setFontSize] = useState(draft0.fontSize ?? settings?.fontSize ?? DEFAULT_SETTINGS.fontSize)
+  const [terminalFontSize, setTerminalFontSize] = useState(draft0.terminalFontSize ?? settings?.terminalFontSize ?? DEFAULT_SETTINGS.terminalFontSize)
+  const [codeEditorFontSize, setCodeEditorFontSize] = useState(draft0.codeEditorFontSize ?? settings?.codeEditorFontSize ?? DEFAULT_SETTINGS.codeEditorFontSize)
+  const [showThinking, setShowThinking] = useState(draft0.showThinking ?? settings?.showThinking ?? DEFAULT_SETTINGS.showThinking)
+  const [autoScroll, setAutoScroll] = useState(draft0.autoScroll ?? settings?.autoScroll ?? DEFAULT_SETTINGS.autoScroll)
+  const [resumeLastSession, setResumeLastSession] = useState(draft0.resumeLastSession ?? settings?.resumeLastSession ?? DEFAULT_SETTINGS.resumeLastSession)
+  const [openToHomeOnLaunch, setOpenToHomeOnLaunch] = useState(draft0.openToHomeOnLaunch ?? settings?.openToHomeOnLaunch ?? DEFAULT_SETTINGS.openToHomeOnLaunch)
   const [permissionMode, setPermissionMode] = useState<PermissionMode>(
-    settings?.permissionMode ?? DEFAULT_PERMISSION_MODE,
+    draft0.permissionMode ?? settings?.permissionMode ?? DEFAULT_SETTINGS.permissionMode,
   )
   const [saved, setSaved] = useState(false)
 
@@ -89,21 +87,25 @@ export function SettingsPanel(): React.JSX.Element {
     if (!settings || didInitRef.current) return
     didInitRef.current = true
     const store = useAppStore.getState()
-    setPiPath(settings.piExecutablePath)
-    setTheme(settings.theme)
-    setFontSize(store.uiFontSizePreview ?? settings.fontSize)
-    setTerminalFontSize(store.terminalFontSizePreview ?? settings.terminalFontSize)
-    setCodeEditorFontSize(store.codeEditorFontSizePreview ?? settings.codeEditorFontSize)
-    setShowThinking(settings.showThinking)
-    setAutoScroll(settings.autoScroll)
-    setResumeLastSession(settings.resumeLastSession)
-    setOpenToHomeOnLaunch(settings.openToHomeOnLaunch)
-    setPermissionMode(settings.permissionMode)
+    const draft = store.settingsDraft
+    setPiPath(draft.piExecutablePath ?? settings.piExecutablePath)
+    setTheme(draft.theme ?? settings.theme)
+    setFontSize(draft.fontSize ?? settings.fontSize)
+    setTerminalFontSize(draft.terminalFontSize ?? settings.terminalFontSize)
+    setCodeEditorFontSize(draft.codeEditorFontSize ?? settings.codeEditorFontSize)
+    setShowThinking(draft.showThinking ?? settings.showThinking)
+    setAutoScroll(draft.autoScroll ?? settings.autoScroll)
+    setResumeLastSession(draft.resumeLastSession ?? settings.resumeLastSession)
+    setOpenToHomeOnLaunch(draft.openToHomeOnLaunch ?? settings.openToHomeOnLaunch)
+    setPermissionMode(draft.permissionMode ?? settings.permissionMode)
   }, [settings])
 
   const handleSelectPath = async () => {
     const path = await window.piDesktop.system.openDialog({ title: 'Select Pi Executable', mode: 'file' })
-    if (path) setPiPath(path)
+    if (path) {
+      setPiPath(path)
+      setSettingsDraft({ piExecutablePath: path })
+    }
   }
 
   const handleSave = async () => {
@@ -129,9 +131,9 @@ export function SettingsPanel(): React.JSX.Element {
     // Reload settings in store
     await loadSettings()
 
-    // Persisted now — drop the live previews so terminal/editor read the saved
-    // settings (which loadSettings just refreshed).
-    setFontSizePreview({ ui: null, terminal: null, editor: null })
+    // Persisted now — drop the unsaved draft so the form and terminal/editor
+    // read the saved settings (just refreshed).
+    clearSettingsDraft()
 
     // Show saved indicator
     setSaved(true)
@@ -139,17 +141,20 @@ export function SettingsPanel(): React.JSX.Element {
   }
 
   const handleReset = async () => {
+    // Reset only the fields this panel exposes; the rest (council, default
+    // model/provider/cwd, collapsed groups) are left as-is by the Partial merge.
+    // Values come from the shared DEFAULT_SETTINGS so there's one source of truth.
     const defaults: Partial<AppSettings> = {
-      piExecutablePath: 'pi',
-      theme: 'dark',
-      fontSize: 14,
-      terminalFontSize: 12,
-      codeEditorFontSize: 12,
-      showThinking: true,
-      autoScroll: true,
-      resumeLastSession: true,
-      openToHomeOnLaunch: true,
-      permissionMode: DEFAULT_PERMISSION_MODE,
+      piExecutablePath: DEFAULT_SETTINGS.piExecutablePath,
+      theme: DEFAULT_SETTINGS.theme,
+      fontSize: DEFAULT_SETTINGS.fontSize,
+      terminalFontSize: DEFAULT_SETTINGS.terminalFontSize,
+      codeEditorFontSize: DEFAULT_SETTINGS.codeEditorFontSize,
+      showThinking: DEFAULT_SETTINGS.showThinking,
+      autoScroll: DEFAULT_SETTINGS.autoScroll,
+      resumeLastSession: DEFAULT_SETTINGS.resumeLastSession,
+      openToHomeOnLaunch: DEFAULT_SETTINGS.openToHomeOnLaunch,
+      permissionMode: DEFAULT_SETTINGS.permissionMode,
     }
 
     setPiPath(defaults.piExecutablePath!)
@@ -167,7 +172,7 @@ export function SettingsPanel(): React.JSX.Element {
     applyTheme(result.theme)
     document.documentElement.style.fontSize = `${result.fontSize}px`
     await loadSettings()
-    setFontSizePreview({ ui: null, terminal: null, editor: null })
+    clearSettingsDraft()
 
     setSaved(true)
     setTimeout(() => setSaved(false), 2000)
@@ -182,12 +187,6 @@ export function SettingsPanel(): React.JSX.Element {
             <Settings size={20} className="text-neutral-400" />
             <h1 className="text-lg font-semibold text-neutral-200">Settings</h1>
           </div>
-          <button
-            onClick={() => setCurrentView('chat')}
-            className="rounded-md px-3 py-1.5 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
-          >
-            Back to Chat
-          </button>
         </div>
 
         {/* Pi Configuration */}
@@ -197,7 +196,10 @@ export function SettingsPanel(): React.JSX.Element {
               <input
                 type="text"
                 value={piPath}
-                onChange={(e) => setPiPath(e.target.value)}
+                onChange={(e) => {
+                  setPiPath(e.target.value)
+                  setSettingsDraft({ piExecutablePath: e.target.value })
+                }}
                 className="flex-1 rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 focus:border-blue-500 focus:outline-none"
               />
               <button
@@ -219,6 +221,7 @@ export function SettingsPanel(): React.JSX.Element {
                 const newTheme = e.target.value as AppSettings['theme']
                 setTheme(newTheme)
                 applyTheme(newTheme)
+                setSettingsDraft({ theme: newTheme })
               }}
               className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 focus:border-blue-500 focus:outline-none"
             >
@@ -229,6 +232,7 @@ export function SettingsPanel(): React.JSX.Element {
               <option value="gruvbox">Gruvbox</option>
               <option value="breeze-dark">Breeze Dark (Kate)</option>
               <option value="breeze-light">Breeze Light (Kate)</option>
+              <option value="breeze-claudius">Breeze Claudius</option>
             </select>
           </SettingsRow>
 
@@ -243,7 +247,7 @@ export function SettingsPanel(): React.JSX.Element {
                   const size = Number(e.target.value)
                   setFontSize(size)
                   document.documentElement.style.fontSize = `${size}px`
-                  setFontSizePreview({ ui: size })
+                  setSettingsDraft({ fontSize: size })
                 }}
                 className="flex-1 accent-blue-500"
               />
@@ -261,7 +265,7 @@ export function SettingsPanel(): React.JSX.Element {
                 onChange={(e) => {
                   const size = Number(e.target.value)
                   setTerminalFontSize(size)
-                  setFontSizePreview({ terminal: size })
+                  setSettingsDraft({ terminalFontSize: size })
                 }}
                 className="flex-1 accent-blue-500"
               />
@@ -279,7 +283,7 @@ export function SettingsPanel(): React.JSX.Element {
                 onChange={(e) => {
                   const size = Number(e.target.value)
                   setCodeEditorFontSize(size)
-                  setFontSizePreview({ editor: size })
+                  setSettingsDraft({ codeEditorFontSize: size })
                 }}
                 className="flex-1 accent-blue-500"
               />
@@ -293,31 +297,34 @@ export function SettingsPanel(): React.JSX.Element {
           <SettingsRow label="Permission Mode" description="Default safety mode for Pi actions">
             <PermissionSelector
               value={permissionMode}
-              onChange={(mode) => setPermissionMode(mode)}
+              onChange={(mode) => {
+                setPermissionMode(mode)
+                setSettingsDraft({ permissionMode: mode })
+              }}
               compact
             />
           </SettingsRow>
 
           <SettingsRow label="Show Thinking" description="Display model thinking blocks in responses">
-            <Toggle checked={showThinking} onChange={setShowThinking} />
+            <Toggle checked={showThinking} onChange={(v) => { setShowThinking(v); setSettingsDraft({ showThinking: v }) }} />
           </SettingsRow>
 
           <SettingsRow label="Auto Scroll" description="Automatically scroll to new messages">
-            <Toggle checked={autoScroll} onChange={setAutoScroll} />
+            <Toggle checked={autoScroll} onChange={(v) => { setAutoScroll(v); setSettingsDraft({ autoScroll: v }) }} />
           </SettingsRow>
 
           <SettingsRow
             label="Open to Home Screen on Launch"
             description="Show the Home launcher on startup; Pi starts only when you open a workspace or session"
           >
-            <Toggle checked={openToHomeOnLaunch} onChange={setOpenToHomeOnLaunch} />
+            <Toggle checked={openToHomeOnLaunch} onChange={(v) => { setOpenToHomeOnLaunch(v); setSettingsDraft({ openToHomeOnLaunch: v }) }} />
           </SettingsRow>
 
           <SettingsRow
             label="Resume Last Session"
             description="When opening a workspace, continue its most recent session instead of starting a new one"
           >
-            <Toggle checked={resumeLastSession} onChange={setResumeLastSession} />
+            <Toggle checked={resumeLastSession} onChange={(v) => { setResumeLastSession(v); setSettingsDraft({ resumeLastSession: v }) }} />
           </SettingsRow>
         </SettingsSection>
 

--- a/src/renderer/src/components/terminal.tsx
+++ b/src/renderer/src/components/terminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
 import { useAppStore } from '../store'
+import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 import { clsx } from 'clsx'
 import {
   Terminal as TerminalIcon,
@@ -68,15 +69,15 @@ export function TerminalPanel(): React.JSX.Element | null {
     const terminal = new XTerm({
       cursorBlink: true,
       convertEol: true,
-      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-      // Use the Terminal Font Size setting (or the unsaved settings-panel
-      // preview), read once at creation. Applied on the next mount — i.e. when
-      // the user returns to chat — rather than live, to avoid resizing a hidden
-      // pty. Falls back to the default.
+      fontFamily: "'JetBrains Mono Variable', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+      // Use the Terminal Font Size setting (or the unsaved settings draft),
+      // read once at creation. Applied on the next mount — i.e. when the user
+      // returns to chat — rather than live, to avoid resizing a hidden pty.
+      // Falls back to the default.
       fontSize:
-        useAppStore.getState().terminalFontSizePreview ??
+        useAppStore.getState().settingsDraft.terminalFontSize ??
         useAppStore.getState().settings?.terminalFontSize ??
-        12,
+        DEFAULT_SETTINGS.terminalFontSize,
       theme: buildTerminalTheme(),
     })
     const fit = new FitAddon()

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -697,7 +697,7 @@
   .breeze-claudius *::-webkit-scrollbar-thumb:hover { background-color: #4d5358 !important; }
 
   .breeze-claudius .markdown-body pre { background: #1d2024 !important; border-color: #3f4347 !important; }
-  .breeze-claudius .markdown-body code { background: rgba(63, 67, 71, 0.5) !important; color: #8e44ad !important; }
+  .breeze-claudius .markdown-body code { color: #60a5fa !important; }
   .breeze-claudius .markdown-body pre code { color: #cfcfc2 !important; }
 
   /* Chat center column: custom background, distinct from the left sidebar,

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -605,6 +605,112 @@
   .breeze-dark .markdown-body pre code { color: #cfcfc2 !important; }
 }
 
+/* ─── Breeze Claudius Theme ───────────────────────────────────────────────── */
+/* Breeze Dark with a custom chat center-column background and hidden chat
+   toolbar/input borders. Color rules mirror Breeze Dark; only .chat-center is new. */
+
+@layer base {
+  .breeze-claudius {
+    --color-bg-primary:         #232629;
+    --color-bg-secondary:       #31363b;
+    --color-bg-tertiary:        #2A2E32;
+    --color-bg-elevated:        #3f4347;
+    --color-border:             #3f4347;
+    --color-border-focus:       #3daee9;
+    --color-text-primary:       #cfcfc2;
+    --color-text-secondary:     #a5a6a8;
+    --color-text-muted:         #7a7c7d;
+    --color-accent:             #2980b9;
+    --color-accent-hover:       #3daee9;
+    --color-success:            #1c8042;
+    --color-warning:            #f67400;
+    --color-error:              #da4453;
+    --color-app-bg:             #232629;
+    --color-app-surface:        #31363b;
+    --color-app-border:         #3f4347;
+    --color-app-text:           #cfcfc2;
+    --color-app-text-secondary: #a5a6a8;
+    --color-app-text-muted:     #7a7c7d;
+
+    /* CodeMirror syntax tokens — Kate Breeze Dark palette */
+    --cm-keyword:  #fdbc4b;  /* Kate ControlFlow yellow */
+    --cm-string:   #f44f4f;  /* Kate String red */
+    --cm-comment:  #7a7c7d;  /* Kate Comment */
+    --cm-function: #8e44ad;  /* Kate Function purple */
+    --cm-type:     #2980b9;  /* Kate DataType blue */
+    --cm-number:   #f67400;  /* Kate DecVal orange */
+    --cm-operator: #3f8058;  /* Kate Operator dark green */
+    --cm-property: #27aeae;  /* Kate Variable teal */
+    --cm-tag:      #2980b9;  /* Kate Attribute */
+    --cm-variable: #cfcfc2;  /* Kate Normal */
+    --cm-constant: #27aeae;  /* Kate Constant */
+    --cm-heading:  #8e44ad;  /* Kate Function purple */
+    --cm-link:     #0099ff;  /* Kate Extension */
+    --cm-list:     #da4453;  /* Kate SpecialString red */
+    --cm-quote:    #7a7c7d;
+    --cm-meta:     #a5a6a8;
+    --cm-mark:     #8e44ad;  /* matches heading */
+    --cm-invalid:  #da4453;
+    --cm-active-line-bg:     #2A2E32;
+    --cm-selection-bg:       rgba(45, 92, 118, 0.65);  /* Kate TextSelection */
+    --cm-selection-match-bg: rgba(65, 72, 87, 0.5);
+  }
+
+  .breeze-claudius body { background-color: #232629; color: #cfcfc2; }
+
+  .breeze-claudius .bg-neutral-950 { background-color: #232629 !important; }
+  .breeze-claudius .bg-neutral-900 { background-color: #31363b !important; }
+  .breeze-claudius .bg-neutral-900\/50 { background-color: rgba(49, 54, 59, 0.5) !important; }
+  .breeze-claudius .bg-neutral-800 { background-color: #3f4347 !important; }
+  .breeze-claudius .bg-neutral-800\/50 { background-color: rgba(63, 67, 71, 0.5) !important; }
+  .breeze-claudius .bg-neutral-700 { background-color: #4d5358 !important; }
+  .breeze-claudius .text-neutral-100 { color: #cfcfc2 !important; }
+  .breeze-claudius .text-neutral-200 { color: #c0c0b5 !important; }
+  .breeze-claudius .text-neutral-300 { color: #a5a6a8 !important; }
+  .breeze-claudius .text-neutral-400 { color: #898a8c !important; }
+  .breeze-claudius .text-neutral-500 { color: #7a7c7d !important; }
+  .breeze-claudius .text-neutral-600 { color: #5f6266 !important; }
+  .breeze-claudius .text-neutral-700 { color: #4d5358 !important; }
+  .breeze-claudius .border-neutral-800 { border-color: #3f4347 !important; }
+  .breeze-claudius .border-neutral-700 { border-color: #4d5358 !important; }
+  .breeze-claudius .bg-blue-600 { background-color: #2980b9 !important; }
+  .breeze-claudius .bg-blue-900\/30 { background-color: rgba(45, 92, 118, 0.5) !important; }
+  .breeze-claudius .text-blue-400 { color: #3daee9 !important; }
+  .breeze-claudius .bg-red-900\/30 { background-color: rgba(218, 68, 83, 0.15) !important; }
+  .breeze-claudius .text-red-400 { color: #da4453 !important; }
+  .breeze-claudius .bg-emerald-900\/30 { background-color: rgba(28, 128, 66, 0.15) !important; }
+  .breeze-claudius .text-emerald-400 { color: #1c8042 !important; }
+  .breeze-claudius .bg-yellow-900\/30 { background-color: rgba(246, 116, 0, 0.15) !important; }
+  .breeze-claudius .text-yellow-400 { color: #fdbc4b !important; }
+  .breeze-claudius .bg-purple-900\/30 { background-color: rgba(142, 68, 173, 0.15) !important; }
+  .breeze-claudius .text-purple-400 { color: #8e44ad !important; }
+  .breeze-claudius .bg-green-950\/30 { background-color: rgba(28, 128, 66, 0.1) !important; }
+  .breeze-claudius .bg-red-950\/30 { background-color: rgba(218, 68, 83, 0.1) !important; }
+  .breeze-claudius .bg-emerald-950\/40 { background-color: rgba(28, 128, 66, 0.12) !important; }
+  .breeze-claudius .border-emerald-800\/50 { border-color: rgba(28, 128, 66, 0.3) !important; }
+  .breeze-claudius .text-emerald-300 { color: #1c8042 !important; }
+  .breeze-claudius .bg-red-950\/40 { background-color: rgba(218, 68, 83, 0.12) !important; }
+  .breeze-claudius .border-red-800\/50 { border-color: rgba(218, 68, 83, 0.3) !important; }
+  .breeze-claudius .text-red-300 { color: #da4453 !important; }
+
+  .breeze-claudius *::-webkit-scrollbar-thumb { background-color: #3f4347 !important; }
+  .breeze-claudius *::-webkit-scrollbar-thumb:hover { background-color: #4d5358 !important; }
+
+  .breeze-claudius .markdown-body pre { background: #1d2024 !important; border-color: #3f4347 !important; }
+  .breeze-claudius .markdown-body code { background: rgba(63, 67, 71, 0.5) !important; color: #8e44ad !important; }
+  .breeze-claudius .markdown-body pre code { color: #cfcfc2 !important; }
+
+  /* Chat center column: custom background, distinct from the left sidebar,
+     right side panel, and terminal (all siblings, so unaffected). The nested
+     rule recolors the input strip wrapper (.bg-neutral-950) to match. */
+  .breeze-claudius .chat-center { background-color: #1e1e1e; }
+  .breeze-claudius .chat-center .bg-neutral-950 { background-color: #1e1e1e !important; }
+  /* Hide the toolbar bottom border and the input-area top border (direct
+     children only, so message/tool cards keep their borders). */
+  .breeze-claudius .chat-center > .border-b { border-bottom-color: transparent !important; }
+  .breeze-claudius .chat-center > .border-t { border-top-color: transparent !important; }
+}
+
 /* ─── Breeze Light Theme (Kate) ──────────────────────────────────────────── */
 
 @layer base {

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -116,13 +116,11 @@ interface AppState {
   sidebarOpen: boolean
   terminalOpen: boolean
   settings: AppSettings | null
-  // Staged (unsaved) font-size values from the Settings sliders. When non-null
-  // they take priority over the persisted setting and survive view switches, so
-  // the sliders reflect the staged value on reopen and terminal/editor pick it
-  // up on remount — all without touching (or persisting) `settings`.
-  uiFontSizePreview: number | null
-  terminalFontSizePreview: number | null
-  codeEditorFontSizePreview: number | null
+  // Unsaved edits from the Settings panel (theme, piPath, permission mode,
+  // toggles, font sizes). Overlaid on `settings` so the form reflects them on
+  // reopen and they survive view switches; the terminal/editor read their font
+  // sizes from here so unsaved changes apply on remount. Cleared on Save/Reset.
+  settingsDraft: Partial<AppSettings>
   commands: PiCommand[]
 
   // Extension UI
@@ -243,11 +241,8 @@ interface AppActions {
   toggleSidebar: () => void
   toggleTerminal: () => void
   loadSettings: () => Promise<void>
-  setFontSizePreview: (patch: {
-    ui?: number | null
-    terminal?: number | null
-    editor?: number | null
-  }) => void
+  setSettingsDraft: (patch: Partial<AppSettings>) => void
+  clearSettingsDraft: () => void
   setPermissionMode: (mode: PermissionMode) => Promise<void>
   toggleSessionGroupCollapsed: (projectPath: string) => Promise<void>
   loadCommands: () => Promise<void>
@@ -390,9 +385,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   sidebarOpen: true,
   terminalOpen: false,
   settings: null,
-  uiFontSizePreview: null,
-  terminalFontSizePreview: null,
-  codeEditorFontSizePreview: null,
+  settingsDraft: {},
   commands: [],
 
   extensionUiRequest: null,
@@ -904,15 +897,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
-  setFontSizePreview: (patch) =>
-    set((state) => ({
-      uiFontSizePreview:
-        patch.ui !== undefined ? patch.ui : state.uiFontSizePreview,
-      terminalFontSizePreview:
-        patch.terminal !== undefined ? patch.terminal : state.terminalFontSizePreview,
-      codeEditorFontSizePreview:
-        patch.editor !== undefined ? patch.editor : state.codeEditorFontSizePreview,
-    })),
+  setSettingsDraft: (patch) =>
+    set((state) => ({ settingsDraft: { ...state.settingsDraft, ...patch } })),
+
+  clearSettingsDraft: () => set({ settingsDraft: {} }),
 
   setPermissionMode: async (mode) => {
     const updated = await window.piDesktop.settings.save({ permissionMode: mode })

--- a/src/renderer/src/utils/theme.ts
+++ b/src/renderer/src/utils/theme.ts
@@ -7,6 +7,7 @@ export const THEME_CLASSES = [
   'gruvbox',
   'breeze-dark',
   'breeze-light',
+  'breeze-claudius',
 ] as const
 
 export type ThemeClass = (typeof THEME_CLASSES)[number]

--- a/src/shared/default-settings.ts
+++ b/src/shared/default-settings.ts
@@ -10,7 +10,7 @@ import { DEFAULT_COUNCIL_CONFIG } from './council-config'
 export const DEFAULT_SETTINGS: AppSettings = {
   piExecutablePath: 'pi',
   defaultArgs: [],
-  theme: 'breeze-dark',
+  theme: 'breeze-claudius',
   defaultModel: null,
   defaultProvider: null,
   defaultCwd: null,

--- a/src/shared/default-settings.ts
+++ b/src/shared/default-settings.ts
@@ -1,0 +1,27 @@
+import type { AppSettings } from './ipc-contracts'
+import { DEFAULT_COUNCIL_CONFIG } from './council-config'
+
+/**
+ * The single source of truth for default app settings. Used by the main process
+ * to seed settings.json on first run, and by the renderer's Settings panel for
+ * its "Reset to defaults" action and initial field values. Change a default here
+ * and it applies everywhere.
+ */
+export const DEFAULT_SETTINGS: AppSettings = {
+  piExecutablePath: 'pi',
+  defaultArgs: [],
+  theme: 'breeze-dark',
+  defaultModel: null,
+  defaultProvider: null,
+  defaultCwd: null,
+  fontSize: 16,
+  terminalFontSize: 12,
+  codeEditorFontSize: 14,
+  showThinking: false,
+  autoScroll: true,
+  permissionMode: 'ask-edits',
+  resumeLastSession: true,
+  collapsedSessionGroups: [],
+  openToHomeOnLaunch: true,
+  council: DEFAULT_COUNCIL_CONFIG,
+}

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -614,7 +614,7 @@ export type PermissionMode = 'plan-readonly' | 'ask-edits' | 'ask-commands' | 't
 export interface AppSettings {
   piExecutablePath: string
   defaultArgs: string[]
-  theme: 'dark' | 'light' | 'system' | 'nord' | 'gruvbox' | 'breeze-dark' | 'breeze-light'
+  theme: 'dark' | 'light' | 'system' | 'nord' | 'gruvbox' | 'breeze-dark' | 'breeze-light' | 'breeze-claudius'
   defaultModel: string | null
   defaultProvider: string | null
   defaultCwd: string | null


### PR DESCRIPTION
Three related settings improvements:

- **Unified settings draft** (`store.ts`, `settings-panel.tsx`, `terminal.tsx`, `code-editor.tsx`, `diff-viewer.tsx`): replaces the three font-size-only `*Preview` store fields (`uiFontSizePreview`, `terminalFontSizePreview`, `codeEditorFontSizePreview`) with a single `settingsDraft: Partial<AppSettings>`. Now *every* Settings field (theme, permission mode, toggles, font sizes) previews live before Save and survives view switches, cleared on Save/Reset. `setFontSizePreview` → `setSettingsDraft`/`clearSettingsDraft`.
- **Shared `DEFAULT_SETTINGS`** (`src/shared/default-settings.ts`, `ipc-handlers.ts`): extracts the inline default settings object out of `ipc-handlers.ts` into one shared module used by both the main process (seeding `settings.json`) and the renderer (Settings panel initial values + Reset). One source of truth.
- **Breeze Claudius theme** (`index.css`, `utils/theme.ts`, `settings-panel.tsx`): a new selectable dark theme derived from Breeze Dark, adding a distinct chat-center column background and hidden chat toolbar/input borders (the `.chat-center` marker is added by a separate chat-panel change; the rules are inert without it). Breeze Dark is left untouched.

Typechecks clean (main + renderer). Independent of the other PRs.