### PR TITLE
fix: enable :hover utilities in the Electron renderer

### DIFF
--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -10,6 +10,12 @@
 
 @custom-variant light (.light &);
 
+/* Tailwind v4 gates the `hover:` variant behind `@media (hover: hover)`. The
+   Electron/Chromium renderer reports `(hover: hover): false`, which silently
+   disables every `hover:` utility app-wide. Redefine the variant to fire on a
+   plain `:hover` so hover states work in the desktop window as intended. */
+@custom-variant hover (&:hover);
+
 @theme {
   --color-app-bg: #0a0a0a;
   --color-app-surface: #141414;


### PR DESCRIPTION
## Problem

Hover states don't work anywhere in the app. `hover:bg-*`, `hover:text-*`, etc. simply never apply in the running Electron window.

## Cause

Tailwind v4 compiles every `hover:` utility gated behind `@media (hover: hover)`:

```css
.hover\:bg-neutral-800 {
  &:hover {
    @media (hover: hover) {
      background-color: var(--color-neutral-800);
    }
  }
}
```

In the Electron/Chromium renderer, `window.matchMedia('(hover: hover)').matches` is **`false`**, so that media query never matches and the hover rules are dropped. Because this affects the `hover:` variant globally, **every** hover state in the app is silently disabled.

I confirmed both facts against the running renderer: `(hover: hover)` reports `false`, and the compiled rule for a hover utility is wrapped in the `@media (hover: hover)` block shown above.

## Fix

Redefine the `hover` variant so it fires on a plain `:hover`, dropping the media-query gate:

```css
@custom-variant hover (&:hover);
```

After this, the same utility compiles to `.hover\:bg-neutral-800 { &:hover { … } }` and hover states work throughout the desktop window. This is the standard workaround for Tailwind v4 in a desktop/Electron context, where hover is always available. One line, no behavior change beyond making the existing `hover:` classes actually apply.
