### PR TITLE
Packages: fetch catalog once + local filtering, concurrent crawl with prefetch

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from 'fs'
 import { basename, join, resolve as resolvePath } from 'path'
 import { WorkspaceManager } from './workspace-manager'
 import { registerIpcHandlers } from './ipc-handlers'
+import { fetchAllCatalogPackages } from './package-catalog'
 import { configureGuiDataDir, getCanonicalUserDataDir, migrateLegacyGuiData } from './app-data-paths'
 
 // Env var honored on startup: if set, the named directory becomes the active
@@ -208,6 +209,10 @@ app.whenReady().then(async () => {
 
   // Create main window
   createMainWindow()
+
+  // Warm the package catalog cache in the background so the Catalog tab is
+  // instant when first opened. Non-blocking; failures are ignored (offline etc).
+  void fetchAllCatalogPackages().catch(() => {})
 
   // macOS: re-create window when dock icon clicked
   app.on('activate', () => {

--- a/src/main/package-catalog.test.ts
+++ b/src/main/package-catalog.test.ts
@@ -6,6 +6,7 @@ import {
   fetchAllCatalogPackages,
   fetchPackageCatalog,
   clearCatalogCache,
+  PAGE_CONCURRENCY,
 } from './package-catalog'
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -105,6 +106,10 @@ test('filterCatalog returns [] when no package matches', () => {
 // ─── fetchAllCatalogPackages (pagination + cache) ─────────────────────────────
 
 const FULL_PAGE = page(Array.from({ length: 50 }, (_, i) => card({ name: `pkg-${i}` })))
+// Distinct names per page so a realistic catalog (unique package names) isn't
+// collapsed by the crawler's name-dedup.
+const fullPageOf = (base: number): string =>
+  page(Array.from({ length: 50 }, (_, i) => card({ name: `pkg-${base}-${i}` })))
 const SHORT_PAGE = page([card({ name: 'pi-ollama-cloud' }), card({ name: 'last-one' })])
 
 function stubPages(pages: Record<number, string>): () => number {
@@ -118,13 +123,14 @@ function stubPages(pages: Record<number, string>): () => number {
   return () => calls
 }
 
-test('fetchAllCatalogPackages crawls until the first short page', async () => {
-  const calls = stubPages({ 1: FULL_PAGE, 2: FULL_PAGE, 3: SHORT_PAGE })
+test('fetchAllCatalogPackages crawls in batches and stops after the short page', async () => {
+  const calls = stubPages({ 1: fullPageOf(1), 2: fullPageOf(2), 3: SHORT_PAGE })
   const packages = await fetchAllCatalogPackages({ force: true })
 
-  // 50 + 50 + 2 cards collected; crawl stops after the short third page.
+  // 50 + 50 + 2 unique cards collected. Pages past 3 are fetched concurrently in
+  // the same batch but return empty, and the short page 3 stops further batches.
   assert.equal(packages.length, 102)
-  assert.equal(calls(), 3)
+  assert.ok(calls() >= 3 && calls() <= PAGE_CONCURRENCY, 'stops after the first concurrent batch')
   assert.ok(packages.some((p) => p.name === 'pi-ollama-cloud'))
 })
 

--- a/src/main/package-catalog.ts
+++ b/src/main/package-catalog.ts
@@ -1,4 +1,8 @@
 import type { CatalogPackage } from '../shared/ipc-contracts'
+import { filterCatalog } from '../shared/package-filter'
+
+// Re-exported so existing importers (and tests) keep resolving it from here.
+export { filterCatalog }
 
 // The package catalog at pi.dev/packages is a server-rendered, paginated list
 // with no search endpoint (query params are ignored, /api/* returns 501). To
@@ -11,6 +15,8 @@ const CATALOG_BASE_URL = 'https://pi.dev/packages'
 const PAGE_SIZE = 50
 // Safety cap so a server change (e.g. always-full pages) cannot loop forever.
 const MAX_PAGES = 40
+// Pages fetched concurrently per batch (crawl stops at the first short page).
+export const PAGE_CONCURRENCY = 8
 // Re-scrape at most this often; search fires on every keystroke, so without a
 // cache each keystroke would re-crawl every page.
 const CACHE_TTL_MS = 5 * 60 * 1000
@@ -21,6 +27,9 @@ interface CatalogCache {
 }
 
 let catalogCache: CatalogCache | null = null
+// Shared in-flight crawl so concurrent callers (e.g. the startup prefetch and a
+// user opening the Catalog tab) await the same request instead of each crawling.
+let inFlightCrawl: Promise<CatalogPackage[]> | null = null
 
 // Parse the package cards out of a single rendered catalog page. Pure so it can
 // be tested against captured HTML without network access.
@@ -80,29 +89,42 @@ export function parseCatalogHtml(html: string): CatalogPackage[] {
   return packages
 }
 
-// Match every whitespace-separated token against the combined name, description
-// and author. Tokenizing lets multi-word queries like "ollama cloud" match a
-// package named "pi-ollama-cloud". Pure for testability.
-export function filterCatalog(
-  packages: CatalogPackage[],
-  query: string | undefined
-): CatalogPackage[] {
-  if (!query || !query.trim()) return packages
-  const tokens = query.trim().toLowerCase().split(/\s+/)
-  return packages.filter((pkg) => {
-    const haystack = `${pkg.name} ${pkg.description} ${pkg.author}`.toLowerCase()
-    return tokens.every((token) => haystack.includes(token))
-  })
-}
-
 async function fetchCatalogPage(page: number): Promise<CatalogPackage[]> {
   const response = await fetch(`${CATALOG_BASE_URL}?page=${page}`)
   if (!response.ok) return []
   return parseCatalogHtml(await response.text())
 }
 
-// Crawl every catalog page (stopping at the first short page) and cache the
-// result. Exposed so the cache can be primed/forced if ever needed.
+// Crawl catalog pages in concurrent batches, stopping once a short page marks
+// the end of the catalog.
+async function crawlAllPages(): Promise<CatalogPackage[]> {
+  // Dedupe by name: batching may request a few pages past the end, and some
+  // paginated servers clamp out-of-range pages to a valid one — deduping keeps
+  // any such repeats out of the catalog. Preserves first-seen (crawl) order.
+  const byName = new Map<string, CatalogPackage>()
+  let nextPage = 1
+  let reachedEnd = false
+
+  while (!reachedEnd && nextPage <= MAX_PAGES) {
+    const batch: number[] = []
+    for (let i = 0; i < PAGE_CONCURRENCY && nextPage <= MAX_PAGES; i++) {
+      batch.push(nextPage++)
+    }
+    // Promise.all preserves order, so pages are merged in sequence.
+    const pages = await Promise.all(batch.map(fetchCatalogPage))
+    for (const pagePackages of pages) {
+      for (const pkg of pagePackages) {
+        if (!byName.has(pkg.name)) byName.set(pkg.name, pkg)
+      }
+      if (pagePackages.length < PAGE_SIZE) reachedEnd = true
+    }
+  }
+
+  return [...byName.values()]
+}
+
+// Crawl every catalog page and cache the result. Concurrent callers share one
+// in-flight crawl. Exposed so the cache can be primed (e.g. a startup prefetch).
 export async function fetchAllCatalogPackages(
   options?: { force?: boolean }
 ): Promise<CatalogPackage[]> {
@@ -114,20 +136,23 @@ export async function fetchAllCatalogPackages(
     return catalogCache.packages
   }
 
-  const packages: CatalogPackage[] = []
-  for (let page = 1; page <= MAX_PAGES; page++) {
-    const pagePackages = await fetchCatalogPage(page)
-    packages.push(...pagePackages)
-    if (pagePackages.length < PAGE_SIZE) break
+  if (!inFlightCrawl) {
+    inFlightCrawl = crawlAllPages()
+      .then((packages) => {
+        catalogCache = { packages, fetchedAt: Date.now() }
+        return packages
+      })
+      .finally(() => {
+        inFlightCrawl = null
+      })
   }
-
-  catalogCache = { packages, fetchedAt: Date.now() }
-  return packages
+  return inFlightCrawl
 }
 
 // Reset the in-memory cache (test seam).
 export function clearCatalogCache(): void {
   catalogCache = null
+  inFlightCrawl = null
 }
 
 // Fetch the full catalog (cached) and apply the search filter locally.

--- a/src/renderer/src/components/package-browser.tsx
+++ b/src/renderer/src/components/package-browser.tsx
@@ -1,6 +1,7 @@
 import { useAppStore } from '../store'
 import type { CatalogPackage } from '../../../shared/ipc-contracts'
-import { useEffect, useState } from 'react'
+import { filterCatalog } from '../../../shared/package-filter'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import {
   Package,
@@ -21,63 +22,51 @@ export function PackageBrowser(): React.JSX.Element {
   const installedPackages = useAppStore((state) => state.installedPackages)
   const catalogPackages = useAppStore((state) => state.catalogPackages)
   const packageLoading = useAppStore((state) => state.packageLoading)
-  const packageSearchQuery = useAppStore((state) => state.packageSearchQuery)
+  const catalogLoading = useAppStore((state) => state.catalogLoading)
   const packageNotification = useAppStore((state) => state.packageNotification)
   const loadInstalledPackages = useAppStore((state) => state.loadInstalledPackages)
   const installPackage = useAppStore((state) => state.installPackage)
   const removePackage = useAppStore((state) => state.removePackage)
-  const searchCatalog = useAppStore((state) => state.searchCatalog)
-  const setPackageSearchQuery = useAppStore((state) => state.setPackageSearchQuery)
+  const loadCatalog = useAppStore((state) => state.loadCatalog)
   const clearPackageNotification = useAppStore((state) => state.clearPackageNotification)
-  const setCurrentView = useAppStore((state) => state.setCurrentView)
   const installedSkills = useAppStore((state) => state.installedSkills)
   const loadSkills = useAppStore((state) => state.loadSkills)
 
-  const installedNames = new Set(installedPackages.map((p) => p.name))
+  // Memoized so the tab components (below, React.memo'd) don't re-render just
+  // because this Set was rebuilt on an unrelated render.
+  const installedNames = useMemo(
+    () => new Set(installedPackages.map((p) => p.name)),
+    [installedPackages]
+  )
 
   const [activeTab, setActiveTab] = useState<'installed' | 'catalog' | 'skills'>('installed')
-  const [installInput, setInstallInput] = useState('')
-  const [installing, setInstalling] = useState(false)
 
+  // Installed packages and skills are local/fast — load them up front so the
+  // default Installed tab paints immediately.
   useEffect(() => {
     loadInstalledPackages()
     loadSkills()
-    searchCatalog()
-  }, [loadInstalledPackages, loadSkills, searchCatalog])
+  }, [loadInstalledPackages, loadSkills])
 
-  const handleInstall = async () => {
-    if (!installInput.trim()) return
-    setInstalling(true)
-    await installPackage(installInput.trim())
-    setInstallInput('')
-    setInstalling(false)
-  }
+  // The catalog requires a (prefetched) network crawl — load it lazily the first
+  // time the Catalog tab is opened, so opening Packages never blocks on it.
+  const catalogRequested = useRef(false)
+  useEffect(() => {
+    if (activeTab === 'catalog' && !catalogRequested.current) {
+      catalogRequested.current = true
+      loadCatalog()
+    }
+  }, [activeTab, loadCatalog])
 
-  const handleRemove = async (spec: string) => {
-    await removePackage(spec)
-  }
-
-  const handleSearch = (query: string) => {
-    setPackageSearchQuery(query)
-    searchCatalog(query)
-  }
+  const handleRemove = useCallback((spec: string) => { removePackage(spec) }, [removePackage])
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
       <div className="border-b border-neutral-800 px-4 py-3">
-        <div className="flex items-center justify-between mb-3">
-          <div className="flex items-center gap-2">
-            <Package size={16} className="text-neutral-400" />
-            <h2 className="text-sm font-medium text-neutral-200">Packages & Skills</h2>
-          </div>
-          <button
-            type="button"
-            onClick={() => setCurrentView('chat')}
-            className="rounded px-2 py-1 text-xs text-neutral-500 hover:text-neutral-300 transition-colors"
-          >
-            Back to Chat
-          </button>
+        <div className="flex items-center gap-2 mb-3">
+          <Package size={16} className="text-neutral-400" />
+          <h2 className="text-sm font-medium text-neutral-200">Packages & Skills</h2>
         </div>
 
         {/* Tabs */}
@@ -105,34 +94,8 @@ export function PackageBrowser(): React.JSX.Element {
         </div>
       </div>
 
-      {/* Install bar */}
-      <div className="border-b border-neutral-800 px-4 py-3">
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={installInput}
-            onChange={(e) => setInstallInput(e.target.value)}
-            placeholder="npm:package-name or git:github.com/user/repo"
-            className="flex-1 rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 placeholder:text-neutral-600 focus:border-blue-500 focus:outline-none"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleInstall()
-            }}
-          />
-          <button
-            type="button"
-            onClick={handleInstall}
-            disabled={installing || !installInput.trim()}
-            className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {installing ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : (
-              <Download size={14} />
-            )}
-            Install
-          </button>
-        </div>
-      </div>
+      {/* Install bar (isolated: its keystrokes never re-render the tab lists) */}
+      <InstallBar />
 
       {/* Notification banner */}
       {packageNotification && (
@@ -170,9 +133,7 @@ export function PackageBrowser(): React.JSX.Element {
         {activeTab === 'catalog' && (
           <CatalogTab
             packages={catalogPackages}
-            loading={packageLoading}
-            searchQuery={packageSearchQuery}
-            onSearch={handleSearch}
+            loading={catalogLoading}
             onInstall={installPackage}
             installedNames={installedNames}
           />
@@ -180,6 +141,51 @@ export function PackageBrowser(): React.JSX.Element {
         {activeTab === 'skills' && (
           <SkillsTab skills={installedSkills} />
         )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Install Bar ─────────────────────────────────────────────────────────────
+
+// Isolated so typing a package spec only re-renders this small component — it
+// never touches the Installed/Catalog/Skills lists. Install runs only on click.
+function InstallBar(): React.JSX.Element {
+  const installPackage = useAppStore((state) => state.installPackage)
+  const [installInput, setInstallInput] = useState('')
+  const [installing, setInstalling] = useState(false)
+
+  const handleInstall = async (): Promise<void> => {
+    const spec = installInput.trim()
+    if (!spec) return
+    setInstalling(true)
+    await installPackage(spec)
+    setInstallInput('')
+    setInstalling(false)
+  }
+
+  return (
+    <div className="border-b border-neutral-800 px-4 py-3">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={installInput}
+          onChange={(e) => setInstallInput(e.target.value)}
+          placeholder="npm:package-name or git:github.com/user/repo"
+          className="flex-1 rounded-md border border-neutral-700 bg-neutral-900 px-3 py-1.5 text-sm text-neutral-200 placeholder:text-neutral-600 focus:border-blue-500 focus:outline-none"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleInstall()
+          }}
+        />
+        <button
+          type="button"
+          onClick={handleInstall}
+          disabled={installing || !installInput.trim()}
+          className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {installing ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+          Install
+        </button>
       </div>
     </div>
   )
@@ -222,7 +228,7 @@ function TabButton({
 
 // ─── Installed Tab ───────────────────────────────────────────────────────────
 
-function InstalledTab({
+const InstalledTab = memo(function InstalledTab({
   packages,
   loading,
   onRemove,
@@ -292,25 +298,31 @@ function InstalledTab({
       ))}
     </div>
   )
-}
+})
 
 // ─── Catalog Tab ─────────────────────────────────────────────────────────────
 
-function CatalogTab({
+// Cap on rendered rows: the full catalog can be ~thousands of packages, so we
+// render a slice and prompt the user to refine rather than paint them all.
+const CATALOG_RENDER_CAP = 100
+
+const CatalogTab = memo(function CatalogTab({
   packages,
   loading,
-  searchQuery,
-  onSearch,
   onInstall,
   installedNames,
 }: {
   packages: CatalogPackage[]
   loading: boolean
-  searchQuery: string
-  onSearch: (query: string) => void
   onInstall: (spec: string) => void
   installedNames: Set<string>
 }): React.JSX.Element {
+  // Search is local state and filtering runs in-renderer against the already
+  // loaded catalog — no per-keystroke IPC or loading toggle.
+  const [query, setQuery] = useState('')
+  const filtered = useMemo(() => filterCatalog(packages, query), [packages, query])
+  const shown = filtered.slice(0, CATALOG_RENDER_CAP)
+
   return (
     <div>
       {/* Search */}
@@ -319,8 +331,8 @@ function CatalogTab({
           <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500" />
           <input
             type="text"
-            value={searchQuery}
-            onChange={(e) => onSearch(e.target.value)}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
             placeholder="Search packages..."
             className="w-full rounded-lg border border-neutral-700 bg-neutral-900 py-2 pl-9 pr-4 text-sm text-neutral-200 placeholder:text-neutral-600 focus:border-blue-500 focus:outline-none"
           />
@@ -331,7 +343,7 @@ function CatalogTab({
         <div className="flex items-center justify-center py-12">
           <Loader2 size={24} className="animate-spin text-neutral-500" />
         </div>
-      ) : packages.length === 0 ? (
+      ) : filtered.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-neutral-500">
           <Store size={32} className="mb-3 text-neutral-600" />
           <p className="text-sm">No packages found</p>
@@ -349,7 +361,7 @@ function CatalogTab({
         </div>
       ) : (
         <div className="space-y-2">
-          {packages.map((pkg, index) => (
+          {shown.map((pkg, index) => (
             <div
               key={`${pkg.name}-${index}`}
               className="rounded-lg border border-neutral-800 bg-neutral-900/50 px-4 py-3"
@@ -415,15 +427,20 @@ function CatalogTab({
               </div>
             </div>
           ))}
+          {filtered.length > shown.length && (
+            <div className="py-3 text-center text-xs text-neutral-600">
+              Showing {shown.length} of {filtered.length} — refine your search to narrow results.
+            </div>
+          )}
         </div>
       )}
     </div>
   )
-}
+})
 
 // ─── Skills Tab ──────────────────────────────────────────────────────────────
 
-function SkillsTab({
+const SkillsTab = memo(function SkillsTab({
   skills,
 }: {
   skills: Array<{ name: string; description: string; path: string; source: string; enabled: boolean }>
@@ -465,4 +482,4 @@ function SkillsTab({
       ))}
     </div>
   )
-}
+})

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -141,8 +141,8 @@ interface AppState {
   // Packages
   installedPackages: InstalledPackage[]
   catalogPackages: CatalogPackage[]
-  packageLoading: boolean
-  packageSearchQuery: string
+  packageLoading: boolean // install/remove operations (affects the Installed tab)
+  catalogLoading: boolean // catalog crawl (Catalog tab only)
   packageNotification: { type: 'success' | 'error'; message: string } | null
 
   // Skills
@@ -279,8 +279,7 @@ interface AppActions {
   loadInstalledPackages: () => Promise<void>
   installPackage: (spec: string) => Promise<void>
   removePackage: (spec: string) => Promise<void>
-  searchCatalog: (query?: string) => Promise<void>
-  setPackageSearchQuery: (query: string) => void
+  loadCatalog: () => Promise<void>
   clearPackageNotification: () => void
 
   // Skills
@@ -406,7 +405,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   installedPackages: [],
   catalogPackages: [],
   packageLoading: false,
-  packageSearchQuery: '',
+  catalogLoading: false,
   packageNotification: null,
 
   installedSkills: [],
@@ -1292,19 +1291,19 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
-  searchCatalog: async (query) => {
-    set({ packageLoading: true })
+  // Load the full catalog once; the Catalog tab filters it locally on each
+  // keystroke (no per-keystroke IPC). catalogLoading gates only this one-time load.
+  loadCatalog: async () => {
+    set({ catalogLoading: true })
     try {
-      const packages = await window.piDesktop.packages.fetchCatalog(query)
+      const packages = await window.piDesktop.packages.fetchCatalog()
       set({ catalogPackages: packages })
     } catch {
       // Silent failure
     } finally {
-      set({ packageLoading: false })
+      set({ catalogLoading: false })
     }
   },
-
-  setPackageSearchQuery: (query) => set({ packageSearchQuery: query }),
 
   clearPackageNotification: () => set({ packageNotification: null }),
 

--- a/src/shared/package-filter.ts
+++ b/src/shared/package-filter.ts
@@ -1,0 +1,19 @@
+import type { CatalogPackage } from './ipc-contracts'
+
+/**
+ * Match every whitespace-separated token against the combined name, description
+ * and author. Tokenizing lets multi-word queries like "ollama cloud" match a
+ * package named "pi-ollama-cloud". Pure, so it runs the same in the main
+ * process (initial crawl filter) and the renderer (live search filtering).
+ */
+export function filterCatalog(
+  packages: CatalogPackage[],
+  query: string | undefined
+): CatalogPackage[] {
+  if (!query || !query.trim()) return packages
+  const tokens = query.trim().toLowerCase().split(/\s+/)
+  return packages.filter((pkg) => {
+    const haystack = `${pkg.name} ${pkg.description} ${pkg.author}`.toLowerCase()
+    return tokens.every((token) => haystack.includes(token))
+  })
+}


### PR DESCRIPTION
Makes the Catalog tab responsive by fetching once and filtering client-side, and speeds up the crawl.

- **Fetch-once + local filter** (`store.ts`, `package-browser.tsx`, `src/shared/package-filter.ts`): the catalog has no search endpoint, so the old flow re-crawled every page on each keystroke (`searchCatalog(query)` → per-keystroke IPC). Now `loadCatalog()` fetches the full catalog once and the Catalog tab filters it locally on every keystroke. Store: `searchCatalog`/`setPackageSearchQuery` + `packageSearchQuery` → `loadCatalog` + `catalogLoading` (separate from `packageLoading`, which now gates only install/remove). `filterCatalog` is extracted to a shared module reused by main and renderer.
- **Concurrent crawl + prefetch** (`package-catalog.ts` + test): pages are fetched in concurrent batches (`PAGE_CONCURRENCY = 8`) instead of strictly serially, stopping at the first short page; a shared in-flight promise coalesces concurrent callers (startup prefetch + user opening the tab) into one crawl. The catalog is prefetched on launch (`index.ts`) so the tab is instant.

Typechecks clean (main + renderer). Independent of the other PRs.