### PR TITLE
fix: restore chat file-link preview

### DIFF
--- a/src/renderer/src/components/chat-file-link.ts
+++ b/src/renderer/src/components/chat-file-link.ts
@@ -86,6 +86,7 @@ export async function openFileFromChat(text: string): Promise<void> {
   if (!base) return
 
   const store = useAppStore.getState()
+  const image = isImagePath(base)
 
   try {
     // Absolute path: open it directly rather than searching the workspace.
@@ -96,7 +97,12 @@ export async function openFileFromChat(text: string): Promise<void> {
       // Only open absolute paths that live inside the active workspace.
       if (!isInsideWorkspace(raw)) return
       if (store.chatSidePanel === 'diff') store.setChatSidePanel(null)
-      store.setSelectedFile(base, original)
+      store.setPreviewTarget({
+        kind: image ? 'image' : 'code',
+        name: base,
+        path: original,
+        relativePath: base,
+      })
       return
     }
 
@@ -113,7 +119,12 @@ export async function openFileFromChat(text: string): Promise<void> {
     if (!match) return
 
     if (store.chatSidePanel === 'diff') store.setChatSidePanel(null)
-    store.setSelectedFile(match.relativePath, match.path)
+    store.setPreviewTarget({
+      kind: image ? 'image' : 'code',
+      name: match.name,
+      path: match.path,
+      relativePath: match.relativePath,
+    })
   } catch {
     // File service unavailable or no active workspace — silently ignore.
   }

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -177,8 +177,6 @@ interface AppState {
   // is absolute (readable via readAttachment / file:// even outside the
   // workspace); `relativePath` drives the code editor's language + header.
   previewTarget: PreviewTarget | null
-  // Legacy code-only file selection (still used by the chat file-link handler).
-  selectedFile: { relativePath: string; path: string } | null
 
   // File search
   fileSearchOpen: boolean
@@ -312,7 +310,6 @@ interface AppActions {
 
   // File preview
   setPreviewTarget: (target: PreviewTarget | null) => void
-  setSelectedFile: (relativePath: string | null, path: string | null) => void
 
   // File search
   toggleFileSearch: () => void
@@ -437,7 +434,6 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   councilRun: null,
 
   previewTarget: null,
-  selectedFile: null,
 
   fileSearchOpen: false,
 
@@ -1372,10 +1368,6 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   setPreviewTarget: (target) => {
     set({ previewTarget: target })
-  },
-
-  setSelectedFile: (relativePath, path) => {
-    set({ selectedFile: relativePath && path ? { relativePath, path } : null })
   },
 
   toggleFileSearch: () => {


### PR DESCRIPTION
Clicking a file reference in the chat opened nothing — no code, image, markdown, or html preview.

**Cause:** the chat file-link handler wrote to the store's `selectedFile` field, but no component reads it. The preview pane (`chat-panel.tsx`), image viewer, and file-tree preview all key off `previewTarget`. `selectedFile` was orphaned when the preview panes migrated to the `previewTarget` API, leaving the link handler pointing at dead state.

**Fix:** route the handler through `setPreviewTarget({ kind, ... })` so links open in the pane that actually renders them — code files in the editor, images in the image viewer. Removes the now-dead `selectedFile` state and its action (verified the link handler was its sole writer, with no readers).

Both relative names and in-workspace absolute paths verified working across code / image / markdown / html.