### PR TITLE
fix: theme-aware hover highlight for menus and sidebar items

### DIFF
--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -339,7 +339,7 @@ function ToolbarButton({
         'rounded p-1 transition-colors',
         active
           ? 'bg-neutral-800 text-neutral-200'
-          : 'text-neutral-500 hover:bg-neutral-800/50 hover:text-neutral-300'
+          : 'pi-hover-highlight text-neutral-500 hover:text-neutral-300'
       )}
       title={title}
     >

--- a/src/renderer/src/components/permission-selector.tsx
+++ b/src/renderer/src/components/permission-selector.tsx
@@ -77,7 +77,7 @@ export function PermissionSelector({
               type="button"
               disabled={saving}
               onClick={() => handleSelect(option.value)}
-              className="flex w-full items-start gap-2 px-3 py-2 text-left transition-colors hover:bg-neutral-800 disabled:opacity-60"
+              className="pi-hover-highlight flex w-full items-start gap-2 px-3 py-2 text-left transition-colors disabled:opacity-60"
             >
               <span className="mt-0.5 w-4 shrink-0">
                 {option.value === mode && <Check size={13} className="text-emerald-400" />}

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -229,7 +229,7 @@ export function Sidebar(): React.JSX.Element {
       </div>
 
       {/* Navigation */}
-      <nav className="px-2 py-1">
+      <nav className="space-y-0.5 px-2 py-1">
         <SidebarItem
           icon={<Home size={14} />}
           label="Home"

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -182,7 +182,7 @@ export function Sidebar(): React.JSX.Element {
           'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
           isActive
             ? 'bg-neutral-800 text-neutral-200'
-            : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300'
+            : 'pi-hover-highlight text-neutral-400 hover:text-neutral-300'
         )}
       >
         <Clock size={12} className="shrink-0" />
@@ -592,7 +592,7 @@ function SidebarItem({
         'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
         active
           ? 'bg-neutral-800 text-neutral-100'
-          : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300'
+          : 'pi-hover-highlight text-neutral-400 hover:text-neutral-300'
       )}
     >
       {icon}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -16,6 +16,15 @@
    plain `:hover` so hover states work in the desktop window as intended. */
 @custom-variant hover (&:hover);
 
+/* Theme-aware hover highlight. Each theme remaps the base `bg-neutral-900`
+   class (its "current session" card surface) but NOT the `hover:bg-neutral-900`
+   variant, so a fixed hover shade would ignore the active theme. Elements that
+   should highlight to the theme's card color on hover use this utility, which
+   references the per-theme `--pi-highlight` token instead. */
+.pi-hover-highlight:hover {
+  background-color: var(--pi-highlight);
+}
+
 @theme {
   --color-app-bg: #0a0a0a;
   --color-app-surface: #141414;
@@ -39,6 +48,10 @@
 @layer base {
   :root {
     --color-bg-primary: #0a0a0a;
+    /* Hover/selected surface — matches this theme's "current session" card
+       (its bg-neutral-900). Referenced by the .pi-hover-highlight utility so
+       hover states track the theme instead of a fixed neutral shade. */
+    --pi-highlight: #171717;
     --color-bg-secondary: #141414;
     --color-bg-tertiary: #1c1c1c;
     --color-bg-elevated: #242424;
@@ -79,6 +92,7 @@
 
   .light {
     --color-bg-primary: #ffffff;
+    --pi-highlight: #f5f5f5;
     --color-bg-secondary: #f5f5f5;
     --color-bg-tertiary: #e5e5e5;
     --color-bg-elevated: #ffffff;
@@ -377,6 +391,7 @@
 @layer base {
   .nord {
     --color-bg-primary:         #2E3440;
+    --pi-highlight:             #3B4252;
     --color-bg-secondary:       #3B4252;
     --color-bg-tertiary:        #434C5E;
     --color-bg-elevated:        #4C566A;
@@ -474,6 +489,7 @@
 @layer base {
   .gruvbox {
     --color-bg-primary:         #282828;
+    --pi-highlight:             #3C3836;
     --color-bg-secondary:       #3C3836;
     --color-bg-tertiary:        #504945;
     --color-bg-elevated:        #665C54;
@@ -568,6 +584,7 @@
 @layer base {
   .breeze-dark {
     --color-bg-primary:         #232629;
+    --pi-highlight:             #31363b;
     --color-bg-secondary:       #31363b;
     --color-bg-tertiary:        #2A2E32;
     --color-bg-elevated:        #3f4347;
@@ -664,6 +681,7 @@
 @layer base {
   .breeze-claudius {
     --color-bg-primary:         #232629;
+    --pi-highlight:             #31363b;
     --color-bg-secondary:       #31363b;
     --color-bg-tertiary:        #2A2E32;
     --color-bg-elevated:        #3f4347;
@@ -768,6 +786,7 @@
 @layer base {
   .breeze-light {
     --color-bg-primary:         #ffffff;
+    --pi-highlight:             #f8f7f6;
     --color-bg-secondary:       #f8f7f6;
     --color-bg-tertiary:        #ebebeb;
     --color-bg-elevated:        #ffffff;


### PR DESCRIPTION
## What
Makes hover highlights theme-aware. Adds a per-theme `--pi-highlight` token (set to each theme's "current session" card color) plus a small `.pi-hover-highlight` utility, and applies it to the sidebar nav/session rows and the review-panel permission menu.

## Why
Each theme remaps the base `bg-neutral-900` class (the current-session card surface), but **not** its `hover:` variant — `.hover\:bg-neutral-900:hover` is a different selector the theme rules don't match. So any fixed `hover:bg-neutral-*` shade ignored the active theme and fell back to default Tailwind neutrals, which looked out of place under Nord / Gruvbox / Breeze.

Routing these hovers through the `--pi-highlight` token means they track the theme and match the card surface in every theme, light or dark.

## Scope
- `index.css`: `--pi-highlight` token in all theme blocks (dark, light, breeze-light, nord, gruvbox, breeze-dark, breeze-claudius) + the `.pi-hover-highlight` utility.
- `sidebar.tsx`: nav items and recent/archived session rows.
- `permission-selector.tsx`: review-panel permission-menu items.
