### PR TITLE
Panel consistency: drop redundant Notes 'Back to chat' button + keyboard-accessible session rows

### DIFF
--- a/src/renderer/src/components/notes-panel.tsx
+++ b/src/renderer/src/components/notes-panel.tsx
@@ -24,7 +24,6 @@ export function NotesPanel(): React.JSX.Element {
   const updateNote = useAppStore((state) => state.updateNote)
   const deleteNote = useAppStore((state) => state.deleteNote)
   const insertPrompt = useAppStore((state) => state.insertPrompt)
-  const setCurrentView = useAppStore((state) => state.setCurrentView)
   const noteDraft = useAppStore((state) => state.noteDraft)
   const clearNoteDraft = useAppStore((state) => state.clearNoteDraft)
 
@@ -106,14 +105,6 @@ export function NotesPanel(): React.JSX.Element {
       {/* Header */}
       <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
         <div className="flex items-center gap-3">
-          <button
-            onClick={() => setCurrentView('chat')}
-            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200 transition-colors"
-            title="Back to chat"
-          >
-            <ArrowLeft size={13} />
-            Back to chat
-          </button>
           <h1 className="text-sm font-medium text-neutral-200">Notes</h1>
         </div>
         <button

--- a/src/renderer/src/components/session-panel.tsx
+++ b/src/renderer/src/components/session-panel.tsx
@@ -450,9 +450,17 @@ function SessionEntry({
         busy && 'pointer-events-none opacity-40'
       )}
     >
-      <button
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onSelect}
-        className="flex w-full items-center gap-3 text-left"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onSelect()
+          }
+        }}
+        className="flex w-full cursor-pointer items-center gap-3 text-left"
       >
         <Clock size={12} className="shrink-0 text-neutral-600" />
         <div className="min-w-0 flex-1">
@@ -517,7 +525,7 @@ function SessionEntry({
             active
           </span>
         )}
-      </button>
+      </div>
 
       {/* Kebab menu trigger — always visible so the actions are discoverable.
           The row also honors right-click for the same actions (see onContextMenu


### PR DESCRIPTION
Two small panel refinements.

- **Remove the Notes header 'Back to chat' button** (`notes-panel.tsx`): dropped for consistency — either every panel gets a Back-to-chat affordance or none do; having it in only some panels is inconsistent design. Navigating back to chat is already available from the sidebar, so the per-panel button is redundant. Also drops the now-unused `setCurrentView` selector (the `ArrowLeft` import stays — still used elsewhere in the panel).
- **Keyboard-accessible recent-session rows** (`session-panel.tsx`): the row's click target was a `<button>` that wraps the kebab-menu button — an invalid nested-button. Changed to `<div role="button" tabIndex={0}>` with an `onKeyDown` handler firing on Enter/Space, so it stays fully keyboard-operable without the nested-interactive-element violation.

Typechecks clean (renderer). Independent of the other PRs.