### PR TITLE
feat: in-conversation find bar (Ctrl+F)

### DIFF
--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -230,11 +230,8 @@ export function ChatInput(): React.JSX.Element {
               e.preventDefault()
               useAppStore.getState().cycleModel()
             }
-            // Ctrl+Shift+F: open file search
-            if (e.ctrlKey && e.shiftKey && e.key === 'F') {
-              e.preventDefault()
-              useAppStore.getState().toggleFileSearch()
-            }
+            // Ctrl+Shift+F (file search) is handled at the window level in
+            // ChatPanel so it works regardless of composer focus.
           }}
         />
 

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -53,7 +53,9 @@ export function ChatPanel(): React.JSX.Element {
   useEffect(() => {
     if (currentView !== 'chat') return
     const onKey = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
+      // Plain Ctrl/Cmd+F only. Exclude Shift so Ctrl+Shift+F stays free for the
+      // workspace file-search modal; the 'F' (uppercase) case still covers Caps Lock.
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && (e.key === 'f' || e.key === 'F')) {
         e.preventDefault()
         setSearchOpen(true)
         setSearchNonce((n) => n + 1)

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -3,12 +3,13 @@ import { ChatInput } from './chat-input'
 import { CouncilPanels } from './council-panels'
 import { MessageBubble } from './message-bubble'
 import { StreamingBubble } from './streaming-bubble'
+import { ChatSearch } from './chat-search'
 import { FileTree, FileSearch, FilePreview } from './file-tree'
 import { ImageViewer } from './image-viewer'
 import { DiffViewer } from './diff-viewer'
 import { TerminalPanel } from './terminal'
 import { useChatScroll } from '../hooks'
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { clsx } from 'clsx'
 import piLogo from '../assets/pi-logo.svg'
 import {
@@ -44,6 +45,23 @@ export function ChatPanel(): React.JSX.Element {
 
   const currentView = useAppStore((state) => state.currentView)
   const { scrollRef, onScroll } = useChatScroll(currentView === 'chat')
+
+  // In-conversation search (Ctrl/Cmd+F while in chat). The nonce bumps on every
+  // press so re-triggering refocuses/selects the already-open input.
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchNonce, setSearchNonce] = useState(0)
+  useEffect(() => {
+    if (currentView !== 'chat') return
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault()
+        setSearchOpen(true)
+        setSearchNonce((n) => n + 1)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [currentView])
 
   const handleRetry = useCallback(async (messageId: string) => {
     // Read from the store so this callback stays referentially stable, keeping
@@ -119,23 +137,32 @@ export function ChatPanel(): React.JSX.Element {
           </div>
 
           {/* Messages area */}
-          <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
-            {messages.length === 0 && !isStreaming ? (
-              <EmptyState piStatus={piStatus} />
-            ) : (
-              <div className="mx-auto max-w-5xl px-4 py-6">
-                {messages.map((message) => (
-                  <MessageBubble key={message.id} message={message} onRetry={handleRetry} />
-                ))}
-                {isStreaming && (
-                  <StreamingBubble
-                    content={streamingContent}
-                    thinking={streamingThinking}
-                    toolCalls={streamingToolCalls}
-                  />
-                )}
-              </div>
+          <div className="relative flex min-h-0 flex-1 flex-col">
+            {searchOpen && (
+              <ChatSearch
+                containerRef={scrollRef}
+                focusNonce={searchNonce}
+                onClose={() => setSearchOpen(false)}
+              />
             )}
+            <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto">
+              {messages.length === 0 && !isStreaming ? (
+                <EmptyState piStatus={piStatus} />
+              ) : (
+                <div className="mx-auto max-w-5xl px-4 py-6">
+                  {messages.map((message) => (
+                    <MessageBubble key={message.id} message={message} onRetry={handleRetry} />
+                  ))}
+                  {isStreaming && (
+                    <StreamingBubble
+                      content={streamingContent}
+                      thinking={streamingThinking}
+                      toolCalls={streamingToolCalls}
+                    />
+                  )}
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Input area */}

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -53,12 +53,19 @@ export function ChatPanel(): React.JSX.Element {
   useEffect(() => {
     if (currentView !== 'chat') return
     const onKey = (e: KeyboardEvent) => {
-      // Plain Ctrl/Cmd+F only. Exclude Shift so Ctrl+Shift+F stays free for the
-      // workspace file-search modal; the 'F' (uppercase) case still covers Caps Lock.
-      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && (e.key === 'f' || e.key === 'F')) {
+      // The 'F' (uppercase) case also covers Caps Lock. Ctrl/Cmd+F opens the
+      // in-conversation find bar; adding Shift opens the workspace file-search
+      // modal. Both handled here at the window level so they fire regardless of
+      // focus (the file-search shortcut used to be composer-scoped, so it only
+      // worked while the textarea had focus).
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'f' || e.key === 'F')) {
         e.preventDefault()
-        setSearchOpen(true)
-        setSearchNonce((n) => n + 1)
+        if (e.shiftKey) {
+          useAppStore.getState().toggleFileSearch()
+        } else {
+          setSearchOpen(true)
+          setSearchNonce((n) => n + 1)
+        }
       }
     }
     window.addEventListener('keydown', onKey)

--- a/src/renderer/src/components/chat-search.tsx
+++ b/src/renderer/src/components/chat-search.tsx
@@ -2,9 +2,37 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppStore } from '../store'
 import { ChevronUp, ChevronDown, X } from 'lucide-react'
 
-// Named CSS custom highlights (styled via ::highlight() in index.css).
+// Named CSS custom highlights, styled via the ::highlight() rules injected by
+// ensureHighlightStyles() below.
 const HIGHLIGHT_ALL = 'pi-search'
 const HIGHLIGHT_CURRENT = 'pi-search-current'
+
+// These rules are injected at runtime via a plain <style> element rather than
+// living in index.css: Tailwind's Lightning CSS transformer doesn't recognize
+// the ::highlight() pseudo-element and — depending on lightningcss version —
+// drops the rule at build time (it warns, and newer versions strip it), which
+// would leave search matches with no visible highlight in the built app.
+// Injecting the <style> bypasses that pipeline entirely.
+const HIGHLIGHT_STYLE_ID = 'pi-search-highlight-styles'
+const HIGHLIGHT_CSS = `
+::highlight(${HIGHLIGHT_ALL}) {
+  background-color: rgba(250, 204, 21, 0.28);
+}
+::highlight(${HIGHLIGHT_CURRENT}) {
+  background-color: rgba(250, 204, 21, 0.85);
+  color: #1a1a1a;
+}
+`
+
+// Idempotently add the highlight rules to <head> (keyed by id).
+function ensureHighlightStyles(): void {
+  if (typeof document === 'undefined') return
+  if (document.getElementById(HIGHLIGHT_STYLE_ID)) return
+  const style = document.createElement('style')
+  style.id = HIGHLIGHT_STYLE_ID
+  style.textContent = HIGHLIGHT_CSS
+  document.head.appendChild(style)
+}
 
 // Feature-detect the CSS Custom Highlight API (Chromium 105+, always present in
 // our Electron; guarded so a missing API degrades to "no highlight" rather than
@@ -127,6 +155,11 @@ export function ChatSearch({
     applyHighlights(ranges, idx)
     if (queryChanged && ranges.length > 0) scrollIntoView(ranges, idx)
   }, [query, messages, computeRanges, applyHighlights, scrollIntoView])
+
+  // Inject the ::highlight() rules once (see note by HIGHLIGHT_CSS).
+  useEffect(() => {
+    ensureHighlightStyles()
+  }, [])
 
   // Focus (and select) on open and whenever Ctrl+F is pressed again.
   useEffect(() => {

--- a/src/renderer/src/components/chat-search.tsx
+++ b/src/renderer/src/components/chat-search.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppStore } from '../store'
+import { ChevronUp, ChevronDown, X } from 'lucide-react'
+
+// Named CSS custom highlights (styled via ::highlight() in index.css).
+const HIGHLIGHT_ALL = 'pi-search'
+const HIGHLIGHT_CURRENT = 'pi-search-current'
+
+// Feature-detect the CSS Custom Highlight API (Chromium 105+, always present in
+// our Electron; guarded so a missing API degrades to "no highlight" rather than
+// throwing).
+function highlightsSupported(): boolean {
+  return typeof CSS !== 'undefined' && 'highlights' in CSS && typeof Highlight !== 'undefined'
+}
+
+/**
+ * In-conversation find bar. Highlights every case-insensitive match of the query
+ * across the chat transcript using the CSS Custom Highlight API (no DOM mutation,
+ * so it works over rendered markdown) and lets the user step through matches.
+ *
+ * `containerRef` is the scrollable messages element to search within.
+ */
+export function ChatSearch({
+  containerRef,
+  focusNonce,
+  onClose,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>
+  focusNonce: number
+  onClose: () => void
+}): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const [count, setCount] = useState(0)
+  const [current, setCurrent] = useState(0) // 0-based; displayed as current + 1
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const rangesRef = useRef<Range[]>([])
+  const currentRef = useRef(0)
+  const prevQuery = useRef('')
+
+  // Recompute when the transcript changes while the bar is open.
+  const messages = useAppStore((state) => state.messages)
+
+  const clearHighlights = useCallback(() => {
+    if (!highlightsSupported()) return
+    CSS.highlights.delete(HIGHLIGHT_ALL)
+    CSS.highlights.delete(HIGHLIGHT_CURRENT)
+  }, [])
+
+  // Build ranges for all matches within the container's text nodes. Matches are
+  // confined to a single text node (won't span inline element boundaries) — fine
+  // for reading-position search.
+  const computeRanges = useCallback(
+    (q: string): Range[] => {
+      const root = containerRef.current
+      if (!root || !q) return []
+      const needle = q.toLowerCase()
+      const ranges: Range[] = []
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) =>
+          node.nodeValue && node.nodeValue.trim()
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_REJECT,
+      })
+      let node = walker.nextNode()
+      while (node) {
+        const hay = (node.nodeValue ?? '').toLowerCase()
+        let idx = hay.indexOf(needle)
+        while (idx !== -1) {
+          const range = document.createRange()
+          range.setStart(node, idx)
+          range.setEnd(node, idx + needle.length)
+          ranges.push(range)
+          idx = hay.indexOf(needle, idx + needle.length)
+        }
+        node = walker.nextNode()
+      }
+      return ranges
+    },
+    [containerRef]
+  )
+
+  const applyHighlights = useCallback(
+    (ranges: Range[], index: number) => {
+      if (!highlightsSupported()) return
+      if (ranges.length === 0) {
+        clearHighlights()
+        return
+      }
+      CSS.highlights.set(HIGHLIGHT_ALL, new Highlight(...ranges))
+      const cur = ranges[index]
+      if (cur) CSS.highlights.set(HIGHLIGHT_CURRENT, new Highlight(cur))
+      else CSS.highlights.delete(HIGHLIGHT_CURRENT)
+    },
+    [clearHighlights]
+  )
+
+  const scrollIntoView = useCallback(
+    (ranges: Range[], index: number) => {
+      const root = containerRef.current
+      const range = ranges[index]
+      if (!root || !range) return
+      const r = range.getBoundingClientRect()
+      const c = root.getBoundingClientRect()
+      // Only scroll if the match is outside the visible band; then center it.
+      if (r.top < c.top || r.bottom > c.bottom) {
+        root.scrollTop += r.top - c.top - root.clientHeight / 2 + r.height / 2
+      }
+    },
+    [containerRef]
+  )
+
+  // Recompute matches when the query or the transcript changes. Scroll to the
+  // first match only when the query itself changed — a transcript update (e.g. a
+  // new streamed message) refreshes highlights without yanking the view.
+  useEffect(() => {
+    const queryChanged = prevQuery.current !== query
+    prevQuery.current = query
+
+    const ranges = computeRanges(query)
+    rangesRef.current = ranges
+    const idx =
+      ranges.length === 0 ? 0 : queryChanged ? 0 : Math.min(currentRef.current, ranges.length - 1)
+    currentRef.current = idx
+    setCount(ranges.length)
+    setCurrent(idx)
+    applyHighlights(ranges, idx)
+    if (queryChanged && ranges.length > 0) scrollIntoView(ranges, idx)
+  }, [query, messages, computeRanges, applyHighlights, scrollIntoView])
+
+  // Focus (and select) on open and whenever Ctrl+F is pressed again.
+  useEffect(() => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [focusNonce])
+
+  // Drop highlights when the bar unmounts.
+  useEffect(() => clearHighlights, [clearHighlights])
+
+  const go = useCallback(
+    (delta: number) => {
+      const ranges = rangesRef.current
+      if (ranges.length === 0) return
+      const next = (currentRef.current + delta + ranges.length) % ranges.length
+      currentRef.current = next
+      setCurrent(next)
+      applyHighlights(ranges, next)
+      scrollIntoView(ranges, next)
+    },
+    [applyHighlights, scrollIntoView]
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      go(e.shiftKey ? -1 : 1)
+    }
+  }
+
+  return (
+    <div className="absolute right-4 top-3 z-20 flex items-center gap-1 rounded-lg border border-neutral-800 bg-neutral-900 px-2 py-2 shadow-lg shadow-black/30">
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find in page"
+        className="w-48 bg-transparent px-1 py-0.5 text-base text-neutral-200 outline-none placeholder:text-neutral-600"
+      />
+      <span className="min-w-[3rem] shrink-0 text-center text-xs tabular-nums text-neutral-500">
+        {query === '' ? '' : `${count === 0 ? 0 : current + 1}/${count}`}
+      </span>
+      <SearchIconButton
+        icon={<ChevronUp size={14} />}
+        onClick={() => go(-1)}
+        title="Previous match (Shift+Enter)"
+        disabled={count === 0}
+      />
+      <SearchIconButton
+        icon={<ChevronDown size={14} />}
+        onClick={() => go(1)}
+        title="Next match (Enter)"
+        disabled={count === 0}
+      />
+      <SearchIconButton icon={<X size={14} />} onClick={onClose} title="Close (Esc)" />
+    </div>
+  )
+}
+
+function SearchIconButton({
+  icon,
+  onClick,
+  title,
+  disabled,
+}: {
+  icon: React.ReactNode
+  onClick: () => void
+  title: string
+  disabled?: boolean
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-label={title}
+      disabled={disabled}
+      className="rounded p-1 text-neutral-400 transition-colors hover:bg-neutral-800 hover:text-neutral-200 disabled:cursor-default disabled:opacity-30 disabled:hover:bg-transparent"
+    >
+      {icon}
+    </button>
+  )
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -926,13 +926,7 @@
   }
 }
 
-/* ─── In-conversation search highlights (CSS Custom Highlight API) ────────── */
-
-::highlight(pi-search) {
-  background-color: rgba(250, 204, 21, 0.28);
-}
-
-::highlight(pi-search-current) {
-  background-color: rgba(250, 204, 21, 0.85);
-  color: #1a1a1a;
-}
+/* In-conversation search highlights (the ::highlight() rules for the CSS Custom
+   Highlight API) are injected at runtime from chat-search.tsx — Tailwind's
+   Lightning CSS transformer drops the unrecognized ::highlight() pseudo-element
+   at build time, so they can't live here. */

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -925,3 +925,14 @@
     animation: fade-in 0.2s ease-out;
   }
 }
+
+/* ─── In-conversation search highlights (CSS Custom Highlight API) ────────── */
+
+::highlight(pi-search) {
+  background-color: rgba(250, 204, 21, 0.28);
+}
+
+::highlight(pi-search-current) {
+  background-color: rgba(250, 204, 21, 0.85);
+  color: #1a1a1a;
+}


### PR DESCRIPTION
Adds an in-conversation find bar so you can locate an earlier command, URL, or error in a long transcript. Previously the only search was over workspace files, not the chat log.

**Change:** Ctrl/Cmd+F while in the chat view opens a compact find bar (query · current/total counter · ↑/↓ prev-next · ✕). Every case-insensitive match is highlighted across the transcript via the **CSS Custom Highlight API** (`CSS.highlights` + `Range`, styled with `::highlight()`), so there's no DOM mutation and it works over rendered markdown.

Details:
- Enter / ↓ = next, Shift+Enter / ↑ = prev (wraps); the current match is centered into view. Esc or ✕ closes and clears highlights. Pressing Ctrl+F again refocuses and selects the input.
- Matches recompute when the query or the message list changes; a transcript update refreshes highlights without yanking the scroll position.
- Input font is `text-base` (= the configured UI font size, scales with it); box uses the tool-box styling.
- New `chat-search.tsx`; `chat-panel.tsx` wraps the messages area in a `relative` container to host the overlay; two `::highlight()` rules in `index.css`.

**Known limitation:** search covers the rendered DOM, so text inside collapsed sections (tool results / thinking blocks are collapsed by default) isn't matched until expanded.



---
**Follow-up fix:** the Ctrl/Cmd+F handler also matched Ctrl+Shift+F (it accepted `key==="F"` without excluding Shift), so Ctrl+Shift+F opened this find bar on top of the workspace file-search modal. Added `!e.shiftKey`; the uppercase-`F` case still covers Caps Lock.


**Follow-up 2:** Ctrl+Shift+F (workspace file search) also only worked while the composer textarea had focus (its handler was composer-scoped). Both shortcuts are now routed through the same window-level handler in ChatPanel — plain Ctrl/Cmd+F opens the find bar, +Shift opens the file-search modal — so each fires regardless of focus; removed the redundant composer-scoped handler.
