### PR TITLE
Don't auto-create a Home workspace from the home directory

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -960,7 +960,10 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
 
   ipcMain.handle(IPC_CHANNELS.GIT_STATUS, async () => {
     const fs = workspaceManager.getActiveFileService()
-    if (!fs) throw new Error('No active workspace')
+    // No active workspace (e.g. the home screen before any workspace is opened)
+    // is an expected state, not an error — report no changes rather than throwing
+    // (which Electron would log as an unhandled handler error every poll).
+    if (!fs) return {}
     const statusMap = await fs.getGitStatus()
     // Convert Map to plain object for IPC
     const result: Record<string, unknown> = {}
@@ -972,7 +975,9 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
 
   ipcMain.handle(IPC_CHANNELS.GIT_BRANCH, async () => {
     const fs = workspaceManager.getActiveFileService()
-    if (!fs) throw new Error('No active workspace')
+    // No active workspace: report "no branch" rather than throwing (matches the
+    // Promise<string | null> contract; keeps the no-workspace state error-free).
+    if (!fs) return null
     return fs.getGitBranch()
   })
 

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -142,11 +142,13 @@ export class WorkspaceManager {
   async initialize(): Promise<void> {
     await this.loadWorkspaces()
 
-    // Auto-create default workspace from home dir if none exist
-    if (this.workspaces.length === 0) {
-      const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? process.cwd()
-      await this.createWorkspace('Home', homeDir)
-    }
+    // No workspace is auto-created. On a fresh install (or empty state) the app
+    // opens to the home screen with no active workspace; the user opens a folder
+    // or resumes a session, each of which creates + activates a workspace on
+    // demand. This avoids fabricating a "Home" workspace pointed at the entire
+    // home directory — unnecessary setup the user may never use, and a costly
+    // recursive file watcher over the home tree (which also trips over
+    // permission-protected Windows system paths).
 
     // Workspaces loaded from disk don't go through emitActiveWorkspaceChanged,
     // so attach the watcher to the active workspace explicitly here.


### PR DESCRIPTION
## What
On a fresh/empty state, `WorkspaceManager.initialize()` auto-created a "Home" workspace pointed at the user's entire home directory (`$HOME` / `%USERPROFILE%`). This removes that. The app now opens to the home screen with **no active workspace**; the user opens a folder or resumes a session — each of which creates and activates a workspace on demand. The existing empty-state UI ("No workspaces yet." / "Open Folder" / "No workspace selected.") already handles this, so there's **no UI change**.

Also makes the `git:status` / `git:branch` IPC handlers degrade gracefully when there is no active workspace (return `{}` / `null` instead of throwing), so the home screen's git-status poll no longer logs handler errors in the no-workspace state.

## Why
The fabricated Home workspace is unnecessary setup a user often never uses — and it's costly. Making it active attaches the recursive `chokidar` watcher to the whole home tree (depth 4).

**On Windows this swarms the log with watch errors** as the walk hits permission-protected system locations:

```
[FileService] watch error: EACCES: permission denied, stat 'C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\wsb.exe'
[FileService] watch error: EPERM: operation not permitted, realpath 'C:\Users\<user>\AppData\Local\Temp\WinSAT'
```

(app-execution-alias reparse points under `WindowsApps`, and `Temp\WinSAT`, deny `stat`/`realpath`.) The ignore list covers `node_modules`/`.git`/etc. but not Windows system dirs, so every launch into the Home workspace produced this noise.

**Likely cross-cutting effect on startup latency.** Beyond the noise, walking the entire home directory is heavy main-process I/O right at launch. In local testing on Windows, removing the Home workspace also made Pi RPC connects on workspace/session resume noticeably faster and eliminated an intermittent startup slowness — consistent with the home-tree watcher contending with the main process exactly during Pi spawn. The RPC handshake itself is hardened separately in #16, but this change appears to remove a real *contributing factor* to that slowness. Worth flagging for anyone chasing Windows startup latency.

## Testing
Typecheck clean; `workspace-manager` unit tests pass. Verified in dev on Windows: fresh launch shows the empty home state with **no watcher errors** and no git:status errors; Open Folder / resume session / switch workspace all work.

## Scope
Independent, branched off `Dev`.