### PR TITLE
fix: preserve chat reading position when toggling Show Thinking

### DIFF
--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -94,7 +94,7 @@ function MessageBubbleImpl({
   if (message.role === 'user') {
     return (
       <>
-      <div onContextMenu={handleMessageContextMenu}>
+      <div data-scroll-anchor={message.id} onContextMenu={handleMessageContextMenu}>
       <UserMessage
         message={message}
         isEditing={isEditing}
@@ -339,7 +339,9 @@ function AssistantMessage({
 
           {/* Text content */}
           {message.content.trim() && (
-            <div className={clsx(
+            <div
+              data-scroll-anchor={message.id}
+              className={clsx(
               'markdown-body text-sm',
               // Sit just below the model/provider header — 6px, 2px tighter than
               // the tool-call box's 8px top gap.

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -57,6 +57,66 @@ export function useMenuActions(): void {
 // and keep following new content.
 const AT_BOTTOM_THRESHOLD = 48
 
+// A content-relative scroll position. We store this instead of a raw scrollTop
+// so the reading spot survives content-height changes that happen while the chat
+// is hidden — chiefly toggling Show Thinking in Settings, which shows/hides every
+// thinking block. A raw scrollTop would then point at different content.
+type ScrollAnchor =
+  | { kind: 'bottom' }
+  // Preserve distance from the bottom. Used when no prose is on screen to anchor
+  // against (e.g. the viewport shows only tool boxes).
+  | { kind: 'fromBottom'; distanceFromBottom: number }
+  // `id` identifies a message's *text body* (the `data-scroll-anchor` marker on
+  // assistant text / user messages — never on tool boxes or thinking blocks).
+  // `viewportOffset` is its top edge relative to the container's top (often
+  // negative — it starts above the fold). Anchoring to the prose the reader is
+  // actually looking at — below any thinking block, even one in the same message
+  // — means collapsing thinking above it doesn't shift it. `distanceFromBottom`
+  // is a last-resort fallback if the element is somehow gone on restore.
+  | { kind: 'body'; id: string; viewportOffset: number; distanceFromBottom: number }
+
+// Snapshot the current reading position of the scroll container.
+function captureAnchor(el: HTMLElement): ScrollAnchor {
+  const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop
+  if (distanceFromBottom <= AT_BOTTOM_THRESHOLD) return { kind: 'bottom' }
+  const containerTop = el.getBoundingClientRect().top
+  const nodes = el.querySelectorAll<HTMLElement>('[data-scroll-anchor]')
+  for (const node of nodes) {
+    const rect = node.getBoundingClientRect()
+    // First text body whose bottom edge is below the container's top — i.e. the
+    // topmost at least partially visible piece of prose.
+    if (rect.bottom > containerTop) {
+      return {
+        kind: 'body',
+        id: node.dataset.scrollAnchor as string,
+        viewportOffset: rect.top - containerTop,
+        distanceFromBottom,
+      }
+    }
+  }
+  return { kind: 'fromBottom', distanceFromBottom }
+}
+
+// Restore a previously captured anchor, absorbing any height change above it.
+function restoreAnchor(el: HTMLElement, anchor: ScrollAnchor): void {
+  if (anchor.kind === 'bottom') {
+    el.scrollTop = el.scrollHeight
+    return
+  }
+  if (anchor.kind === 'fromBottom') {
+    el.scrollTop = el.scrollHeight - el.clientHeight - anchor.distanceFromBottom
+    return
+  }
+  const node = el.querySelector<HTMLElement>(`[data-scroll-anchor="${CSS.escape(anchor.id)}"]`)
+  if (!node) {
+    el.scrollTop = el.scrollHeight - el.clientHeight - anchor.distanceFromBottom
+    return
+  }
+  const containerTop = el.getBoundingClientRect().top
+  const currentOffset = node.getBoundingClientRect().top - containerTop
+  el.scrollTop += currentOffset - anchor.viewportOffset
+}
+
 /**
  * Manages the chat scroll container:
  *  - remembers each session's scroll offset and restores it when you switch back
@@ -79,10 +139,13 @@ export function useChatScroll(active: boolean): {
   const streamingContent = useAppStore((state) => state.streamingContent)
   const scrollBottomNonce = useAppStore((state) => state.chatScrollBottomNonce)
 
-  const positions = useRef<Map<string, number>>(new Map())
+  const positions = useRef<Map<string, ScrollAnchor>>(new Map())
   const activeSession = useRef<string | null>(null)
   const seenNonce = useRef(scrollBottomNonce)
   const forceBottom = useRef(false)
+  // Whether the chat was visible on the previous run, so we can re-anchor when it
+  // becomes visible again (e.g. returning from Settings after toggling thinking).
+  const prevActive = useRef(false)
   // While a just-switched session's messages are still loading (async), keep
   // re-applying the target scroll until content is actually present.
   const pendingRestore = useRef(false)
@@ -99,7 +162,7 @@ export function useChatScroll(active: boolean): {
     // clobbering the saved offset with 0 when messages are momentarily cleared
     // during a session switch.
     if (activeSession.current !== null && scrollable > AT_BOTTOM_THRESHOLD) {
-      positions.current.set(activeSession.current, el.scrollTop)
+      positions.current.set(activeSession.current, captureAnchor(el))
     }
   }, [])
 
@@ -115,7 +178,13 @@ export function useChatScroll(active: boolean): {
 
     // Defer scrolling while hidden: a display:none element has no layout, so
     // scrollHeight is 0 and any positioning would be wrong.
-    if (!el || !active) return
+    if (!el || !active) {
+      prevActive.current = active
+      return
+    }
+
+    const becameActive = !prevActive.current
+    prevActive.current = active
 
     if (scrollBottomNonce !== seenNonce.current) {
       seenNonce.current = scrollBottomNonce
@@ -133,13 +202,28 @@ export function useChatScroll(active: boolean): {
       if (forceBottom.current || saved === undefined) {
         el.scrollTop = el.scrollHeight
       } else {
-        el.scrollTop = Math.min(saved, el.scrollHeight)
+        restoreAnchor(el, saved)
       }
       // Consider the switch settled once the session's messages have loaded.
       if (messages.length > 0) {
         pendingRestore.current = false
         forceBottom.current = false
       }
+      return
+    }
+
+    // Returned to the chat view (e.g. from Settings) in the same session. The
+    // content height may have changed while hidden — Show Thinking toggles every
+    // thinking block — so re-anchor to the saved reading position rather than
+    // leaving the now-stale scrollTop, which would show different content.
+    if (becameActive) {
+      const saved = positions.current.get(sessionKey)
+      if (forceBottom.current || saved === undefined) {
+        el.scrollTop = el.scrollHeight
+      } else {
+        restoreAnchor(el, saved)
+      }
+      forceBottom.current = false
       return
     }
 


### PR DESCRIPTION
Toggling **Show Thinking** in Settings shows/hides every thinking block, changing the chat's content height while the chat view is hidden. On return, the saved raw `scrollTop` pointed at different content, so the reading position jumped by roughly the height of the thinking that appeared/disappeared above it.

**Fix:** save a content-relative anchor instead of a raw `scrollTop`, and restore it when the chat becomes visible again. The anchor is a `data-scroll-anchor` marker on each message's **text body** (assistant text / user messages — deliberately not tool boxes or thinking blocks):

- It's the prose the reader is actually looking at, so pinning it keeps their spot.
- It sits *below* any thinking block, including one inside the same message, so collapsing thinking above it doesn't shift it.

Falls back to preserving distance-from-bottom when no prose is on screen, and stays pinned to the bottom when the user was at the bottom. Only runs on the view-return path — streaming auto-scroll, session switching, and Home→resume are untouched.

In-view expand/collapse (per-message thinking chevron, tool results) was never affected — Chromium's native scroll anchoring already handles those.