### PR TITLE
feat: group consecutive tool calls into a collapsible block

### DIFF
--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -1,14 +1,15 @@
 import { useAppStore } from '../store'
 import { ChatInput } from './chat-input'
 import { CouncilPanels } from './council-panels'
-import { MessageBubble } from './message-bubble'
+import { MessageBubble, ToolGroupBubble } from './message-bubble'
 import { StreamingBubble } from './streaming-bubble'
+import { groupToolMessages } from '../message-grouping'
 import { FileTree, FileSearch, FilePreview } from './file-tree'
 import { ImageViewer } from './image-viewer'
 import { DiffViewer } from './diff-viewer'
 import { TerminalPanel } from './terminal'
 import { useChatScroll } from '../hooks'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { clsx } from 'clsx'
 import piLogo from '../assets/pi-logo.svg'
 import {
@@ -44,6 +45,11 @@ export function ChatPanel(): React.JSX.Element {
 
   const currentView = useAppStore((state) => state.currentView)
   const { scrollRef, onScroll } = useChatScroll(currentView === 'chat')
+
+  // Fold consecutive tool-call/result runs into collapsed groups. Memoized so
+  // the grouping only recomputes when the message list changes, and so lone
+  // MessageBubbles keep their stable refs (no markdown re-parse on re-render).
+  const renderItems = useMemo(() => groupToolMessages(messages), [messages])
 
   const handleRetry = useCallback(async (messageId: string) => {
     // Read from the store so this callback stays referentially stable, keeping
@@ -124,9 +130,18 @@ export function ChatPanel(): React.JSX.Element {
               <EmptyState piStatus={piStatus} />
             ) : (
               <div className="mx-auto max-w-5xl px-4 py-6">
-                {messages.map((message) => (
-                  <MessageBubble key={message.id} message={message} onRetry={handleRetry} />
-                ))}
+                {renderItems.map((item) =>
+                  item.kind === 'toolGroup' ? (
+                    <ToolGroupBubble
+                      key={item.id}
+                      title={item.title}
+                      messages={item.messages}
+                      onRetry={handleRetry}
+                    />
+                  ) : (
+                    <MessageBubble key={item.message.id} message={item.message} onRetry={handleRetry} />
+                  )
+                )}
                 {isStreaming && (
                   <StreamingBubble
                     content={streamingContent}

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useRef } from 'react'
 import { useAppStore, type DisplayMessage } from '../store'
 import { modelDisplayName } from '../../../shared/models-config'
-import { toolLabel } from '../message-grouping'
+import { toolCallLabel } from '../message-grouping'
 import { MarkdownRenderer } from './markdown-renderer'
 import { CopyButton } from './copy-button'
 import { useContextMenu, buildMessageContextMenu } from './context-menu'
@@ -413,9 +413,11 @@ function ToolCallBadge({
         onClick={() => setExpanded(!expanded)}
         className="flex w-full items-center gap-2 py-2 pl-3 pr-9 text-xs text-neutral-400 hover:text-neutral-300 transition-colors"
       >
-        <span className="font-jetbrains">{toolLabel(toolCall.name)}</span>
+        <span className="font-jetbrains min-w-0 truncate">
+          {toolCallLabel(toolCall.name, toolCall.arguments)}
+        </span>
         {toolCall.durationMs !== undefined && !toolCall.isExecuting && (
-          <span className="text-neutral-600">{formatDuration(toolCall.durationMs)}</span>
+          <span className="shrink-0 text-neutral-600">{formatDuration(toolCall.durationMs)}</span>
         )}
         {toolCall.isError !== undefined && (
           <span className={clsx(

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, useRef } from 'react'
 import { useAppStore, type DisplayMessage } from '../store'
 import { modelDisplayName } from '../../../shared/models-config'
+import { toolLabel } from '../message-grouping'
 import { MarkdownRenderer } from './markdown-renderer'
 import { CopyButton } from './copy-button'
 import { useContextMenu, buildMessageContextMenu } from './context-menu'
@@ -23,9 +24,13 @@ import {
 function MessageBubbleImpl({
   message,
   onRetry,
+  hideModelHeader,
 }: {
   message: DisplayMessage
   onRetry?: (messageId: string) => void
+  // When rendered inside a tool group that shows a single shared model header,
+  // suppress this message's own provider · model line to avoid repetition.
+  hideModelHeader?: boolean
 }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
   const [showThinking, setShowThinking] = useState(false)
@@ -125,6 +130,7 @@ function MessageBubbleImpl({
         showThinking={showThinking}
         onToggleThinking={() => setShowThinking(!showThinking)}
         onExport={handleExport}
+        hideModelHeader={hideModelHeader}
       />
       </div>
       {MessageContextMenu}
@@ -268,6 +274,7 @@ function AssistantMessage({
   showThinking,
   onToggleThinking,
   onExport,
+  hideModelHeader,
 }: {
   message: DisplayMessage
   onCopy: () => void
@@ -275,6 +282,7 @@ function AssistantMessage({
   showThinking: boolean
   onToggleThinking: () => void
   onExport: () => void
+  hideModelHeader?: boolean
 }): React.JSX.Element {
   const customModels = useAppStore((state) => state.customModels)
   const thinkingEnabled = useAppStore(
@@ -293,15 +301,21 @@ function AssistantMessage({
   return (
     <div className="group mb-4 animate-fade-in">
       <div className="flex items-start gap-3">
-        {/* Avatar */}
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
-          <Bot size={14} className="text-neutral-400" />
-        </div>
+        {/* Avatar — suppressed inside a tool group (the group shows one above),
+            keeping an empty spacer so the tool boxes stay aligned with the
+            wrench-avatared result rows. */}
+        {hideModelHeader ? (
+          <div className="h-7 w-7 shrink-0" />
+        ) : (
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
+            <Bot size={14} className="text-neutral-400" />
+          </div>
+        )}
 
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Model info */}
-          {message.model && (
+          {message.model && !hideModelHeader && (
             <div className="flex h-7 items-center gap-2 text-sm text-neutral-500">
               <span>{message.provider}</span>
               <span className="text-neutral-700">·</span>
@@ -486,6 +500,101 @@ function ToolResultMessage({ message }: { message: DisplayMessage }): React.JSX.
   )
 }
 
+// ─── Tool Group ──────────────────────────────────────────────────────────────
+
+// A run of consecutive tool-activity messages (tool calls + their results, plus
+// any thinking-only turns among them) folded into one collapsed block. Collapsed
+// by default to keep repetitive runs from dominating the scrollback; expanding
+// reveals the original messages rendered exactly as they would appear ungrouped.
+function ToolGroupBubbleImpl({
+  title,
+  messages,
+  onRetry,
+}: {
+  title: string
+  messages: DisplayMessage[]
+  onRetry?: (messageId: string) => void
+}): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const customModels = useAppStore((state) => state.customModels)
+
+  // If every assistant turn in the group used the same model, show one shared
+  // provider · model header above the body and suppress the per-turn headers. If
+  // they differ (a mid-run model switch), keep each turn's own header so the
+  // distinction isn't lost.
+  const modelKeys = new Set<string>()
+  let sharedModel: string | undefined
+  let sharedProvider: string | undefined
+  for (const m of messages) {
+    if (m.role === 'assistant' && m.model) {
+      modelKeys.add(`${m.provider ?? ''}|${m.model}`)
+      if (sharedModel === undefined) {
+        sharedModel = m.model
+        sharedProvider = m.provider
+      }
+    }
+  }
+  const showSharedHeader = modelKeys.size === 1 && sharedModel !== undefined
+
+  return (
+    <div className="group mb-4 animate-fade-in">
+      <div className="flex items-start gap-3">
+        {/* Bot avatar + model header so a grouped run reads like any other
+            assistant message, not a distinct kind of block. */}
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
+          <Bot size={14} className="text-neutral-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          {showSharedHeader && (
+            <div className="flex h-7 items-center gap-2 text-sm text-neutral-500">
+              <span>{sharedProvider}</span>
+              <span className="text-neutral-700">·</span>
+              <span>{modelDisplayName(sharedModel as string, customModels)}</span>
+            </div>
+          )}
+          <div
+            className={clsx(
+              'relative rounded-lg border border-neutral-800 bg-neutral-900/50',
+              showSharedHeader && 'mt-1.5'
+            )}
+          >
+            <CopyButton text={groupCopyText(messages)} className="absolute right-1.5 top-1.5" />
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="flex w-full items-center gap-2 py-2 pl-3 pr-9 text-xs text-neutral-400 hover:text-neutral-300 transition-colors"
+            >
+              <span className="font-jetbrains">{title}</span>
+              {expanded ? (
+                <ChevronDown size={12} className="ml-auto shrink-0" />
+              ) : (
+                <ChevronRight size={12} className="ml-auto shrink-0" />
+              )}
+            </button>
+          </div>
+          {/* Expanded body: the original messages, on a left rail to signal they
+              belong to the group. Per-turn model headers are suppressed since the
+              group already shows one above. Last child's bottom margin trimmed so
+              it doesn't double up on the group's own mb-4. */}
+          {expanded && (
+            <div className="mt-2 border-l border-neutral-800 pl-3 [&>*:last-child]:mb-0">
+              {messages.map((m) => (
+                <MessageBubble
+                  key={m.id}
+                  message={m}
+                  onRetry={onRetry}
+                  hideModelHeader={showSharedHeader}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const ToolGroupBubble = memo(ToolGroupBubbleImpl)
+
 // ─── System Message ──────────────────────────────────────────────────────────
 
 function SystemMessage({ message }: { message: DisplayMessage }): React.JSX.Element {
@@ -526,21 +635,6 @@ function ActionButton({
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-// Map common Pi tool names to a friendly, user-facing label; falls back to the
-// raw name so custom/unknown tools still show something. Keyword matching
-// mirrors toolIcon() so the label and icon stay in sync.
-export function toolLabel(name: string): string {
-  const n = name.toLowerCase()
-  if (n.includes('bash') || n.includes('shell') || n.includes('exec') || n.includes('terminal')) return 'Run command'
-  if (n.includes('search') || n.includes('grep') || n.includes('find')) return 'Search'
-  if (n.includes('web') || n.includes('fetch') || n.includes('http') || n.includes('url')) return 'Fetch URL'
-  if (n.includes('edit') || n.includes('replace') || n.includes('patch')) return 'Edit file'
-  if (n.includes('write') || n.includes('create')) return 'Write file'
-  if (n.includes('list') || n.startsWith('ls') || n.includes('tree') || n.includes('dir')) return 'List files'
-  if (n.includes('read') || n.includes('view') || n.includes('cat') || n.includes('file')) return 'Read file'
-  return name
-}
-
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`
   return `${(ms / 1000).toFixed(ms < 10000 ? 1 : 0)}s`
@@ -553,6 +647,20 @@ function formatToolCallArgs(args: string): string {
   } catch {
     return args
   }
+}
+
+// The group's copy button yields every call and result in order: each tool
+// call's copy text (raw command / formatted args) followed by its result.
+function groupCopyText(messages: DisplayMessage[]): string {
+  const parts: string[] = []
+  for (const m of messages) {
+    if (m.role === 'assistant') {
+      for (const tc of m.toolCalls ?? []) parts.push(toolCallCopyText(tc))
+    } else if (m.role === 'toolResult') {
+      parts.push(m.content)
+    }
+  }
+  return parts.join('\n\n')
 }
 
 // What the copy button on a tool-call box yields: the raw command for

--- a/src/renderer/src/components/streaming-bubble.tsx
+++ b/src/renderer/src/components/streaming-bubble.tsx
@@ -1,5 +1,5 @@
 import { MarkdownRenderer } from './markdown-renderer'
-import { toolLabel } from './message-bubble'
+import { toolLabel } from '../message-grouping'
 import { useAppStore } from '../store'
 import { Wrench, Brain, Bot, Loader2 } from 'lucide-react'
 import { clsx } from 'clsx'

--- a/src/renderer/src/message-grouping.test.ts
+++ b/src/renderer/src/message-grouping.test.ts
@@ -1,14 +1,14 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { groupToolMessages, toolLabel, type ChatRenderItem } from './message-grouping'
+import { groupToolMessages, toolLabel, toolCallLabel, type ChatRenderItem } from './message-grouping'
 import type { DisplayMessage } from './message-parsing'
 
 let idCounter = 0
 function assistant(over: Partial<DisplayMessage> = {}): DisplayMessage {
   return { id: `a${++idCounter}`, role: 'assistant', content: '', timestamp: 0, ...over }
 }
-function toolTurn(name: string): DisplayMessage {
-  return assistant({ toolCalls: [{ id: `tc${++idCounter}`, name, arguments: '{}' }] })
+function toolTurn(name: string, args: Record<string, unknown> = {}): DisplayMessage {
+  return assistant({ toolCalls: [{ id: `tc${++idCounter}`, name, arguments: JSON.stringify(args) }] })
 }
 function result(): DisplayMessage {
   return { id: `r${++idCounter}`, role: 'toolResult', content: 'output', timestamp: 0 }
@@ -50,11 +50,41 @@ test('a single tool call is not grouped', () => {
   assert.ok(items.every((i) => i.kind === 'message'))
 })
 
-test('mixed tools get the generic title', () => {
+test('mixed tools combine their verbs (first capitalized, rest lower-cased)', () => {
   const items = groupToolMessages([
     toolTurn('read_file'),
     result(),
     toolTurn('web_fetch'),
+    result(),
+  ])
+  assert.deepEqual(titles(items), ['Read a file, fetched a URL'])
+})
+
+test('mixed run combines counts per tool type in first-appearance order', () => {
+  const items = groupToolMessages([
+    toolTurn('web_fetch'),
+    result(),
+    toolTurn('web_fetch'),
+    result(),
+    toolTurn('web_fetch'),
+    result(),
+    toolTurn('web_fetch'),
+    result(),
+    toolTurn('read_file'),
+    result(),
+    toolTurn('read_file'),
+    result(),
+    toolTurn('edit_file'),
+    result(),
+  ])
+  assert.deepEqual(titles(items), ['Fetched 4 URLs, read 2 files, edited a file'])
+})
+
+test('unknown tools bucket together under the generic verb', () => {
+  const items = groupToolMessages([
+    toolTurn('mystery_tool'),
+    result(),
+    toolTurn('another_weird_one'),
     result(),
   ])
   assert.deepEqual(titles(items), ['Ran 2 tools'])
@@ -104,4 +134,27 @@ test('toolLabel maps known tools and falls back to raw name', () => {
   assert.equal(toolLabel('web_fetch'), 'Fetch URL')
   assert.equal(toolLabel('bash'), 'Run command')
   assert.equal(toolLabel('some_custom_tool'), 'some_custom_tool')
+})
+
+test('toolCallLabel shows the operated-on value (path args as basename)', () => {
+  assert.equal(toolCallLabel('web_fetch', '{"url":"https://x.com/a"}'), 'Fetched https://x.com/a')
+  assert.equal(toolCallLabel('read_file', '{"path":"src/app/foo.ts"}'), 'Read foo.ts')
+  assert.equal(toolCallLabel('write_file', '{"path":"a/b/new.ts"}'), 'Created new.ts')
+  assert.equal(toolCallLabel('edit_file', '{"file":"lib/bar.ts"}'), 'Edited bar.ts')
+  assert.equal(toolCallLabel('grep', '{"pattern":"TODO"}'), 'Searched TODO')
+  assert.equal(toolCallLabel('list_dir', '{"path":"src/components"}'), 'Listed components')
+})
+
+test('toolCallLabel omits the value for commands and when no arg is present', () => {
+  assert.equal(toolCallLabel('bash', '{"command":"ls -la"}'), 'Ran a command')
+  assert.equal(toolCallLabel('read_file', '{}'), 'Read a file')
+  assert.equal(toolCallLabel('some_custom_tool', '{}'), 'some_custom_tool')
+})
+
+test('toolCallLabel truncates very long values', () => {
+  const longUrl = 'https://example.com/' + 'a'.repeat(100)
+  const label = toolCallLabel('web_fetch', JSON.stringify({ url: longUrl }))
+  assert.ok(label.startsWith('Fetched https://example.com/'))
+  assert.ok(label.endsWith('…'))
+  assert.ok(label.length < longUrl.length)
 })

--- a/src/renderer/src/message-grouping.test.ts
+++ b/src/renderer/src/message-grouping.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { groupToolMessages, toolLabel, type ChatRenderItem } from './message-grouping'
+import type { DisplayMessage } from './message-parsing'
+
+let idCounter = 0
+function assistant(over: Partial<DisplayMessage> = {}): DisplayMessage {
+  return { id: `a${++idCounter}`, role: 'assistant', content: '', timestamp: 0, ...over }
+}
+function toolTurn(name: string): DisplayMessage {
+  return assistant({ toolCalls: [{ id: `tc${++idCounter}`, name, arguments: '{}' }] })
+}
+function result(): DisplayMessage {
+  return { id: `r${++idCounter}`, role: 'toolResult', content: 'output', timestamp: 0 }
+}
+function prose(text = 'hello'): DisplayMessage {
+  return assistant({ content: text })
+}
+function user(): DisplayMessage {
+  return { id: `u${++idCounter}`, role: 'user', content: 'hi', timestamp: 0 }
+}
+
+function titles(items: ChatRenderItem[]): string[] {
+  return items.filter((i) => i.kind === 'toolGroup').map((i) => (i as { title: string }).title)
+}
+
+test('folds a run of same-tool turns into one titled group', () => {
+  const items = groupToolMessages([
+    user(),
+    toolTurn('web_fetch'),
+    result(),
+    toolTurn('web_fetch'),
+    result(),
+    toolTurn('web_fetch'),
+    result(),
+    prose('Here are three stories'),
+  ])
+  // user, group, prose
+  assert.equal(items.length, 3)
+  assert.equal(items[0].kind, 'message')
+  assert.equal(items[1].kind, 'toolGroup')
+  assert.equal(items[2].kind, 'message')
+  assert.deepEqual(titles(items), ['Fetched 3 URLs'])
+  assert.equal((items[1] as { messages: DisplayMessage[] }).messages.length, 6)
+})
+
+test('a single tool call is not grouped', () => {
+  const items = groupToolMessages([toolTurn('read_file'), result()])
+  assert.equal(items.length, 2)
+  assert.ok(items.every((i) => i.kind === 'message'))
+})
+
+test('mixed tools get the generic title', () => {
+  const items = groupToolMessages([
+    toolTurn('read_file'),
+    result(),
+    toolTurn('web_fetch'),
+    result(),
+  ])
+  assert.deepEqual(titles(items), ['Ran 2 tools'])
+})
+
+test('prose turn breaks a run into two groups', () => {
+  const items = groupToolMessages([
+    toolTurn('bash'),
+    result(),
+    toolTurn('bash'),
+    result(),
+    prose('done phase one'),
+    toolTurn('read_file'),
+    result(),
+    toolTurn('read_file'),
+    result(),
+  ])
+  assert.deepEqual(titles(items), ['Ran 2 commands', 'Read 2 files'])
+})
+
+test('thinking-only turn rides along in the group without breaking it', () => {
+  const thinkingOnly = assistant({ thinking: 'let me think', content: '' })
+  const items = groupToolMessages([
+    toolTurn('web_fetch'),
+    result(),
+    thinkingOnly,
+    toolTurn('web_fetch'),
+    result(),
+  ])
+  // One group; the thinking turn is absorbed (count stays at the 2 tool calls).
+  assert.deepEqual(titles(items), ['Fetched 2 URLs'])
+  assert.equal((items[0] as { messages: DisplayMessage[] }).messages.length, 5)
+})
+
+test('multiple tool calls in a single assistant turn count toward the threshold', () => {
+  const twoCalls = assistant({
+    toolCalls: [
+      { id: 'x1', name: 'read_file', arguments: '{}' },
+      { id: 'x2', name: 'read_file', arguments: '{}' },
+    ],
+  })
+  const items = groupToolMessages([twoCalls, result(), result()])
+  assert.deepEqual(titles(items), ['Read 2 files'])
+})
+
+test('toolLabel maps known tools and falls back to raw name', () => {
+  assert.equal(toolLabel('web_fetch'), 'Fetch URL')
+  assert.equal(toolLabel('bash'), 'Run command')
+  assert.equal(toolLabel('some_custom_tool'), 'some_custom_tool')
+})

--- a/src/renderer/src/message-grouping.ts
+++ b/src/renderer/src/message-grouping.ts
@@ -34,28 +34,108 @@ function isToolActivity(m: DisplayMessage): boolean {
   return false
 }
 
-const plural = (n: number, unit: string): string => `${n} ${unit}${n === 1 ? '' : 's'}`
-
-// Verb templates for a homogeneous run (all calls map to the same label). A mixed
-// or unknown run falls back to the generic "Ran N tools".
-const GROUP_TITLES: Record<string, (n: number) => string> = {
-  'Fetch URL': (n) => `Fetched ${plural(n, 'URL')}`,
-  'Read file': (n) => `Read ${plural(n, 'file')}`,
-  'Run command': (n) => `Ran ${plural(n, 'command')}`,
-  'Edit file': (n) => `Edited ${plural(n, 'file')}`,
-  'Write file': (n) => `Wrote ${plural(n, 'file')}`,
-  Search: (n) => `${n} search${n === 1 ? '' : 'es'}`,
-  'List files': (n) => `Listed ${plural(n, 'location')}`,
+// Past-tense verb + object noun for each canonical tool label, used to phrase
+// both single-operation labels ("Fetched <url>") and group titles ("Fetched 3
+// URLs"). `argKeys` are the argument fields a single-op label pulls its shown
+// value from (empty = show no value, e.g. commands).
+interface ToolVerb {
+  verb: string // past tense, capitalized
+  noun: string // singular object noun
+  nounPlural: string
+  argKeys: string[]
 }
 
-function groupTitle(run: DisplayMessage[], count: number): string {
-  const labels = new Set<string>()
-  for (const m of run) {
-    for (const tc of m.toolCalls ?? []) labels.add(toolLabel(tc.name))
+const TOOL_VERBS: Record<string, ToolVerb> = {
+  'Fetch URL': { verb: 'Fetched', noun: 'URL', nounPlural: 'URLs', argKeys: ['url', 'uri', 'href', 'link'] },
+  'Read file': { verb: 'Read', noun: 'file', nounPlural: 'files', argKeys: ['path', 'file', 'filename', 'file_path', 'filepath'] },
+  'Run command': { verb: 'Ran', noun: 'command', nounPlural: 'commands', argKeys: [] },
+  'Edit file': { verb: 'Edited', noun: 'file', nounPlural: 'files', argKeys: ['path', 'file', 'filename', 'file_path', 'filepath'] },
+  'Write file': { verb: 'Created', noun: 'file', nounPlural: 'files', argKeys: ['path', 'file', 'filename', 'file_path', 'filepath'] },
+  Search: { verb: 'Searched', noun: 'query', nounPlural: 'queries', argKeys: ['query', 'pattern', 'text', 'search', 'q', 'regex'] },
+  'List files': { verb: 'Listed', noun: 'location', nounPlural: 'locations', argKeys: ['path', 'dir', 'directory', 'location', 'folder'] },
+}
+
+// Fallback for custom/unknown tools so mixed or unknown runs still read sensibly.
+const GENERIC_VERB: ToolVerb = { verb: 'Ran', noun: 'tool', nounPlural: 'tools', argKeys: [] }
+
+const MAX_ARG_LEN = 60
+
+function lowerFirst(s: string): string {
+  return s.charAt(0).toLowerCase() + s.slice(1)
+}
+
+function shorten(s: string): string {
+  return s.length > MAX_ARG_LEN ? s.slice(0, MAX_ARG_LEN - 1) + '…' : s
+}
+
+// Pull the value a single-op label should show from the tool call's arguments.
+function extractArg(v: ToolVerb, argumentsJson: string): string | null {
+  if (v.argKeys.length === 0) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(argumentsJson)
+  } catch {
+    return null
   }
-  const only = labels.size === 1 ? [...labels][0] : null
-  const maker = only ? GROUP_TITLES[only] : undefined
-  return maker ? maker(count) : `Ran ${plural(count, 'tool')}`
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+  const obj = parsed as Record<string, unknown>
+  for (const key of v.argKeys) {
+    const val = obj[key]
+    if (typeof val === 'string' && val.trim()) return val.trim()
+  }
+  return null
+}
+
+// Path-like args show just the basename; URLs/queries show in full (shortened).
+function displayArg(label: string, raw: string): string {
+  const pathLike =
+    label === 'Read file' || label === 'Edit file' || label === 'Write file' || label === 'List files'
+  if (pathLike) {
+    const base = raw.replace(/[\\/]+$/, '').split(/[\\/]/).pop()
+    return shorten(base || raw)
+  }
+  return shorten(raw)
+}
+
+/**
+ * Label for a single tool-call badge: past-tense verb plus the operated-on value,
+ * e.g. "Fetched https://…", "Read config.ts", "Ran a command". Falls back to a
+ * value-less "<Verb> a <noun>" when the argument can't be read, and to the raw
+ * label for unknown tools.
+ */
+export function toolCallLabel(name: string, argumentsJson: string): string {
+  const label = toolLabel(name)
+  const v = TOOL_VERBS[label]
+  if (!v) return label
+  const arg = extractArg(v, argumentsJson)
+  return arg ? `${v.verb} ${displayArg(label, arg)}` : `${v.verb} a ${v.noun}`
+}
+
+// Combine the per-tool verbs across a run into one title, e.g.
+// "Fetched 4 URLs, read 2 files, edited a file". Counts are bucketed by canonical
+// label in first-appearance order; the leading verb is capitalized, the rest
+// lower-cased. Unknown tools bucket together under the generic verb.
+function groupTitle(run: DisplayMessage[]): string {
+  const order: string[] = []
+  const counts = new Map<string, number>()
+  for (const m of run) {
+    for (const tc of m.toolCalls ?? []) {
+      const label = toolLabel(tc.name)
+      const key = TOOL_VERBS[label] ? label : '__generic__'
+      if (!counts.has(key)) order.push(key)
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+  }
+
+  return order
+    .map((key, i) => {
+      const v = key === '__generic__' ? GENERIC_VERB : TOOL_VERBS[key]
+      const n = counts.get(key) ?? 0
+      const verb = i === 0 ? v.verb : lowerFirst(v.verb)
+      const quantity = n === 1 ? `a ${v.noun}` : `${n} ${v.nounPlural}`
+      return `${verb} ${quantity}`
+    })
+    .join(', ')
 }
 
 /**
@@ -76,7 +156,7 @@ export function groupToolMessages(messages: DisplayMessage[]): ChatRenderItem[] 
       items.push({
         kind: 'toolGroup',
         id: `group-${run[0].id}`,
-        title: groupTitle(run, toolCallCount),
+        title: groupTitle(run),
         messages: run,
       })
     } else {

--- a/src/renderer/src/message-grouping.ts
+++ b/src/renderer/src/message-grouping.ts
@@ -1,0 +1,99 @@
+import type { DisplayMessage } from './store'
+
+// Map common Pi tool names to a friendly, user-facing label; falls back to the
+// raw name so custom/unknown tools still show something. Keyword matching
+// mirrors toolIcon() so the label and icon stay in sync.
+export function toolLabel(name: string): string {
+  const n = name.toLowerCase()
+  if (n.includes('bash') || n.includes('shell') || n.includes('exec') || n.includes('terminal')) return 'Run command'
+  if (n.includes('search') || n.includes('grep') || n.includes('find')) return 'Search'
+  if (n.includes('web') || n.includes('fetch') || n.includes('http') || n.includes('url')) return 'Fetch URL'
+  if (n.includes('edit') || n.includes('replace') || n.includes('patch')) return 'Edit file'
+  if (n.includes('write') || n.includes('create')) return 'Write file'
+  if (n.includes('list') || n.startsWith('ls') || n.includes('tree') || n.includes('dir')) return 'List files'
+  if (n.includes('read') || n.includes('view') || n.includes('cat') || n.includes('file')) return 'Read file'
+  return name
+}
+
+// A single chat item to render: either a lone message or a collapsed group of
+// consecutive tool-activity messages.
+export type ChatRenderItem =
+  | { kind: 'message'; message: DisplayMessage }
+  | { kind: 'toolGroup'; id: string; title: string; messages: DisplayMessage[] }
+
+// Group a run only once it holds this many tool calls; a lone call renders as-is.
+const MIN_GROUP_TOOL_CALLS = 2
+
+// "Tool activity" is anything with no user-facing prose: tool results, and
+// assistant turns whose only body is tool calls and/or thinking (no text). A run
+// of these between two prose turns is what gets folded into one group; the
+// thinking turns ride along and render in the expanded body per the setting.
+function isToolActivity(m: DisplayMessage): boolean {
+  if (m.role === 'toolResult') return true
+  if (m.role === 'assistant') return m.content.trim().length === 0
+  return false
+}
+
+const plural = (n: number, unit: string): string => `${n} ${unit}${n === 1 ? '' : 's'}`
+
+// Verb templates for a homogeneous run (all calls map to the same label). A mixed
+// or unknown run falls back to the generic "Ran N tools".
+const GROUP_TITLES: Record<string, (n: number) => string> = {
+  'Fetch URL': (n) => `Fetched ${plural(n, 'URL')}`,
+  'Read file': (n) => `Read ${plural(n, 'file')}`,
+  'Run command': (n) => `Ran ${plural(n, 'command')}`,
+  'Edit file': (n) => `Edited ${plural(n, 'file')}`,
+  'Write file': (n) => `Wrote ${plural(n, 'file')}`,
+  Search: (n) => `${n} search${n === 1 ? '' : 'es'}`,
+  'List files': (n) => `Listed ${plural(n, 'location')}`,
+}
+
+function groupTitle(run: DisplayMessage[], count: number): string {
+  const labels = new Set<string>()
+  for (const m of run) {
+    for (const tc of m.toolCalls ?? []) labels.add(toolLabel(tc.name))
+  }
+  const only = labels.size === 1 ? [...labels][0] : null
+  const maker = only ? GROUP_TITLES[only] : undefined
+  return maker ? maker(count) : `Ran ${plural(count, 'tool')}`
+}
+
+/**
+ * Fold consecutive tool-activity messages into collapsible groups. A run that
+ * carries fewer than MIN_GROUP_TOOL_CALLS tool calls is emitted as individual
+ * messages (unchanged rendering); larger runs become a single `toolGroup` item.
+ * Prose turns (assistant text, user, system) always render on their own and act
+ * as run boundaries.
+ */
+export function groupToolMessages(messages: DisplayMessage[]): ChatRenderItem[] {
+  const items: ChatRenderItem[] = []
+  let run: DisplayMessage[] = []
+
+  const flush = (): void => {
+    if (run.length === 0) return
+    const toolCallCount = run.reduce((n, m) => n + (m.toolCalls?.length ?? 0), 0)
+    if (toolCallCount >= MIN_GROUP_TOOL_CALLS) {
+      items.push({
+        kind: 'toolGroup',
+        id: `group-${run[0].id}`,
+        title: groupTitle(run, toolCallCount),
+        messages: run,
+      })
+    } else {
+      for (const m of run) items.push({ kind: 'message', message: m })
+    }
+    run = []
+  }
+
+  for (const m of messages) {
+    if (isToolActivity(m)) {
+      run.push(m)
+    } else {
+      flush()
+      items.push({ kind: 'message', message: m })
+    }
+  }
+  flush()
+
+  return items
+}


### PR DESCRIPTION
Long runs of tool calls — e.g. the model fetching several URLs or reading several files in sequence — produce an alternating stack of tool-call and tool-result blocks that dominates the scrollback. This folds a consecutive run into one collapsible summary.

**Change:** a render-side grouping pass (`message-grouping.ts`) folds a run of consecutive tool-activity messages into a single `ToolGroupBubble`, collapsed by default. No store, parsing, or data-model changes — grouping is purely presentational, so recording and history reload are untouched.

Details:
- A run of **≥2 tool calls** is grouped; a lone tool call renders unchanged. Prose turns (assistant text, user, system) end a run and never group.
- Each single tool call reads as a past-tense verb plus the operated-on value: `Fetched https://...`, `Read config.ts` (basename), `Edited bar.ts`, `Created new.ts`, `Searched TODO`, `Listed components`, `Ran a command` (no value). Unknown tools keep their raw name; long values truncate.
- The group title combines those verbs across the run, e.g. `Fetched 4 URLs, read 2 files, edited a file` (first verb capitalized, rest lower-cased; a lone call of a type gives `a file`, N give `N files`). Homogeneous runs read as one segment like `Fetched 3 URLs`; unknown tools bucket under `Ran N tools`.
- Thinking-only turns ride along inside a run without breaking it, and render in the expanded body per the Show Thinking setting.
- The group reads like a normal assistant message: Bot avatar + one `provider · model` header above the title. Inside the expanded body the per-turn model header and Bot avatar are suppressed (an empty spacer keeps the tool boxes aligned with the wrench-avatared result rows). When a run mixes models, per-turn headers are kept instead.
- Copy button on the group yields every call + result in order.
- Always on; the collapse itself is the control.
- `toolLabel()` moved from `message-bubble.tsx` to `message-grouping.ts` (type-only import of `DisplayMessage`, so the logic stays unit-testable); `streaming-bubble.tsx` import repointed.
- Unit tests in `message-grouping.test.ts` cover grouping, threshold, mixed titles, run boundaries, thinking pass-through, and multi-call turns.


---

**Overlaps #23** (`feat/scroll-to-bottom-button`) in `chat-panel.tsx` — both branch off `Dev` and rewrite the messages-area block, so whichever merges second needs a manual resolution. Combine both: keep #23's `relative flex` scroll wrapper and the jump-to-bottom chevron, and render the grouped list (`renderItems.map` with `ToolGroupBubble`) inside it in place of the plain `messages.map`.

Minor: also a trivial import-adjacency conflict with #19 in `message-bubble.tsx` (this PR adds `import { toolLabel } from '../message-grouping'`, #19 adds the `DEFAULT_SETTINGS` import) — keep both import lines.



