### PR TITLE
feat: use a cleaner StickyNote icon for Notes

### DIFF
--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useState, useEffect } from 'react'
 import { useAppStore } from '../store'
 import { useChatKeyboard } from '../hooks'
-import { CornerDownLeft, Square, Paperclip, X, FileText, NotebookPen, Users } from 'lucide-react'
+import { CornerDownLeft, Square, Paperclip, X, FileText, StickyNote, Users } from 'lucide-react'
 import { SUPPORTED_IMAGE_EXTENSIONS, type PromptImage } from '../../../shared/ipc-contracts'
 
 // Max height (px) the auto-growing input expands to before scrolling.
@@ -190,7 +190,7 @@ export function ChatInput(): React.JSX.Element {
           title="Insert a saved note (Ctrl+Shift+P)"
           aria-label="Insert a saved note"
         >
-          <NotebookPen size={16} />
+          <StickyNote size={16} />
         </button>
 
         {/* Plan with Council button */}

--- a/src/renderer/src/components/context-menu.tsx
+++ b/src/renderer/src/components/context-menu.tsx
@@ -11,7 +11,7 @@ import {
   ArchiveRestore,
   Trash2,
   MessageSquare,
-  NotebookPen,
+  StickyNote,
   Pencil,
 } from 'lucide-react'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
@@ -325,7 +325,7 @@ export function buildMessageContextMenu(
     {
       id: 'add-to-notes',
       label: hasSelection ? 'Add Selection to Notes' : 'Add Message to Notes',
-      icon: <NotebookPen size={14} />,
+      icon: <StickyNote size={14} />,
       action: () => onAddToNotes(hasSelection ? selectedText : messageContent),
     },
     {

--- a/src/renderer/src/components/notes-panel.tsx
+++ b/src/renderer/src/components/notes-panel.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from 'react'
 import { clsx } from 'clsx'
-import { Plus, Search, Pencil, Trash2, CornerDownLeft, Tag, ArrowLeft } from 'lucide-react'
+import { Plus, Search, Pencil, Trash2, CornerDownLeft, Tag, ArrowLeft, StickyNote } from 'lucide-react'
 import { useAppStore } from '../store'
 import { MarkdownRenderer } from './markdown-renderer'
 import type { Note, NoteInput } from '../../../shared/ipc-contracts'
@@ -104,7 +104,8 @@ export function NotesPanel(): React.JSX.Element {
     <div className="flex h-full flex-col">
       {/* Header */}
       <div className="flex h-12 items-center justify-between border-b border-neutral-800 px-4">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
+          <StickyNote size={16} className="text-neutral-400" />
           <h1 className="text-sm font-medium text-neutral-200">Notes</h1>
         </div>
         <button

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -14,7 +14,7 @@ import {
   ChevronDown,
   Check,
   Trash2,
-  NotebookPen,
+  StickyNote,
   Archive,
   Sparkles,
   Pencil,
@@ -261,7 +261,7 @@ export function Sidebar(): React.JSX.Element {
           onClick={() => setCurrentView('packages')}
         />
         <SidebarItem
-          icon={<NotebookPen size={14} />}
+          icon={<StickyNote size={14} />}
           label="Notes"
           active={currentView === 'notes'}
           onClick={() => setCurrentView('notes')}


### PR DESCRIPTION
## What
- Swap the Notes icon from `NotebookPen` to `StickyNote` everywhere it appears — the sidebar nav item, the composer's notes button, and the context-menu "Add to notes" action.
- Add that same icon to the Notes panel's title bar, which was the only panel title showing a bare label with no icon.

## Why
The sidebar is a row of simple, flat outline glyphs, and `NotebookPen` — a notebook overlaid with a pen — was the busiest, most detailed mark in that set. `StickyNote` is a cleaner shape that still reads as "notes" at a glance and sits more consistently alongside its neighbours. Adding the icon to the Notes panel header brings it in line with every other panel, which all lead their title with an icon + label.

Purely cosmetic — no behavior changes.

## Scope
Icon-only, 4 files: `sidebar.tsx`, `chat-input.tsx`, `context-menu.tsx`, `notes-panel.tsx`.
