### PR TITLE
feat: composer prompt-history recall (Up/Down)

### DIFF
--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -346,7 +346,6 @@ export function ChatInput(): React.JSX.Element {
         <div className="flex gap-3">
           <span>Enter: send</span>
           <span>Shift+Enter: newline</span>
-          <span>↑/↓: history</span>
           <span>Esc: stop</span>
           <span>Ctrl+P: model</span>
           <span>Ctrl+Shift+F: search</span>

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -23,6 +23,14 @@ export function ChatInput(): React.JSX.Element {
   const setNotePickerOpen = useAppStore((state) => state.setNotePickerOpen)
   const councilEnabled = useAppStore((s) => s.settings?.council?.enabled ?? false)
   const runCouncil = useAppStore((s) => s.runCouncil)
+  const recordPrompt = useAppStore((s) => s.recordPrompt)
+
+  // Prompt-history recall (shell-style ↑/↓). `historyIndex` is -1 when editing a
+  // fresh draft; while navigating it points into store.promptHistory and `draft`
+  // holds the text that was in the box before recall started (restored on ↓ past
+  // the newest entry).
+  const historyIndex = useRef(-1)
+  const draft = useRef('')
 
   // Apply a note inserted from the panel or picker: drop the text at the
   // cursor, refocus, resize, then clear so the same note can be inserted again.
@@ -66,6 +74,12 @@ export function ChatInput(): React.JSX.Element {
 
   const handleSend = useCallback(
     async (message: string) => {
+      // Record the raw prompt (pre-attachment-inlining) for ↑/↓ recall, and
+      // reset any in-progress history navigation.
+      recordPrompt(message)
+      historyIndex.current = -1
+      draft.current = ''
+
       // Text attachments are inlined into the prompt; image attachments are
       // sent as Pi image blocks so the model actually sees them.
       const textAttachments = attachments.filter((a) => a.kind === 'text')
@@ -94,12 +108,22 @@ export function ChatInput(): React.JSX.Element {
       setAttachments([])
       resetComposer()
     },
-    [sendPrompt, attachments, resetComposer]
+    [sendPrompt, attachments, recordPrompt, resetComposer]
   )
 
   const handleAbort = useCallback(() => {
     abort()
   }, [abort])
+
+  // Drop a recalled prompt into the box: set value, regrow height, caret to end.
+  const applyHistory = useCallback((text: string) => {
+    const ta = textareaRef.current
+    if (!ta) return
+    ta.value = text
+    ta.style.height = 'auto'
+    ta.style.height = `${Math.min(ta.scrollHeight, MAX_INPUT_HEIGHT)}px`
+    ta.setSelectionRange(text.length, text.length)
+  }, [])
 
   const handleAttachFile = useCallback(async () => {
     setAttachError(null)
@@ -199,6 +223,9 @@ export function ChatInput(): React.JSX.Element {
             onClick={() => {
               const value = textareaRef.current?.value.trim()
               if (value) {
+                recordPrompt(value)
+                historyIndex.current = -1
+                draft.current = ''
                 void runCouncil(value)
                 resetComposer()
               }
@@ -229,6 +256,8 @@ export function ChatInput(): React.JSX.Element {
             const target = e.currentTarget
             target.style.height = 'auto'
             target.style.height = `${Math.min(target.scrollHeight, MAX_INPUT_HEIGHT)}px`
+            // Any real edit ends history navigation; the box is a fresh draft again.
+            historyIndex.current = -1
             const value = target.value
             if (value.startsWith('/')) {
               useAppStore.getState().setCommandPalette(true, value, true)
@@ -243,6 +272,42 @@ export function ChatInput(): React.JSX.Element {
             }
             // Ctrl+Shift+F (file search) is handled at the window level in
             // ChatPanel so it works regardless of composer focus.
+            // ↑/↓: shell-style prompt-history recall. Only kicks in at the text
+            // edge (↑ on the first line, ↓ on the last) with no selection and no
+            // modifiers, so ordinary multi-line cursor movement is untouched. Left
+            // to the command palette when it's driving the arrows.
+            if (
+              (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+              !e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey &&
+              !useAppStore.getState().commandPaletteOpen
+            ) {
+              const ta = e.currentTarget
+              if (ta.selectionStart !== ta.selectionEnd) return
+              const history = useAppStore.getState().promptHistory
+              if (e.key === 'ArrowUp') {
+                const onFirstLine = ta.value.slice(0, ta.selectionStart).indexOf('\n') === -1
+                if (!onFirstLine || history.length === 0) return
+                e.preventDefault()
+                if (historyIndex.current === -1) {
+                  draft.current = ta.value
+                  historyIndex.current = history.length - 1
+                } else if (historyIndex.current > 0) {
+                  historyIndex.current -= 1
+                }
+                applyHistory(history[historyIndex.current])
+              } else {
+                const onLastLine = ta.value.slice(ta.selectionEnd).indexOf('\n') === -1
+                if (!onLastLine || historyIndex.current === -1) return
+                e.preventDefault()
+                if (historyIndex.current < history.length - 1) {
+                  historyIndex.current += 1
+                  applyHistory(history[historyIndex.current])
+                } else {
+                  historyIndex.current = -1
+                  applyHistory(draft.current)
+                }
+              }
+            }
           }}
         />
 
@@ -281,6 +346,7 @@ export function ChatInput(): React.JSX.Element {
         <div className="flex gap-3">
           <span>Enter: send</span>
           <span>Shift+Enter: newline</span>
+          <span>↑/↓: history</span>
           <span>Esc: stop</span>
           <span>Ctrl+P: model</span>
           <span>Ctrl+Shift+F: search</span>

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -109,6 +109,9 @@ interface AppState {
 
   // Messages
   messages: DisplayMessage[]
+  // Shell-style recall of prompts sent this session (oldest→newest); reset per
+  // session in clearMessages. Recorded raw (before attachment inlining).
+  promptHistory: string[]
   streamingContent: string
   streamingThinking: string
   streamingToolCalls: Map<
@@ -222,6 +225,7 @@ interface AppActions {
   addMessage: (message: DisplayMessage) => void
   setMessages: (messages: DisplayMessage[]) => void
   clearMessages: () => void
+  recordPrompt: (text: string) => void
 
   // Prompts
   sendPrompt: (message: string, options?: { images?: PromptImage[]; attachments?: DisplayAttachment[] }) => Promise<void>
@@ -393,6 +397,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   forkMessages: [],
 
   messages: [],
+  promptHistory: [],
   streamingContent: '',
   streamingThinking: '',
   streamingToolCalls: new Map(),
@@ -512,7 +517,20 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   setMessages: (messages) => set({ messages }),
 
-  clearMessages: () => set({ messages: [], streamingContent: '', streamingThinking: '', streamingToolCalls: new Map() }),
+  clearMessages: () => set({ messages: [], promptHistory: [], streamingContent: '', streamingThinking: '', streamingToolCalls: new Map() }),
+
+  // Append a sent prompt to the recall history. Ignores blanks and consecutive
+  // duplicates (shell-style), and caps the list so it can't grow unbounded.
+  recordPrompt: (text) =>
+    set((state) => {
+      const trimmed = text.trim()
+      if (!trimmed) return state
+      const history = state.promptHistory
+      if (history[history.length - 1] === trimmed) return state
+      const next = [...history, trimmed]
+      if (next.length > 200) next.shift()
+      return { promptHistory: next }
+    }),
 
   // ─── Prompts ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Shell-style recall of prompts you've typed this session, in the chat composer.

## Behavior
- **Up** on the first line of the composer walks back through previously sent prompts; **Down** on the last line walks forward, and going past the newest entry restores the live draft you were typing before you started recalling.
- Caret moves to the end after each recall and the box re-grows to fit. Typing ends navigation (the box becomes a fresh draft again).
- Only kicks in at the text edge (Up on the first line, Down on the last), with no selection and no modifiers, so ordinary multi-line cursor movement is untouched. Yields to the `/` command palette when that's driving the arrows.
- Records the raw prompt (before attachment inlining) on every send path: Enter, the Send button, and Council.
- Added an `Up/Down: history` hint to the composer shortcuts footer.

## Storage & lifecycle
- **In-memory only** — kept in the Zustand store (`promptHistory: string[]`); nothing is written to disk.
- **Limit: 200 entries**, FIFO — oldest drops off once full. Blanks and consecutive duplicates are not recorded.
- **Reset per session** — cleared in `clearMessages`, which fires on every session switch / load, so each conversation gets its own fresh history. Also gone on app restart / renderer reload (it's in-memory). Survives view switches (Home <-> Chat) that don't change the active session.
- Resumed sessions start with **empty** history by design — the saved transcript's user messages contain inlined `--- File: ... ---` attachment dumps, so seeding from them would recall ugly text.

## Files
- `store.ts` — new `promptHistory` state + `recordPrompt` action (trim, skip blanks/consecutive dups, cap 200); reset in `clearMessages`.
- `chat-input.tsx` — record on send; Up/Down recall in the textarea `onKeyDown`; nav reset on `onInput`; footer hint.

Tested via `npm run dev:hot`.
