### PR TITLE
fix: live-preview Show-thinking and Auto-scroll toggles

### DIFF
--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useRef } from 'react'
 import { useAppStore, type DisplayMessage } from '../store'
 import { modelDisplayName } from '../../../shared/models-config'
+import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 import { MarkdownRenderer } from './markdown-renderer'
 import { CopyButton } from './copy-button'
 import { useContextMenu, buildMessageContextMenu } from './context-menu'
@@ -278,7 +279,7 @@ function AssistantMessage({
 }): React.JSX.Element {
   const customModels = useAppStore((state) => state.customModels)
   const thinkingEnabled = useAppStore(
-    (state) => state.settings?.showThinking ?? false
+    (state) => state.settingsDraft.showThinking ?? state.settings?.showThinking ?? DEFAULT_SETTINGS.showThinking
   )
 
   // With thinking off, a thinking-only turn (no text, no tool calls) would

--- a/src/renderer/src/components/streaming-bubble.tsx
+++ b/src/renderer/src/components/streaming-bubble.tsx
@@ -1,6 +1,7 @@
 import { MarkdownRenderer } from './markdown-renderer'
 import { toolLabel } from './message-bubble'
 import { useAppStore } from '../store'
+import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 import { Wrench, Brain, Bot, Loader2 } from 'lucide-react'
 import { clsx } from 'clsx'
 
@@ -15,7 +16,7 @@ interface StreamingBubbleProps {
 
 export function StreamingBubble({ content, thinking, toolCalls }: StreamingBubbleProps): React.JSX.Element {
   const thinkingEnabled = useAppStore(
-    (state) => state.settings?.showThinking ?? false
+    (state) => state.settingsDraft.showThinking ?? state.settings?.showThinking ?? DEFAULT_SETTINGS.showThinking
   )
   return (
     <div className="mb-4 animate-fade-in">

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import { useAppStore } from './store'
+import { DEFAULT_SETTINGS } from '../../shared/default-settings'
 
 /**
  * Subscribes to Pi events from the main process and routes them to the store.
@@ -73,7 +74,9 @@ export function useChatScroll(active: boolean): {
   onScroll: () => void
 } {
   const ref = useRef<HTMLDivElement>(null)
-  const autoScroll = useAppStore((state) => state.settings?.autoScroll ?? true)
+  const autoScroll = useAppStore(
+    (state) => state.settingsDraft.autoScroll ?? state.settings?.autoScroll ?? DEFAULT_SETTINGS.autoScroll
+  )
   const sessionId = useAppStore((state) => state.sessionState?.sessionId ?? null)
   const messages = useAppStore((state) => state.messages)
   const streamingContent = useAppStore((state) => state.streamingContent)
@@ -212,7 +215,7 @@ export function useInitialize(): void {
 
     const initialize = async (): Promise<void> => {
       await loadSettings()
-      const openToHome = useAppStore.getState().settings?.openToHomeOnLaunch ?? true
+      const openToHome = useAppStore.getState().settings?.openToHomeOnLaunch ?? DEFAULT_SETTINGS.openToHomeOnLaunch
 
       // Pi-free data needed by both Home and Chat.
       await loadWorkspaces()


### PR DESCRIPTION
The Show-thinking and Auto-scroll toggles read saved settings only, so changing them in the Settings panel had no effect until Save — unlike the font-size settings (code editor, diff viewer, terminal), which already live-preview from `settingsDraft`.

**Fix:** read through `settingsDraft.X ?? settings?.X ?? DEFAULT_SETTINGS.X` so the toggles preview immediately while the panel is open, matching the established pattern.

Also fixes a latent fallback bug: Show-thinking fell back to `false` before settings load, but the real default is `true`. Replaces the remaining hardcoded default literals with `DEFAULT_SETTINGS`.