### PR TITLE
fix: dismiss workspace file search on Escape

### DIFF
--- a/src/renderer/src/components/file-tree.tsx
+++ b/src/renderer/src/components/file-tree.tsx
@@ -292,6 +292,21 @@ export function FileSearch({ isOpen, onClose }: FileSearchProps): React.JSX.Elem
     }
   }, [isOpen])
 
+  // Close on Escape. Capture phase + stopPropagation so it preempts the
+  // window-level Escape-to-abort handler while the modal is open.
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [isOpen, onClose])
+
   useEffect(() => {
     if (!query.trim()) {
       setResults([])


### PR DESCRIPTION
The workspace file-search modal (`FileSearch` in `file-tree.tsx`, opened with Ctrl+Shift+F) shows an "Esc to close" hint in its footer, but pressing Escape did nothing — the component had no Escape handler at all, so it could only be closed via the ✕ button or by selecting a result.

## Fix
Added an Escape key listener that's active only while the modal is open and calls `onClose()`. Registered in the **capture phase with `stopPropagation`** so it preempts the window-level Escape-to-abort handler — otherwise pressing Escape while a turn is streaming would both close the modal *and* abort the response. Verified via `dev:hot`: Escape dismisses the modal and leaves a streaming response running.

## Files
- `file-tree.tsx` — `FileSearch` gains an `isOpen`-gated Escape listener.

Tested via `npm run dev:hot`.
