### PR TITLE
feat: PDF preview in the pane; add avif/bmp/ico image support

### DIFF
--- a/src/main/attachment-reader.ts
+++ b/src/main/attachment-reader.ts
@@ -2,13 +2,19 @@ import { readFile, stat } from 'fs/promises'
 import { basename, extname } from 'path'
 import type { AttachmentReadResult } from '../shared/ipc-contracts'
 
-// Lowercase file extension -> MIME type Pi accepts as an inline image block.
+// Lowercase file extension -> MIME type for images we decode to base64 (for the
+// preview pane's image viewer, and as Pi inline-image blocks). Note: the chat
+// attachment picker is separately limited to SUPPORTED_IMAGE_EXTENSIONS, so the
+// extra preview-only formats here (avif/bmp/ico) are never sent to Pi.
 const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   png: 'image/png',
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
   gif: 'image/gif',
   webp: 'image/webp',
+  avif: 'image/avif',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
 }
 
 // Guard against accidentally base64-inlining a huge file into a prompt.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -119,6 +119,10 @@ function createMainWindow(): BrowserWindow {
     webPreferences.sandbox = true
     webPreferences.webSecurity = true
     webPreferences.allowRunningInsecureContent = false
+    // Enable Chromium's built-in PDF viewer (pdfium) so the preview pane can
+    // render local .pdf files. It's a bundled internal component; the guest is
+    // still confined to file:// (below), sandboxed, with no preload/node.
+    webPreferences.plugins = true
 
     if (!params.src.startsWith('file://')) {
       event.preventDefault()

--- a/src/renderer/src/components/chat-file-link.ts
+++ b/src/renderer/src/components/chat-file-link.ts
@@ -1,8 +1,9 @@
 import { useAppStore } from '../store'
 
-// Image extensions the viewer can render. png/jpg/jpeg/gif/webp arrive as base64
-// from readAttachment; svg comes back as text and is rendered from its markup.
-const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
+// Image extensions the viewer can render. png/jpg/jpeg/gif/webp/avif/bmp/ico
+// arrive as base64 from readAttachment; svg comes back as text and is rendered
+// from its markup.
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'bmp', 'ico', 'svg'])
 
 // Common file extensions we treat as "this inline code is a filename". Kept as an
 // allowlist (rather than "anything with a dot") so abbreviations like `e.g` and
@@ -18,6 +19,7 @@ const FILE_EXTENSIONS = new Set([
   'sh', 'bash', 'zsh', 'ps1', 'bat', 'cmd',
   'sql', 'graphql', 'gql', 'proto', 'tcl', 'gradle', 'groovy',
   'lock', 'gitignore', 'dockerignore', 'editorconfig',
+  'pdf',
   ...IMAGE_EXTENSIONS,
 ])
 

--- a/src/renderer/src/components/file-tree.tsx
+++ b/src/renderer/src/components/file-tree.tsx
@@ -588,9 +588,9 @@ export function FilePreview(): React.JSX.Element | null {
       <div className="flex flex-1 flex-col overflow-auto">
         {isPdf ? (
           <Webview
-            // Ask Chromium's PDF viewer to open with the thumbnail/bookmark
-            // sidebar hidden but keep the toolbar (zoom/print).
-            src={`${toFileUrl(path)}#toolbar=1&navpanes=0`}
+            // Ask Chromium's PDF viewer to open with both the thumbnail/bookmark
+            // sidebar and the top toolbar hidden, for a clean embedded preview.
+            src={`${toFileUrl(path)}#toolbar=0&navpanes=0`}
             partition="persist:pdf-preview"
             plugins
             className="flex-1"

--- a/src/renderer/src/components/file-tree.tsx
+++ b/src/renderer/src/components/file-tree.tsx
@@ -26,7 +26,7 @@ import {
 // to a component so TS accepts the props we use. It renders the HTML preview in
 // an isolated guest process so its JavaScript runs without touching the app CSP.
 const Webview = 'webview' as unknown as React.FC<
-  React.HTMLAttributes<HTMLElement> & { src: string; partition?: string }
+  React.HTMLAttributes<HTMLElement> & { src: string; partition?: string; plugins?: boolean }
 >
 
 function toFileUrl(absolutePath: string): string {
@@ -425,11 +425,14 @@ export function FilePreview(): React.JSX.Element | null {
   const displayPath = file?.relativePath ?? file?.name ?? ''
   const isMarkdown = /\.(md|markdown|mdx)$/i.test(displayPath)
   const isHtml = /\.(html?|htm)$/i.test(displayPath)
+  // PDFs render in Chromium's built-in viewer via the <webview> — binary, so we
+  // never read them as text or offer editing.
+  const isPdf = /\.pdf$/i.test(displayPath)
   const canPreview = isMarkdown || isHtml
   const path = file?.path ?? null
 
   useEffect(() => {
-    if (!path) {
+    if (!path || isPdf) {
       setContent(null)
       setSavedContent(null)
       return
@@ -460,7 +463,7 @@ export function FilePreview(): React.JSX.Element | null {
     return () => {
       cancelled = true
     }
-  }, [path])
+  }, [path, isPdf])
 
   // Default to the rendered preview for markdown/HTML, source otherwise.
   useEffect(() => {
@@ -551,22 +554,26 @@ export function FilePreview(): React.JSX.Element | null {
               </button>
             </div>
           )}
-          <button
-            onClick={handleRevert}
-            disabled={!isDirty || saving}
-            className="rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
-            title="Revert changes"
-          >
-            <RotateCcw size={12} />
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={!isDirty || saving}
-            className="rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
-            title="Save file"
-          >
-            <Save size={12} />
-          </button>
+          {!isPdf && (
+            <>
+              <button
+                onClick={handleRevert}
+                disabled={!isDirty || saving}
+                className="rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+                title="Revert changes"
+              >
+                <RotateCcw size={12} />
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={!isDirty || saving}
+                className="rounded p-1 text-neutral-500 transition-colors hover:text-neutral-300 disabled:cursor-not-allowed disabled:opacity-40"
+                title="Save file"
+              >
+                <Save size={12} />
+              </button>
+            </>
+          )}
           <button
             onClick={() => useAppStore.getState().setPreviewTarget(null)}
             className="rounded p-1 text-neutral-500 hover:text-neutral-300"
@@ -579,7 +586,17 @@ export function FilePreview(): React.JSX.Element | null {
 
       {/* Content */}
       <div className="flex flex-1 flex-col overflow-auto">
-        {loading ? (
+        {isPdf ? (
+          <Webview
+            // Ask Chromium's PDF viewer to open with the thumbnail/bookmark
+            // sidebar hidden but keep the toolbar (zoom/print).
+            src={`${toFileUrl(path)}#toolbar=1&navpanes=0`}
+            partition="persist:pdf-preview"
+            plugins
+            className="flex-1"
+            style={{ display: 'flex', width: '100%', height: '100%', border: 'none' }}
+          />
+        ) : loading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 size={20} className="animate-spin text-neutral-500" />
           </div>


### PR DESCRIPTION
Adds PDF rendering to the preview pane and broadens image-format support.

## PDF preview
Routes `.pdf` files to Chromium's built-in PDF viewer (pdfium) via the existing preview `<webview>`:
- Enables `webPreferences.plugins` on the sandbox-hardened `file://` guest, plus the webview `plugins` attribute.
- Uses a dedicated **persistent** partition (`persist:pdf-preview`) — the non-persistent `preview` partition doesn't get the PDF viewer extension registered, so PDFs came up blank there.
- Opens with the nav sidebar hidden but the toolbar kept (`#navpanes=0`).
- `FilePreview` skips the text read and hides the editor/save controls for PDFs.

The guest stays confined to `file://`, sandboxed, with no preload/node integration and contextIsolation + webSecurity on.

## Image formats
Adds `avif`, `bmp`, and `ico` to the image decode map and preview routing so they open in the image viewer (they previously fell through to the text editor). Makes `.pdf` clickable as a chat file-link. The Pi attachment picker stays limited to its existing formats (`SUPPORTED_IMAGE_EXTENSIONS`).

## Note on ordering
The **file-tree → PDF** path works standalone. The **chat file-link → PDF** path depends on #18 (restore chat file-link preview) — chat file-links write to an orphaned store field on `Dev` until that lands, so #18 should be merged first for clickable PDF links in chat to open. This PR is otherwise independent.