### PR TITLE
Chat panes: code+image preview, review toggle, per-session scroll restore, composer/tree polish

### DIFF
--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -108,7 +108,11 @@ export function App(): React.JSX.Element {
         <div className="flex min-w-0 flex-1 overflow-hidden">
           <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
             {currentView === 'home' && <HomeScreen />}
-            {currentView === 'chat' && <ChatPanel />}
+            {/* Kept mounted (just hidden) so the chat scroll position survives
+                navigating to another view and back. */}
+            <div className={currentView === 'chat' ? 'flex min-w-0 flex-1 flex-col overflow-hidden' : 'hidden'}>
+              <ChatPanel />
+            </div>
             {currentView === 'settings' && <SettingsPanel />}
             {currentView === 'sessions' && <SessionPanel />}
             {currentView === 'timeline' && <Timeline />}

--- a/src/renderer/src/assets.d.ts
+++ b/src/renderer/src/assets.d.ts
@@ -1,0 +1,7 @@
+// Ambient declarations for Vite asset imports (this file is a script, not a
+// module, so the wildcard module declaration applies globally). Vite resolves
+// an asset import to its served URL (a string).
+declare module '*.svg' {
+  const src: string
+  export default src
+}

--- a/src/renderer/src/assets/pi-logo.svg
+++ b/src/renderer/src/assets/pi-logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <!-- Charcoal rounded background -->
+  <rect width="512" height="512" rx="77" fill="#36454F"/>
+
+  <!-- Pi letterforms: official brand marks, scaled from 800 -> 512 -->
+  <g transform="translate(5.5, 5.5) scale(0.62625)">
+    <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+    <path fill="#e67e22" fill-rule="evenodd" d="
+      M165.29 165.29
+      H517.36
+      V400
+      H400
+      V517.36
+      H282.65
+      V634.72
+      H165.29
+      Z
+      M282.65 282.65
+      V400
+      H400
+      V282.65
+      Z
+    "/>
+    <!-- i dot -->
+    <path fill="#e67e22" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+  </g>
+</svg>

--- a/src/renderer/src/components/chat-file-link.ts
+++ b/src/renderer/src/components/chat-file-link.ts
@@ -1,0 +1,120 @@
+import { useAppStore } from '../store'
+
+// Image extensions the viewer can render. png/jpg/jpeg/gif/webp arrive as base64
+// from readAttachment; svg comes back as text and is rendered from its markup.
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
+
+// Common file extensions we treat as "this inline code is a filename". Kept as an
+// allowlist (rather than "anything with a dot") so abbreviations like `e.g` and
+// version strings like `1.2.3` don't masquerade as clickable files.
+const FILE_EXTENSIONS = new Set([
+  'txt', 'md', 'mdx', 'rst', 'log', 'csv', 'tsv',
+  'json', 'jsonc', 'json5', 'yaml', 'yml', 'toml', 'ini', 'conf', 'cfg', 'env', 'properties',
+  'xml', 'svg', 'html', 'htm', 'css', 'scss', 'less', 'vue', 'svelte',
+  'js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx', 'json5',
+  'py', 'pyi', 'rb', 'php', 'go', 'rs', 'java', 'kt', 'kts', 'scala', 'swift', 'dart',
+  'c', 'h', 'cc', 'cpp', 'cxx', 'hpp', 'hh', 'cs', 'm', 'mm',
+  'lua', 'pl', 'pm', 'r', 'jl', 'ex', 'exs', 'erl', 'clj', 'cljs', 'edn', 'hs', 'ml', 'fs',
+  'sh', 'bash', 'zsh', 'ps1', 'bat', 'cmd',
+  'sql', 'graphql', 'gql', 'proto', 'tcl', 'gradle', 'groovy',
+  'lock', 'gitignore', 'dockerignore', 'editorconfig',
+  ...IMAGE_EXTENSIONS,
+])
+
+function extensionOf(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : ''
+}
+
+export function isImagePath(name: string): boolean {
+  return IMAGE_EXTENSIONS.has(extensionOf(name))
+}
+
+// Absolute path (forward-slash normalized): Windows drive (C:/…), UNC (//…),
+// or POSIX (/…).
+function isAbsolutePath(normalized: string): boolean {
+  return /^(?:[A-Za-z]:\/|\/)/.test(normalized)
+}
+
+// True when a forward-slash-normalized absolute path lives inside the active
+// workspace. Used to keep the preview scoped to the workspace (case-insensitive
+// to be forgiving on Windows).
+function isInsideWorkspace(normalizedAbsolute: string): boolean {
+  const root = useAppStore.getState().activeWorkspace?.path
+  if (!root) return false
+  const normRoot = root.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase()
+  const p = normalizedAbsolute.toLowerCase()
+  return p === normRoot || p.startsWith(normRoot + '/')
+}
+
+/**
+ * Heuristic: does this inline-code text read like a file reference (relative or
+ * absolute)? Requires path-safe characters ending in a known extension, and
+ * rejects function calls / quoted literals so keywords stay non-clickable.
+ */
+export function looksLikeFilePath(text: string): boolean {
+  const t = text.trim()
+  if (!t || /\s/.test(t)) return false
+  // Reject function calls, quoted strings, comparisons, globs, etc. (a lone `:`
+  // is allowed so Windows drive letters like `C:\…` still qualify).
+  if (/[()"'`=<>|*?{}[\];,!@#$%^&~]/.test(t)) return false
+  if (t.includes('://')) return false // URLs
+  const match = /^(?:[A-Za-z]:)?[A-Za-z0-9_.\-/\\]+\.([A-Za-z0-9]+)$/.exec(t)
+  if (!match) return false
+  if (!FILE_EXTENSIONS.has(match[1].toLowerCase())) return false
+  // Absolute paths are only clickable when they resolve inside the workspace;
+  // relative names resolve via workspace search, so they're always fine.
+  const normalized = t.replace(/\\/g, '/')
+  if (isAbsolutePath(normalized) && !isInsideWorkspace(normalized)) return false
+  return true
+}
+
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase()
+}
+
+/**
+ * Open the file referenced by inline-code text. Images open in the image viewer
+ * pane; other files open in the code editor. Absolute paths are read directly
+ * (may live outside the workspace); relative names are resolved by searching the
+ * workspace on basename. No-op if nothing resolves.
+ */
+export async function openFileFromChat(text: string): Promise<void> {
+  const original = text.trim()
+  const raw = original.replace(/\\/g, '/').replace(/^\.\//, '')
+  const base = raw.split('/').pop() ?? raw
+  if (!base) return
+
+  const store = useAppStore.getState()
+
+  try {
+    // Absolute path: open it directly rather than searching the workspace.
+    // The code editor reads paths inside the workspace; the HTML preview loads
+    // via file:// so it works regardless. relativePath is the basename so the
+    // header stays readable and language/preview detection still works.
+    if (isAbsolutePath(raw)) {
+      // Only open absolute paths that live inside the active workspace.
+      if (!isInsideWorkspace(raw)) return
+      if (store.chatSidePanel === 'diff') store.setChatSidePanel(null)
+      store.setSelectedFile(base, original)
+      return
+    }
+
+    const results = await window.piDesktop.files.search(base)
+    if (results.length === 0) return
+
+    const wanted = normalize(raw)
+    const match =
+      results.find((r) => normalize(r.relativePath) === wanted) ??
+      results.find((r) => normalize(r.relativePath).endsWith('/' + wanted)) ??
+      results.find((r) => r.name.toLowerCase() === base.toLowerCase()) ??
+      results[0]
+
+    if (!match) return
+
+    if (store.chatSidePanel === 'diff') store.setChatSidePanel(null)
+    store.setSelectedFile(match.relativePath, match.path)
+  } catch {
+    // File service unavailable or no active workspace — silently ignore.
+  }
+}

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useState, useEffect } from 'react'
 import { useAppStore } from '../store'
 import { useChatKeyboard } from '../hooks'
-import { Send, Square, Paperclip, X, FileText, NotebookPen, Users } from 'lucide-react'
+import { CornerDownLeft, Square, Paperclip, X, FileText, NotebookPen, Users } from 'lucide-react'
 import { SUPPORTED_IMAGE_EXTENSIONS, type PromptImage } from '../../../shared/ipc-contracts'
 
 // Max height (px) the auto-growing input expands to before scrolling.
@@ -160,7 +160,7 @@ export function ChatInput(): React.JSX.Element {
         </div>
       )}
 
-      <div className="relative flex items-end rounded-xl border border-neutral-700 bg-neutral-900 focus-within:border-neutral-600 transition-colors">
+      <div className="relative flex items-center rounded-xl border border-neutral-700 bg-neutral-900 focus-within:border-neutral-600 transition-colors">
         {/* Attachment button */}
         <button
           onClick={handleAttachFile}
@@ -175,7 +175,7 @@ export function ChatInput(): React.JSX.Element {
         {/* Notes picker button */}
         <button
           onClick={() => setNotePickerOpen(true)}
-          className="flex shrink-0 items-center justify-center py-3 pr-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+          className="flex shrink-0 items-center justify-center py-3 pr-3 text-neutral-500 hover:text-neutral-300 transition-colors"
           title="Insert a saved note (Ctrl+Shift+P)"
           aria-label="Insert a saved note"
         >
@@ -213,7 +213,7 @@ export function ChatInput(): React.JSX.Element {
           }
           disabled={isDisabled}
           rows={1}
-          className="max-h-48 min-h-[24px] flex-1 resize-none bg-transparent py-3 text-sm text-neutral-200 placeholder:text-neutral-600 outline-none disabled:opacity-50"
+          className="font-chat max-h-48 min-h-[24px] flex-1 resize-none bg-transparent py-3 text-sm text-neutral-200 placeholder:text-neutral-600 outline-none disabled:opacity-50"
           onInput={(e) => {
             const target = e.currentTarget
             target.style.height = 'auto'
@@ -243,11 +243,11 @@ export function ChatInput(): React.JSX.Element {
           {isStreaming ? (
             <button
               onClick={handleAbort}
-              className="flex items-center justify-center rounded-lg bg-red-600 p-2 text-white hover:bg-red-500 transition-colors"
+              className="flex items-center justify-center rounded-lg p-2 text-neutral-500 hover:text-neutral-300 transition-colors"
               title="Stop (Esc)"
               aria-label="Stop generating"
             >
-              <Square size={14} />
+              <Square size={16} />
             </button>
           ) : (
             <button
@@ -259,11 +259,11 @@ export function ChatInput(): React.JSX.Element {
                 }
               }}
               disabled={isDisabled}
-              className="flex items-center justify-center rounded-lg bg-blue-600 p-2 text-white hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex items-center justify-center rounded-lg p-2 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               title="Send (Enter)"
               aria-label="Send message"
             >
-              <Send size={14} />
+              <CornerDownLeft size={16} />
             </button>
           )}
         </div>

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -4,15 +4,20 @@ import { CouncilPanels } from './council-panels'
 import { MessageBubble } from './message-bubble'
 import { StreamingBubble } from './streaming-bubble'
 import { FileTree, FileSearch, FilePreview } from './file-tree'
+import { ImageViewer } from './image-viewer'
 import { DiffViewer } from './diff-viewer'
 import { TerminalPanel } from './terminal'
-import { useAutoScroll } from '../hooks'
+import { useChatScroll } from '../hooks'
 import { useState, useCallback } from 'react'
 import { clsx } from 'clsx'
+import piLogo from '../assets/pi-logo.svg'
 import {
   FolderTree,
   GitCompare,
   Terminal,
+  ShieldCheck,
+  PanelLeft,
+  PanelLeftClose,
   X,
 } from 'lucide-react'
 
@@ -24,9 +29,11 @@ export function ChatPanel(): React.JSX.Element {
   const streamingToolCalls = useAppStore((state) => state.streamingToolCalls)
   const piStatus = useAppStore((state) => state.piStatus)
   const terminalOpen = useAppStore((state) => state.terminalOpen)
+  const reviewOpen = useAppStore((state) => state.reviewOpen)
+  const sidebarOpen = useAppStore((state) => state.sidebarOpen)
   const fileSearchOpen = useAppStore((state) => state.fileSearchOpen)
   const toggleFileSearch = useAppStore((state) => state.toggleFileSearch)
-  const selectedFile = useAppStore((state) => state.selectedFile)
+  const previewTarget = useAppStore((state) => state.previewTarget)
 
   // sidePanel lives in the store so it survives view switches (e.g. Settings
   // round-trip). Widths stay local — resetting them on remount is benign.
@@ -35,7 +42,8 @@ export function ChatPanel(): React.JSX.Element {
   const [sidePanelWidth, setSidePanelWidth] = useState(640)
   const [filePaneWidth, setFilePaneWidth] = useState(280)
 
-  const scrollRef = useAutoScroll([messages.length, streamingContent])
+  const currentView = useAppStore((state) => state.currentView)
+  const { scrollRef, onScroll } = useChatScroll(currentView === 'chat')
 
   const handleRetry = useCallback(async (messageId: string) => {
     // Read from the store so this callback stays referentially stable, keeping
@@ -48,12 +56,13 @@ export function ChatPanel(): React.JSX.Element {
   }, [])
 
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
-  const showSidePanel = sidePanel !== null || selectedFile !== null
+  const showSidePanel = sidePanel !== null || previewTarget !== null
   const showFileTree = sidePanel === 'files'
-  const showEditor = selectedFile !== null && sidePanel !== 'diff'
+  const showImage = previewTarget?.kind === 'image' && sidePanel !== 'diff'
+  const showEditor = previewTarget?.kind === 'code' && sidePanel !== 'diff'
   const showDiff = sidePanel === 'diff'
-  const showFileTreeOnly = showFileTree && !showEditor
-  const minSidePanelWidth = showFileTree && showEditor ? 600 : 360
+  const showFileTreeOnly = showFileTree && !showEditor && !showImage
+  const minSidePanelWidth = showFileTree && (showEditor || showImage) ? 600 : 360
   const effectiveSidePanelWidth = clamp(sidePanelWidth, minSidePanelWidth, 1280)
   const maxFilePaneWidth = Math.max(220, effectiveSidePanelWidth - 360)
   const effectiveFilePaneWidth = clamp(filePaneWidth, 220, maxFilePaneWidth)
@@ -63,10 +72,10 @@ export function ChatPanel(): React.JSX.Element {
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="flex flex-1 overflow-hidden">
         {/* Main chat area */}
-        <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="chat-center flex flex-1 flex-col overflow-hidden">
           {/* Toolbar */}
           <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-1.5">
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-0.5">
               {/* Workspace path — always visible */}
               {activeWorkspace && (
                 <div className="flex items-center gap-1.5 mr-2 px-2 py-0.5 rounded bg-neutral-800/60" title={activeWorkspace.path}>
@@ -76,6 +85,18 @@ export function ChatPanel(): React.JSX.Element {
                   </span>
                 </div>
               )}
+              <ToolbarButton
+                icon={sidebarOpen ? <PanelLeftClose size={14} /> : <PanelLeft size={14} />}
+                active={false}
+                onClick={() => useAppStore.getState().toggleSidebar()}
+                title={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+              />
+              <ToolbarButton
+                icon={<ShieldCheck size={14} />}
+                active={reviewOpen}
+                onClick={() => useAppStore.getState().toggleReview()}
+                title="Review panel"
+              />
               <ToolbarButton
                 icon={<FolderTree size={14} />}
                 active={sidePanel === 'files'}
@@ -98,7 +119,7 @@ export function ChatPanel(): React.JSX.Element {
           </div>
 
           {/* Messages area */}
-          <div ref={scrollRef} className="flex-1 overflow-y-auto">
+          <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
             {messages.length === 0 && !isStreaming ? (
               <EmptyState piStatus={piStatus} />
             ) : (
@@ -145,7 +166,7 @@ export function ChatPanel(): React.JSX.Element {
                   <div className="flex min-w-0 shrink-0 flex-col overflow-hidden" style={{ width: effectiveFilePaneWidth }}>
                     <FileTree />
                   </div>
-                  {showEditor && (
+                  {(showEditor || showImage) && (
                     <ResizeHandle
                       onResize={(delta) => setFilePaneWidth((width) => clamp(width + delta, 220, maxFilePaneWidth))}
                     />
@@ -158,8 +179,20 @@ export function ChatPanel(): React.JSX.Element {
                 </div>
               )}
               {showEditor && (
-                <div className="flex min-w-[360px] flex-1 flex-col overflow-hidden border-l border-neutral-800">
+                <div
+                  className={clsx(
+                    'flex min-w-[360px] flex-1 flex-col overflow-hidden',
+                    // Divider only when the file tree is beside it; alone, the
+                    // outer panel's border-l is the left edge (avoids doubling).
+                    showFileTree && 'border-l border-neutral-800'
+                  )}
+                >
                   <FilePreview />
+                </div>
+              )}
+              {showImage && (
+                <div className="flex min-w-[360px] flex-1 flex-col overflow-hidden">
+                  <ImageViewer />
                 </div>
               )}
             </div>
@@ -214,7 +247,7 @@ function ResizeHandle({ onResize }: { onResize: (delta: number) => void }): Reac
       className="group flex w-2 shrink-0 cursor-col-resize items-stretch justify-center bg-neutral-950 transition-colors hover:bg-neutral-800"
       title="Drag to resize"
     >
-      <div className="w-px bg-neutral-700 transition-colors group-hover:bg-blue-400" />
+      <div className="w-px bg-transparent transition-colors group-hover:bg-blue-400" />
     </div>
   )
 }
@@ -238,7 +271,7 @@ function ToolbarButton({
     <button
       onClick={onClick}
       className={clsx(
-        'rounded p-1.5 transition-colors',
+        'rounded p-1 transition-colors',
         active
           ? 'bg-neutral-800 text-neutral-200'
           : 'text-neutral-500 hover:bg-neutral-800/50 hover:text-neutral-300'
@@ -254,11 +287,11 @@ function EmptyState({ piStatus }: { piStatus: string }): React.JSX.Element {
   return (
     <div className="flex h-full flex-col items-center justify-center px-4">
       <div className="text-center">
-        <div className="mb-4 text-4xl">⌘</div>
-        <h2 className="mb-2 text-lg font-medium text-neutral-200">
+        <img src={piLogo} alt="Pi Desktop" className="mx-auto mb-4 block h-16 w-16" />
+        <h2 className="mb-6 text-2xl font-semibold text-neutral-100">
           Pi Desktop
         </h2>
-        <p className="mb-6 max-w-md text-sm text-neutral-500">
+        <p className="mb-6 max-w-3xl text-balance text-sm text-neutral-500">
           {piStatus === 'running'
             ? 'Start a conversation with your coding agent. Ask it to build, debug, or explore your codebase.'
             : piStatus === 'starting'

--- a/src/renderer/src/components/file-tree.tsx
+++ b/src/renderer/src/components/file-tree.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState, useCallback, useRef } from 'react'
 import { useAppStore } from '../store'
 import type { FileTreeNode, GitFileStatus, FileSearchResult } from '../../../shared/ipc-contracts'
 import { CodeEditor } from './code-editor'
+import { MarkdownRenderer } from './markdown-renderer'
+import { isImagePath } from './chat-file-link'
 import { clsx } from 'clsx'
 import {
   FolderOpen,
@@ -16,7 +18,22 @@ import {
   Loader2,
   Save,
   RotateCcw,
+  Eye,
+  Code2,
 } from 'lucide-react'
+
+// `<webview>` (enabled via webviewTag) isn't a typed JSX intrinsic; cast the tag
+// to a component so TS accepts the props we use. It renders the HTML preview in
+// an isolated guest process so its JavaScript runs without touching the app CSP.
+const Webview = 'webview' as unknown as React.FC<
+  React.HTMLAttributes<HTMLElement> & { src: string; partition?: string }
+>
+
+function toFileUrl(absolutePath: string): string {
+  let p = absolutePath.replace(/\\/g, '/')
+  if (!p.startsWith('/')) p = '/' + p // Windows "C:/…" -> "/C:/…"
+  return encodeURI('file://' + p)
+}
 
 // ─── File Tree ───────────────────────────────────────────────────────────────
 
@@ -90,8 +107,14 @@ export function FileTree(): React.JSX.Element {
 
   const handleFileClick = useCallback((path: string, relativePath: string) => {
     setSelectedFile(relativePath)
-    // Store the selected file for preview
-    useAppStore.getState().setSelectedFile(relativePath, path)
+    // Store the selected file for preview (images route to the image viewer).
+    const name = relativePath.split(/[\\/]/).pop() ?? relativePath
+    useAppStore.getState().setPreviewTarget({
+      kind: isImagePath(name) ? 'image' : 'code',
+      name,
+      path,
+      relativePath,
+    })
   }, [])
 
   if (loading) {
@@ -293,7 +316,12 @@ export function FileSearch({ isOpen, onClose }: FileSearchProps): React.JSX.Elem
   }, [query, contentMode])
 
   const handleSelect = (result: FileSearchResult) => {
-    useAppStore.getState().setSelectedFile(result.relativePath, result.path)
+    useAppStore.getState().setPreviewTarget({
+      kind: isImagePath(result.name) ? 'image' : 'code',
+      name: result.name,
+      path: result.path,
+      relativePath: result.relativePath,
+    })
     onClose()
   }
 
@@ -380,18 +408,28 @@ export function FileSearch({ isOpen, onClose }: FileSearchProps): React.JSX.Elem
 // ─── File Preview ────────────────────────────────────────────────────────────
 
 export function FilePreview(): React.JSX.Element | null {
-  const selectedFile = useAppStore((state) => state.selectedFile)
+  const target = useAppStore((state) => state.previewTarget)
+  const file = target?.kind === 'code' ? target : null
   const [content, setContent] = useState<string | null>(null)
   const [savedContent, setSavedContent] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saveSuccess, setSaveSuccess] = useState(false)
+  const [viewMode, setViewMode] = useState<'source' | 'preview'>('preview')
+  // Bumped after a save so the HTML <webview> remounts and reloads from disk.
+  const [reloadKey, setReloadKey] = useState(0)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isDirty = content !== null && savedContent !== null && content !== savedContent
 
+  const displayPath = file?.relativePath ?? file?.name ?? ''
+  const isMarkdown = /\.(md|markdown|mdx)$/i.test(displayPath)
+  const isHtml = /\.(html?|htm)$/i.test(displayPath)
+  const canPreview = isMarkdown || isHtml
+  const path = file?.path ?? null
+
   useEffect(() => {
-    if (!selectedFile) {
+    if (!path) {
       setContent(null)
       setSavedContent(null)
       return
@@ -403,7 +441,7 @@ export function FilePreview(): React.JSX.Element | null {
       setLoading(true)
       setError(null)
       try {
-        const data = await window.piDesktop.files.read(selectedFile.path)
+        const data = await window.piDesktop.files.read(path)
         if (!cancelled) {
           setContent(data)
           setSavedContent(data)
@@ -422,7 +460,12 @@ export function FilePreview(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [selectedFile])
+  }, [path])
+
+  // Default to the rendered preview for markdown/HTML, source otherwise.
+  useEffect(() => {
+    setViewMode(canPreview ? 'preview' : 'source')
+  }, [path, canPreview])
 
   // Cleanup pending debounce on unmount
   useEffect(() => {
@@ -439,18 +482,19 @@ export function FilePreview(): React.JSX.Element | null {
     }, 150)
   }, [])
 
-  if (!selectedFile) return null
+  if (!file || !path) return null
 
   const handleSave = async () => {
-    if (content === null || !selectedFile) return
+    if (content === null) return
 
     setSaving(true)
     setError(null)
     setSaveSuccess(false)
     try {
-      await window.piDesktop.files.write(selectedFile.path, content)
+      await window.piDesktop.files.write(path, content)
       setSavedContent(content)
       setSaveSuccess(true)
+      setReloadKey((k) => k + 1)
       setTimeout(() => setSaveSuccess(false), 2000)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save file')
@@ -471,7 +515,7 @@ export function FilePreview(): React.JSX.Element | null {
       <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
         <div className="flex items-center gap-2 min-w-0">
           <FileText size={14} className="shrink-0 text-neutral-500" />
-          <span className="text-xs text-neutral-300 truncate">{selectedFile.relativePath}</span>
+          <span className="text-xs text-neutral-300 truncate">{displayPath}</span>
           {saveSuccess ? (
             <span className="rounded bg-green-900/30 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-green-400">
               saved
@@ -483,6 +527,30 @@ export function FilePreview(): React.JSX.Element | null {
           ) : null}
         </div>
         <div className="flex items-center gap-1">
+          {canPreview && (
+            <div className="mr-1 flex items-center rounded bg-neutral-900 p-0.5">
+              <button
+                onClick={() => setViewMode('source')}
+                className={clsx(
+                  'rounded p-1 transition-colors',
+                  viewMode === 'source' ? 'bg-neutral-700 text-neutral-100' : 'text-neutral-500 hover:text-neutral-300'
+                )}
+                title="Source"
+              >
+                <Code2 size={12} />
+              </button>
+              <button
+                onClick={() => setViewMode('preview')}
+                className={clsx(
+                  'rounded p-1 transition-colors',
+                  viewMode === 'preview' ? 'bg-neutral-700 text-neutral-100' : 'text-neutral-500 hover:text-neutral-300'
+                )}
+                title="Preview"
+              >
+                <Eye size={12} />
+              </button>
+            </div>
+          )}
           <button
             onClick={handleRevert}
             disabled={!isDirty || saving}
@@ -500,7 +568,7 @@ export function FilePreview(): React.JSX.Element | null {
             <Save size={12} />
           </button>
           <button
-            onClick={() => useAppStore.getState().setSelectedFile(null, null)}
+            onClick={() => useAppStore.getState().setPreviewTarget(null)}
             className="rounded p-1 text-neutral-500 hover:text-neutral-300"
             title="Close editor"
           >
@@ -510,21 +578,33 @@ export function FilePreview(): React.JSX.Element | null {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex flex-1 flex-col overflow-auto">
         {loading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 size={20} className="animate-spin text-neutral-500" />
           </div>
         ) : error ? (
           <div className="p-4 text-xs text-red-400">{error}</div>
-        ) : content !== null ? (
+        ) : content === null ? null : viewMode === 'preview' && isMarkdown ? (
+          <div className="markdown-body text-sm p-4">
+            <MarkdownRenderer content={content} />
+          </div>
+        ) : viewMode === 'preview' && isHtml ? (
+          <Webview
+            key={reloadKey}
+            src={toFileUrl(path)}
+            partition="preview"
+            className="flex-1"
+            style={{ display: 'flex', width: '100%', height: '100%', border: 'none' }}
+          />
+        ) : (
           <CodeEditor
-            filePath={selectedFile.relativePath}
+            filePath={displayPath}
             value={content}
             readOnly={false}
             onChange={handleChange}
           />
-        ) : null}
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/image-viewer.tsx
+++ b/src/renderer/src/components/image-viewer.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+import { useAppStore } from '../store'
+import { Image as ImageIcon, Loader2, X } from 'lucide-react'
+
+/**
+ * Read-only image preview pane, opened when a chat filename link points at an
+ * image. Loads via readAttachment (absolute path, works outside the workspace)
+ * and renders the base64 payload as a data URL.
+ */
+export function ImageViewer(): React.JSX.Element | null {
+  const target = useAppStore((state) => state.previewTarget)
+  const image = target?.kind === 'image' ? target : null
+  const [dataUrl, setDataUrl] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!image) {
+      setDataUrl(null)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    setDataUrl(null)
+
+    void (async () => {
+      try {
+        const result = await window.piDesktop.files.readAttachment(image.path)
+        if (cancelled) return
+        if (result.kind === 'image') {
+          setDataUrl(`data:${result.image.mimeType};base64,${result.image.data}`)
+        } else if (/\.svg$/i.test(image.name)) {
+          // SVG is read as text; render it directly from its markup.
+          setDataUrl(`data:image/svg+xml;charset=utf-8,${encodeURIComponent(result.content)}`)
+        } else {
+          setError('Not a supported image file')
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to read image')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [image])
+
+  if (!image) return null
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden bg-[var(--color-bg-primary)]">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <ImageIcon size={14} className="shrink-0 text-neutral-500" />
+          <span className="truncate text-xs text-neutral-300">{image.name}</span>
+        </div>
+        <button
+          onClick={() => useAppStore.getState().setPreviewTarget(null)}
+          className="rounded p-1 text-neutral-500 hover:text-neutral-300"
+          title="Close image"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-1 items-center justify-center overflow-auto p-4">
+        {loading ? (
+          <Loader2 size={20} className="animate-spin text-neutral-500" />
+        ) : error ? (
+          <div className="text-xs text-red-400">{error}</div>
+        ) : dataUrl ? (
+          <img
+            src={dataUrl}
+            alt={image.name}
+            className="max-h-full max-w-full object-contain"
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/review-rail.tsx
+++ b/src/renderer/src/components/review-rail.tsx
@@ -9,7 +9,8 @@ interface ChangedFile {
   status: GitFileStatus
 }
 
-export function ReviewRail(): React.JSX.Element {
+export function ReviewRail(): React.JSX.Element | null {
+  const reviewOpen = useAppStore((state) => state.reviewOpen)
   const settings = useAppStore((state) => state.settings)
   const setPermissionMode = useAppStore((state) => state.setPermissionMode)
   const pendingSteering = useAppStore((state) => state.pendingSteering)
@@ -48,8 +49,10 @@ export function ReviewRail(): React.JSX.Element {
     }
   }, [activeWorkspace?.id, messages.length, isStreaming])
 
+  if (!reviewOpen) return null
+
   return (
-    <aside className="hidden w-80 shrink-0 flex-col border-l border-neutral-800 bg-neutral-950 xl:flex">
+    <aside className="flex w-80 shrink-0 flex-col border-l border-neutral-800 bg-neutral-950">
       <div className="border-b border-neutral-800 px-4 py-3">
         <div className="flex items-center gap-2">
           <ShieldCheck size={16} className="text-emerald-400" />

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -113,6 +113,9 @@ export function Sidebar(): React.JSX.Element {
       }
     }
     switchSession(session.path)
+    // Bring the chat into view (may be on Settings/Notes/etc.). In-app switches
+    // keep their remembered scroll position, so no force-to-bottom here.
+    setCurrentView('chat')
   }
 
   const handleSessionRightClick = (e: React.MouseEvent, session: SessionListItem): void => {
@@ -194,7 +197,7 @@ export function Sidebar(): React.JSX.Element {
   }
 
   return (
-    <aside className="flex w-64 flex-col border-r border-neutral-800 bg-neutral-950">
+    <aside className="flex w-[calc(16rem_+_16px)] flex-col border-r border-neutral-800 bg-neutral-950">
       {/* Header */}
       <div className="flex h-12 items-center justify-between border-b border-neutral-800 px-3">
         <div className="flex items-center gap-2">

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import { useAppStore } from './store'
 
 /**
@@ -53,23 +53,110 @@ export function useMenuActions(): void {
   }, [createNewSession, setCurrentView])
 }
 
+// Distance (px) from the bottom within which we consider the user "at bottom"
+// and keep following new content.
+const AT_BOTTOM_THRESHOLD = 48
+
 /**
- * Auto-scrolls an element to the bottom when content changes.
+ * Manages the chat scroll container:
+ *  - remembers each session's scroll offset and restores it when you switch back
+ *  - follows new/streamed content (a new prompt or live tokens) while Auto Scroll
+ *    is enabled; leaves the position alone when it's off
+ *  - jumps to the bottom when `chatScrollBottomNonce` changes (Home resume)
+ *
+ * `active` is whether the chat view is currently visible; while hidden the panel
+ * stays mounted (so scrollTop persists) but we defer any scrolling until it's
+ * shown again, so measurements are valid.
  */
-export function useAutoScroll<T>(dependency: T): React.RefObject<HTMLDivElement | null> {
+export function useChatScroll(active: boolean): {
+  scrollRef: React.RefObject<HTMLDivElement | null>
+  onScroll: () => void
+} {
   const ref = useRef<HTMLDivElement>(null)
   const autoScroll = useAppStore((state) => state.settings?.autoScroll ?? true)
+  const sessionId = useAppStore((state) => state.sessionState?.sessionId ?? null)
+  const messages = useAppStore((state) => state.messages)
+  const streamingContent = useAppStore((state) => state.streamingContent)
+  const scrollBottomNonce = useAppStore((state) => state.chatScrollBottomNonce)
 
-  useEffect(() => {
-    if (autoScroll && ref.current) {
-      ref.current.scrollTo({
-        top: ref.current.scrollHeight,
-        behavior: 'smooth',
-      })
+  const positions = useRef<Map<string, number>>(new Map())
+  const activeSession = useRef<string | null>(null)
+  const seenNonce = useRef(scrollBottomNonce)
+  const forceBottom = useRef(false)
+  // While a just-switched session's messages are still loading (async), keep
+  // re-applying the target scroll until content is actually present.
+  const pendingRestore = useRef(false)
+  // Track content size to distinguish genuinely new content from unrelated
+  // re-renders (e.g. re-showing the panel), so returning to chat doesn't scroll.
+  const prevMsgCount = useRef(0)
+  const prevStreamLen = useRef(0)
+
+  const onScroll = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    const scrollable = el.scrollHeight - el.clientHeight
+    // Only remember a position while there's a real scroll range — avoids
+    // clobbering the saved offset with 0 when messages are momentarily cleared
+    // during a session switch.
+    if (activeSession.current !== null && scrollable > AT_BOTTOM_THRESHOLD) {
+      positions.current.set(activeSession.current, el.scrollTop)
     }
-  }, [dependency, autoScroll])
+  }, [])
 
-  return ref
+  useLayoutEffect(() => {
+    const el = ref.current
+
+    // Did content actually grow (new message or streamed text)? Tracked even
+    // while hidden so re-showing the panel isn't mistaken for new content.
+    const grew =
+      messages.length > prevMsgCount.current || streamingContent.length > prevStreamLen.current
+    prevMsgCount.current = messages.length
+    prevStreamLen.current = streamingContent.length
+
+    // Defer scrolling while hidden: a display:none element has no layout, so
+    // scrollHeight is 0 and any positioning would be wrong.
+    if (!el || !active) return
+
+    if (scrollBottomNonce !== seenNonce.current) {
+      seenNonce.current = scrollBottomNonce
+      forceBottom.current = true
+    }
+
+    const sessionKey = sessionId ?? '__none__'
+    if (activeSession.current !== sessionKey) {
+      activeSession.current = sessionKey
+      pendingRestore.current = true
+    }
+
+    if (pendingRestore.current) {
+      const saved = positions.current.get(sessionKey)
+      if (forceBottom.current || saved === undefined) {
+        el.scrollTop = el.scrollHeight
+      } else {
+        el.scrollTop = Math.min(saved, el.scrollHeight)
+      }
+      // Consider the switch settled once the session's messages have loaded.
+      if (messages.length > 0) {
+        pendingRestore.current = false
+        forceBottom.current = false
+      }
+      return
+    }
+
+    if (forceBottom.current) {
+      el.scrollTop = el.scrollHeight
+      forceBottom.current = false
+      return
+    }
+
+    // New prompt or streamed tokens in the active session: follow the bottom
+    // when Auto Scroll is enabled. When it's off, leave the position alone.
+    if (grew && autoScroll) {
+      el.scrollTop = el.scrollHeight
+    }
+  }, [active, sessionId, messages, streamingContent, scrollBottomNonce, autoScroll])
+
+  return { scrollRef: ref, onScroll }
 }
 
 /**

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -47,6 +47,20 @@ import type {
 
 export type { DisplayAttachment, DisplayMessage } from './message-parsing'
 
+// ─── Preview Target ──────────────────────────────────────────────────────────
+
+/**
+ * What the side-panel preview is currently showing. `code` opens the editor
+ * (with a Source/Preview toggle for markdown & HTML); `image` opens the image
+ * viewer. `path` is absolute; `relativePath` (code only) drives the editor.
+ */
+export interface PreviewTarget {
+  kind: 'code' | 'image'
+  name: string
+  path: string
+  relativePath?: string
+}
+
 // ─── Council Run State ───────────────────────────────────────────────────────
 
 export type CouncilPhase = 'detecting' | 'consulting' | 'merging' | 'awaiting-approval' | 'refused'
@@ -109,12 +123,17 @@ interface AppState {
 
   // UI
   currentView: 'home' | 'chat' | 'settings' | 'sessions' | 'timeline' | 'packages' | 'diff' | 'notes' | 'skills'
+  // Bumped to request the chat scroll jump to the bottom (used when resuming a
+  // session/workspace from Home). In-app session switches leave it untouched so
+  // the chat restores each session's remembered scroll position instead.
+  chatScrollBottomNonce: number
   // Chat side panel: which secondary view (file tree or diff) is open in
   // the chat workspace. Lifted into the store so it survives navigating
   // away from chat (e.g. into Settings) and back.
   chatSidePanel: 'files' | 'diff' | null
   sidebarOpen: boolean
   terminalOpen: boolean
+  reviewOpen: boolean
   settings: AppSettings | null
   // Staged (unsaved) font-size values from the Settings sliders. When non-null
   // they take priority over the persisted setting and survive view switches, so
@@ -155,7 +174,12 @@ interface AppState {
   // Council run UI state (null when no council run is active)
   councilRun: CouncilRunState | null
 
-  // File preview
+  // File preview. A single target drives the side-panel preview; `kind` selects
+  // the viewer (code editor with Source/Preview toggle, or image viewer). `path`
+  // is absolute (readable via readAttachment / file:// even outside the
+  // workspace); `relativePath` drives the code editor's language + header.
+  previewTarget: PreviewTarget | null
+  // Legacy code-only file selection (still used by the chat file-link handler).
   selectedFile: { relativePath: string; path: string } | null
 
   // File search
@@ -239,9 +263,11 @@ interface AppActions {
 
   // UI
   setCurrentView: (view: AppState['currentView']) => void
+  requestChatScrollToBottom: () => void
   setChatSidePanel: (panel: AppState['chatSidePanel']) => void
   toggleSidebar: () => void
   toggleTerminal: () => void
+  toggleReview: () => void
   loadSettings: () => Promise<void>
   setFontSizePreview: (patch: {
     ui?: number | null
@@ -291,6 +317,7 @@ interface AppActions {
   saveCustomModels: (edited: ModelsConfig) => Promise<{ ok: boolean; errors?: string[] }>
 
   // File preview
+  setPreviewTarget: (target: PreviewTarget | null) => void
   setSelectedFile: (relativePath: string | null, path: string | null) => void
 
   // File search
@@ -386,9 +413,11 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   // Default to the Home/launcher view; useInitialize switches to 'chat' when
   // the openToHomeOnLaunch setting is off (legacy boot-into-chat behavior).
   currentView: 'home',
+  chatScrollBottomNonce: 0,
   chatSidePanel: null,
   sidebarOpen: true,
   terminalOpen: false,
+  reviewOpen: false,
   settings: null,
   uiFontSizePreview: null,
   terminalFontSizePreview: null,
@@ -415,6 +444,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   customModelsError: null,
   councilRun: null,
 
+  previewTarget: null,
   selectedFile: null,
 
   fileSearchOpen: false,
@@ -884,11 +914,15 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   // ─── UI ───────────────────────────────────────────────────────────────
 
   setCurrentView: (view) => set({ currentView: view }),
+  requestChatScrollToBottom: () =>
+    set((state) => ({ chatScrollBottomNonce: state.chatScrollBottomNonce + 1 })),
   setChatSidePanel: (panel) => set({ chatSidePanel: panel }),
 
   toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
 
   toggleTerminal: () => set((state) => ({ terminalOpen: !state.terminalOpen })),
+
+  toggleReview: () => set((state) => ({ reviewOpen: !state.reviewOpen })),
 
   loadSettings: async () => {
     try {
@@ -1341,6 +1375,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     if (!result.success) return { ok: false, errors: [result.error ?? 'Write failed'] }
     await get().loadCustomModels()
     return { ok: true }
+  },
+
+  setPreviewTarget: (target) => {
+    set({ previewTarget: target })
   },
 
   setSelectedFile: (relativePath, path) => {


### PR DESCRIPTION
Rounds out the chat workspace panes and scroll behavior.

- **Unified side preview** (`store.ts` `previewTarget`, `image-viewer.tsx`, `file-tree.tsx`, `chat-panel.tsx`): a single `previewTarget` ({ kind: 'code' | 'image', path, relativePath }) drives the side panel — code opens in the editor (with Source/Preview toggle), images open in a new `ImageViewer`. File tree and chat wire into it. (`selectedFile`/`setSelectedFile` are retained for the chat file-link handler; `chat-file-link.ts` is included for its `isImagePath` helper.)
- **Review pane toggle** (`store.ts` `reviewOpen`/`toggleReview`, `review-rail.tsx`, `chat-panel.tsx`, `sidebar.tsx`): the git review rail is now toggleable from the chat toolbar and status bar.
- **Per-session chat scroll restore** (`hooks.ts` `useChatScroll`, `app.tsx`, `store.ts`): `useAutoScroll` is replaced by `useChatScroll`, which remembers each session's scroll offset and restores it on switch, follows new/streamed content only while Auto Scroll is on, and jumps to the bottom on the Home-resume nonce. `ChatPanel` stays mounted (hidden) across view switches so scrollTop survives.
- **Composer / tree / sidebar polish** (`chat-input.tsx`, `file-tree.tsx`, `sidebar.tsx`): assorted UI refinements.

Adds the `chatScrollBottomNonce`/`requestChatScrollToBottom` store members that the Home PR bumps (duplicated additively so each PR builds standalone; a trivial dedupe on merge). Typechecks clean (main + renderer).