### PR TITLE
feat: gate streaming auto-scroll to bottom, add jump-to-bottom button

### DIFF
--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -19,6 +19,7 @@ import {
   PanelLeft,
   PanelLeftClose,
   X,
+  ChevronDown,
 } from 'lucide-react'
 
 export function ChatPanel(): React.JSX.Element {
@@ -43,7 +44,7 @@ export function ChatPanel(): React.JSX.Element {
   const [filePaneWidth, setFilePaneWidth] = useState(280)
 
   const currentView = useAppStore((state) => state.currentView)
-  const { scrollRef, onScroll } = useChatScroll(currentView === 'chat')
+  const { scrollRef, onScroll, atBottom, scrollToBottom } = useChatScroll(currentView === 'chat')
 
   const handleRetry = useCallback(async (messageId: string) => {
     // Read from the store so this callback stays referentially stable, keeping
@@ -119,22 +120,37 @@ export function ChatPanel(): React.JSX.Element {
           </div>
 
           {/* Messages area */}
-          <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
-            {messages.length === 0 && !isStreaming ? (
-              <EmptyState piStatus={piStatus} />
-            ) : (
-              <div className="mx-auto max-w-5xl px-4 py-6">
-                {messages.map((message) => (
-                  <MessageBubble key={message.id} message={message} onRetry={handleRetry} />
-                ))}
-                {isStreaming && (
-                  <StreamingBubble
-                    content={streamingContent}
-                    thinking={streamingThinking}
-                    toolCalls={streamingToolCalls}
-                  />
-                )}
-              </div>
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
+              {messages.length === 0 && !isStreaming ? (
+                <EmptyState piStatus={piStatus} />
+              ) : (
+                <div className="mx-auto max-w-5xl px-4 py-6">
+                  {messages.map((message) => (
+                    <MessageBubble key={message.id} message={message} onRetry={handleRetry} />
+                  ))}
+                  {isStreaming && (
+                    <StreamingBubble
+                      content={streamingContent}
+                      thinking={streamingThinking}
+                      toolCalls={streamingToolCalls}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Jump to bottom — shown while scrolled up, so streaming can keep
+                its position until the user opts back into following. */}
+            {!atBottom && (
+              <button
+                onClick={scrollToBottom}
+                className="absolute bottom-3 left-1/2 flex h-8 w-8 -translate-x-1/2 items-center justify-center rounded-full border border-neutral-700 bg-neutral-800/90 text-neutral-300 shadow-lg shadow-black/30 backdrop-blur transition-colors hover:bg-neutral-700 hover:text-neutral-100"
+                title="Scroll to bottom"
+                aria-label="Scroll to bottom"
+              >
+                <ChevronDown size={16} />
+              </button>
             )}
           </div>
 

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useCallback } from 'react'
+import { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react'
 import { useAppStore } from './store'
 
 /**
@@ -71,6 +71,8 @@ const AT_BOTTOM_THRESHOLD = 48
 export function useChatScroll(active: boolean): {
   scrollRef: React.RefObject<HTMLDivElement | null>
   onScroll: () => void
+  atBottom: boolean
+  scrollToBottom: () => void
 } {
   const ref = useRef<HTMLDivElement>(null)
   const autoScroll = useAppStore((state) => state.settings?.autoScroll ?? true)
@@ -91,6 +93,30 @@ export function useChatScroll(active: boolean): {
   const prevMsgCount = useRef(0)
   const prevStreamLen = useRef(0)
 
+  // Whether the viewport is at (or within a hair of) the bottom. `atBottom` (state)
+  // drives the jump-to-bottom button; `atBottomRef` is read synchronously in the
+  // layout effect to decide whether streamed content should keep following.
+  const [atBottom, setAtBottom] = useState(true)
+  const atBottomRef = useRef(true)
+
+  // Recompute at-bottom from the live DOM and publish it to both the ref and the
+  // button state (setState no-ops when unchanged, so this is cheap to call often).
+  const syncAtBottom = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    const next = el.scrollHeight - el.clientHeight - el.scrollTop <= AT_BOTTOM_THRESHOLD
+    atBottomRef.current = next
+    setAtBottom(next)
+  }, [])
+
+  const scrollToBottom = useCallback(() => {
+    const el = ref.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+    atBottomRef.current = true
+    setAtBottom(true)
+  }, [])
+
   const onScroll = useCallback(() => {
     const el = ref.current
     if (!el) return
@@ -101,6 +127,9 @@ export function useChatScroll(active: boolean): {
     if (activeSession.current !== null && scrollable > AT_BOTTOM_THRESHOLD) {
       positions.current.set(activeSession.current, el.scrollTop)
     }
+    const next = scrollable - el.scrollTop <= AT_BOTTOM_THRESHOLD
+    atBottomRef.current = next
+    setAtBottom(next)
   }, [])
 
   useLayoutEffect(() => {
@@ -108,8 +137,8 @@ export function useChatScroll(active: boolean): {
 
     // Did content actually grow (new message or streamed text)? Tracked even
     // while hidden so re-showing the panel isn't mistaken for new content.
-    const grew =
-      messages.length > prevMsgCount.current || streamingContent.length > prevStreamLen.current
+    const messagesGrew = messages.length > prevMsgCount.current
+    const grew = messagesGrew || streamingContent.length > prevStreamLen.current
     prevMsgCount.current = messages.length
     prevStreamLen.current = streamingContent.length
 
@@ -140,23 +169,31 @@ export function useChatScroll(active: boolean): {
         pendingRestore.current = false
         forceBottom.current = false
       }
+      syncAtBottom()
       return
     }
 
     if (forceBottom.current) {
       el.scrollTop = el.scrollHeight
       forceBottom.current = false
+      syncAtBottom()
       return
     }
 
-    // New prompt or streamed tokens in the active session: follow the bottom
-    // when Auto Scroll is enabled. When it's off, leave the position alone.
-    if (grew && autoScroll) {
+    // A new user message means the user just sent a prompt — always reveal it.
+    const lastIsUser = messagesGrew && messages[messages.length - 1]?.role === 'user'
+
+    // Follow new/streamed content only when Auto Scroll is on AND the user was
+    // already at the bottom. If they scrolled up, leave their position put and
+    // let the jump-to-bottom button take them down on demand.
+    if (autoScroll && (lastIsUser || (grew && atBottomRef.current))) {
       el.scrollTop = el.scrollHeight
     }
-  }, [active, sessionId, messages, streamingContent, scrollBottomNonce, autoScroll])
 
-  return { scrollRef: ref, onScroll }
+    syncAtBottom()
+  }, [active, sessionId, messages, streamingContent, scrollBottomNonce, autoScroll, syncAtBottom])
+
+  return { scrollRef: ref, onScroll, atBottom, scrollToBottom }
 }
 
 /**


### PR DESCRIPTION
Auto Scroll previously snapped the chat to the bottom on every streamed chunk, regardless of where the user was reading — so scrolling up to review earlier output during a response was constantly interrupted.

**Change:** streaming now follows the bottom only when the user is already at the bottom. If they scroll up, their position is left untouched and a centered jump-to-bottom arrow appears just above the composer; clicking it returns to the bottom and resumes following. Sending a prompt still scrolls to reveal it.

Details:
- At-bottom is tracked via a ref (read synchronously as content grows) plus state (drives the button).
- The button shows whenever scrolled up with content below — a standard chat affordance — and is independent of the Auto Scroll setting, which still gates all automatic following.
- Session-switch position restore and Home→resume jump-to-bottom are unchanged.

---

**Overlaps #20** (`fix/chat-scroll-anchor-on-return`) in `useChatScroll`; both branch off `Dev`, so whichever merges second needs a small manual conflict resolution. When resolving, the `becameActive` branch introduced by #20 must call `syncAtBottom()` before returning, so the jump-to-bottom chevron reflects the restored reading position when returning to chat from Settings. Without it, the chevron can stay hidden until the next scroll after a Settings round-trip that changed content height (e.g. toggling Show Thinking).
