### PR TITLE
fix: refresh session state after Pi restart

### DIFF
--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -493,6 +493,15 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     try {
       const status = await window.piDesktop.pi.restart(options as Record<string, unknown> | undefined)
       set({ piStatus: status.status, piPid: status.pid, piError: status.error })
+
+      // Re-read session state after a restart so the status bar's model label
+      // and stats reflect a changed models.json (mirrors startPi). Without this
+      // the label keeps the pre-restart model.
+      if (status.status === 'running') {
+        await get().refreshSessionState()
+        await get().refreshSessionStats()
+        await get().refreshSessionList()
+      }
     } catch (err) {
       set({ piStatus: 'error', piError: err instanceof Error ? err.message : String(err) })
     }


### PR DESCRIPTION
After editing a model in the Custom models editor (Save models.json → Restart Pi to apply), the status bar's model label kept showing the pre-restart model, even though Pi restarted with the new one.

**Cause:** `restartPi` set the new process status but never re-read session state, unlike `startPi` which refreshes session state/stats/list once running. So the status bar kept rendering the stale `sessionState.model` (it briefly disappears while Pi isn't running, then reappears with the old value).

**Fix:** mirror `startPi` — refresh session state, stats, and list after the restarted process is running. The label now reflects whatever model Pi actually loaded.