### PR TITLE
feat: cleaner composer footer — actions row + per-session permission menu

### DIFF
--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -359,7 +359,7 @@ export function ChatInput(): React.JSX.Element {
               }
             }}
             disabled={isDisabled || isStreaming}
-            className="flex shrink-0 items-center justify-center py-3 pr-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
+            className="flex shrink-0 items-center justify-center py-3 pl-3 pr-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
             title="Plan with Council"
             aria-label="Plan with Council"
           >
@@ -379,7 +379,7 @@ export function ChatInput(): React.JSX.Element {
           }
           disabled={isDisabled}
           rows={1}
-          className="font-chat max-h-48 min-h-[24px] flex-1 resize-none bg-transparent py-3 pl-4 text-sm text-neutral-200 placeholder:text-neutral-600 outline-none disabled:opacity-50"
+          className={`font-chat max-h-48 min-h-[24px] flex-1 resize-none bg-transparent py-3 text-sm text-neutral-200 placeholder:text-neutral-600 outline-none disabled:opacity-50 ${councilEnabled ? 'pl-1' : 'pl-4'}`}
           onInput={(e) => {
             const target = e.currentTarget
             target.style.height = 'auto'

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -1,7 +1,8 @@
 import { useRef, useCallback, useState, useEffect } from 'react'
 import { useAppStore } from '../store'
 import { useChatKeyboard } from '../hooks'
-import { CornerDownLeft, Square, Paperclip, X, FileText, StickyNote, Users } from 'lucide-react'
+import { ComposerPermissionMenu } from './composer-permission-menu'
+import { CornerDownLeft, Square, Paperclip, X, FileText, StickyNote, Users, Search } from 'lucide-react'
 import {
   SUPPORTED_IMAGE_EXTENSIONS,
   type PromptImage,
@@ -73,6 +74,9 @@ export function ChatInput(): React.JSX.Element {
   const councilEnabled = useAppStore((s) => s.settings?.council?.enabled ?? false)
   const runCouncil = useAppStore((s) => s.runCouncil)
   const recordPrompt = useAppStore((s) => s.recordPrompt)
+  const permissionMode = useAppStore((s) => s.settings?.permissionMode)
+  const setPermissionMode = useAppStore((s) => s.setPermissionMode)
+  const toggleFileSearch = useAppStore((s) => s.toggleFileSearch)
 
   // Prompt-history recall (shell-style ↑/↓). `historyIndex` is -1 when editing a
   // fresh draft; while navigating it points into store.promptHistory and `draft`
@@ -341,27 +345,6 @@ export function ChatInput(): React.JSX.Element {
           </div>
         )}
 
-        {/* Attachment button */}
-        <button
-          onClick={handleAttachFile}
-          disabled={isDisabled}
-          className="flex shrink-0 items-center justify-center p-3 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
-          title="Attach file"
-          aria-label="Attach file"
-        >
-          <Paperclip size={16} />
-        </button>
-
-        {/* Notes picker button */}
-        <button
-          onClick={() => setNotePickerOpen(true)}
-          className="flex shrink-0 items-center justify-center py-3 pr-3 text-neutral-500 hover:text-neutral-300 transition-colors"
-          title="Insert a saved note (Ctrl+Shift+P)"
-          aria-label="Insert a saved note"
-        >
-          <StickyNote size={16} />
-        </button>
-
         {/* Plan with Council button */}
         {councilEnabled && (
           <button
@@ -392,11 +375,11 @@ export function ChatInput(): React.JSX.Element {
               ? 'Pi agent is not running...'
               : isStreaming
                 ? 'Type to steer the agent...'
-                : 'Ask Pi anything... (Enter to send, Shift+Enter for newline)'
+                : 'Type / for commands'
           }
           disabled={isDisabled}
           rows={1}
-          className="font-chat max-h-48 min-h-[24px] flex-1 resize-none bg-transparent py-3 text-sm text-neutral-200 placeholder:text-neutral-600 outline-none disabled:opacity-50"
+          className="font-chat max-h-48 min-h-[24px] flex-1 resize-none bg-transparent py-3 pl-4 text-sm text-neutral-200 placeholder:text-neutral-600 outline-none disabled:opacity-50"
           onInput={(e) => {
             const target = e.currentTarget
             target.style.height = 'auto'
@@ -517,19 +500,42 @@ export function ChatInput(): React.JSX.Element {
         </div>
       </div>
 
-      {/* Keyboard shortcuts hint */}
-      <div className="mt-2 flex items-center justify-between text-xs text-neutral-600">
-        <div className="flex gap-3">
-          <span>Enter: send</span>
-          <span>Shift+Enter: newline</span>
-          <span>Esc: stop</span>
-          <span>Ctrl+P: model</span>
-          <span>Ctrl+Shift+F: search</span>
-          <span>Ctrl+Shift+P: notes</span>
-        </div>
-        {isStreaming && (
-          <span className="text-yellow-500 animate-pulse">Streaming...</span>
-        )}
+      {/* Composer actions */}
+      <div className="font-chat mt-2 flex items-center gap-0.5">
+        {/* Permission-mode shortcut — same modes as the review panel */}
+        <ComposerPermissionMenu value={permissionMode} onChange={setPermissionMode} />
+        <button
+          onClick={handleAttachFile}
+          disabled={isDisabled}
+          className="flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
+          title="Attach file"
+          aria-label="Attach file"
+        >
+          <Paperclip size={16} />
+        </button>
+        <button
+          onClick={() => setNotePickerOpen(true)}
+          className="flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+          title="Insert note (Ctrl+Shift+P)"
+          aria-label="Insert note"
+        >
+          <StickyNote size={16} />
+        </button>
+        <button
+          onClick={() => toggleFileSearch()}
+          className="flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+          title="Search workspace (Ctrl+Shift+F)"
+          aria-label="Search workspace"
+        >
+          <Search size={16} />
+        </button>
+        <span className="ml-auto text-xs text-neutral-600">
+          {isStreaming ? (
+            <span className="text-yellow-500 animate-pulse">Streaming...</span>
+          ) : (
+            'Shift+Enter for newline'
+          )}
+        </span>
       </div>
     </div>
   )

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -475,7 +475,7 @@ export function ChatInput(): React.JSX.Element {
           {isStreaming ? (
             <button
               onClick={handleAbort}
-              className="flex items-center justify-center rounded-lg p-2 text-neutral-500 hover:text-neutral-300 transition-colors"
+              className="pi-hover-highlight-strong flex items-center justify-center rounded-lg p-2 text-neutral-500 hover:text-neutral-300 transition-colors"
               title="Stop (Esc)"
               aria-label="Stop generating"
             >
@@ -490,7 +490,7 @@ export function ChatInput(): React.JSX.Element {
                 }
               }}
               disabled={isDisabled}
-              className="flex items-center justify-center rounded-lg p-2 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="pi-hover-highlight-strong flex items-center justify-center rounded-lg p-2 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               title="Send (Enter)"
               aria-label="Send message"
             >
@@ -507,7 +507,7 @@ export function ChatInput(): React.JSX.Element {
         <button
           onClick={handleAttachFile}
           disabled={isDisabled}
-          className="flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
+          className="pi-hover-highlight-strong flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
           title="Attach file"
           aria-label="Attach file"
         >
@@ -515,7 +515,7 @@ export function ChatInput(): React.JSX.Element {
         </button>
         <button
           onClick={() => setNotePickerOpen(true)}
-          className="flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+          className="pi-hover-highlight-strong flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
           title="Insert note (Ctrl+Shift+P)"
           aria-label="Insert note"
         >
@@ -523,7 +523,7 @@ export function ChatInput(): React.JSX.Element {
         </button>
         <button
           onClick={() => toggleFileSearch()}
-          className="flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
+          className="pi-hover-highlight-strong flex items-center justify-center rounded-md p-1 text-neutral-500 hover:text-neutral-300 transition-colors"
           title="Search workspace (Ctrl+Shift+F)"
           aria-label="Search workspace"
         >

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -339,7 +339,7 @@ function ToolbarButton({
         'rounded p-1 transition-colors',
         active
           ? 'bg-neutral-800 text-neutral-200'
-          : 'text-neutral-500 hover:bg-neutral-800/50 hover:text-neutral-300'
+          : 'pi-hover-highlight text-neutral-500 hover:text-neutral-300'
       )}
       title={title}
     >

--- a/src/renderer/src/components/composer-permission-menu.tsx
+++ b/src/renderer/src/components/composer-permission-menu.tsx
@@ -2,7 +2,12 @@ import { useEffect, useRef, useState } from 'react'
 import { ChevronUp, Check } from 'lucide-react'
 import { clsx } from 'clsx'
 import type { PermissionMode } from '../../../shared/ipc-contracts'
-import { DEFAULT_PERMISSION_MODE, PERMISSION_MODE_OPTIONS, getPermissionModeLabel } from './permission-mode'
+import {
+  DEFAULT_PERMISSION_MODE,
+  PERMISSION_MODE_OPTIONS,
+  getPermissionModeLabel,
+  getPermissionModeDescription,
+} from './permission-mode'
 
 interface ComposerPermissionMenuProps {
   value: PermissionMode | null | undefined
@@ -53,7 +58,7 @@ export function ComposerPermissionMenu({ value, onChange }: ComposerPermissionMe
             ? 'bg-yellow-500/15 text-yellow-300 hover:bg-yellow-500/35 hover:text-yellow-200'
             : 'pi-hover-highlight text-neutral-300 hover:text-neutral-200'
         )}
-        title="Permission mode"
+        title={getPermissionModeDescription(mode).replace(/\.$/, '')}
       >
         {getPermissionModeLabel(mode)}
         <ChevronUp

--- a/src/renderer/src/components/composer-permission-menu.tsx
+++ b/src/renderer/src/components/composer-permission-menu.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronUp, Check } from 'lucide-react'
+import { clsx } from 'clsx'
+import type { PermissionMode } from '../../../shared/ipc-contracts'
+import { DEFAULT_PERMISSION_MODE, PERMISSION_MODE_OPTIONS, getPermissionModeLabel } from './permission-mode'
+
+interface ComposerPermissionMenuProps {
+  value: PermissionMode | null | undefined
+  onChange: (mode: PermissionMode) => Promise<void> | void
+}
+
+/**
+ * A compact, label-only permission-mode picker for the composer footer — a
+ * shortcut for the same modes offered in the review panel. The current mode
+ * shows as a plain label; the menu opens upward (the composer sits at the
+ * bottom of the window). Selecting a mode applies it via `onChange`, the same
+ * path the review panel uses.
+ */
+export function ComposerPermissionMenu({ value, onChange }: ComposerPermissionMenuProps): React.JSX.Element {
+  const [isOpen, setIsOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const mode = value ?? DEFAULT_PERMISSION_MODE
+  const isTrusted = mode === 'trusted'
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClick = (event: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(event.target as Node)) setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [isOpen])
+
+  const handleSelect = async (next: PermissionMode): Promise<void> => {
+    setSaving(true)
+    try {
+      await onChange(next)
+      setIsOpen(false)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        className={clsx(
+          'flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors',
+          isTrusted
+            ? 'bg-yellow-500/15 text-yellow-300 hover:bg-yellow-500/35 hover:text-yellow-200'
+            : 'pi-hover-highlight text-neutral-300 hover:text-neutral-200'
+        )}
+        title="Permission mode"
+      >
+        {getPermissionModeLabel(mode)}
+        <ChevronUp
+          size={12}
+          className={clsx(
+            'transition-transform',
+            isTrusted ? 'text-yellow-400/70' : 'text-neutral-500',
+            isOpen && 'rotate-180'
+          )}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full left-0 z-50 mb-1 min-w-[180px] rounded-lg border border-neutral-700 bg-neutral-950 py-1 shadow-xl shadow-black/40">
+          <div className="px-3 pb-0.5 pt-1 text-[11px] text-neutral-500">Mode</div>
+          {PERMISSION_MODE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              disabled={saving}
+              onClick={() => handleSelect(option.value)}
+              className="pi-hover-highlight flex w-full items-center justify-between gap-6 whitespace-nowrap px-3 py-1 text-left text-xs text-neutral-200 transition-colors disabled:opacity-60"
+            >
+              <span>{option.label}</span>
+              {option.value === mode && <Check size={12} className="shrink-0 text-neutral-400" />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/composer-permission-menu.tsx
+++ b/src/renderer/src/components/composer-permission-menu.tsx
@@ -68,7 +68,7 @@ export function ComposerPermissionMenu({ value, onChange }: ComposerPermissionMe
 
       {isOpen && (
         <div className="absolute bottom-full left-0 z-50 mb-1 min-w-[180px] rounded-lg border border-neutral-700 bg-neutral-950 py-1 shadow-xl shadow-black/40">
-          <div className="px-3 pb-0.5 pt-1 text-[11px] text-neutral-500">Mode</div>
+          <div className="px-3 pb-0.5 pt-1 text-[11px] text-neutral-500">Permissions</div>
           {PERMISSION_MODE_OPTIONS.map((option) => (
             <button
               key={option.value}

--- a/src/renderer/src/components/composer-permission-menu.tsx
+++ b/src/renderer/src/components/composer-permission-menu.tsx
@@ -56,7 +56,7 @@ export function ComposerPermissionMenu({ value, onChange }: ComposerPermissionMe
           'flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors',
           isTrusted
             ? 'bg-yellow-500/15 text-yellow-300 hover:bg-yellow-500/35 hover:text-yellow-200'
-            : 'pi-hover-highlight text-neutral-300 hover:text-neutral-200'
+            : 'pi-hover-highlight-strong text-neutral-300 hover:text-neutral-200'
         )}
         title={getPermissionModeDescription(mode).replace(/\.$/, '')}
       >

--- a/src/renderer/src/components/permission-mode.ts
+++ b/src/renderer/src/components/permission-mode.ts
@@ -45,3 +45,10 @@ export function isPermissionMode(value: unknown): value is PermissionMode {
 export function getPermissionModeLabel(mode: PermissionMode): string {
   return PERMISSION_MODE_OPTIONS.find((option) => option.value === mode)?.label ?? 'Ask before edits'
 }
+
+export function getPermissionModeDescription(mode: PermissionMode): string {
+  return (
+    PERMISSION_MODE_OPTIONS.find((option) => option.value === mode)?.description ??
+    'Pi will ask before file edits and shell commands that can change files.'
+  )
+}

--- a/src/renderer/src/components/permission-selector.tsx
+++ b/src/renderer/src/components/permission-selector.tsx
@@ -77,7 +77,7 @@ export function PermissionSelector({
               type="button"
               disabled={saving}
               onClick={() => handleSelect(option.value)}
-              className="flex w-full items-start gap-2 px-3 py-2 text-left transition-colors hover:bg-neutral-800 disabled:opacity-60"
+              className="pi-hover-highlight flex w-full items-start gap-2 px-3 py-2 text-left transition-colors disabled:opacity-60"
             >
               <span className="mt-0.5 w-4 shrink-0">
                 {option.value === mode && <Check size={13} className="text-emerald-400" />}

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -229,7 +229,7 @@ export function Sidebar(): React.JSX.Element {
       </div>
 
       {/* Navigation */}
-      <nav className="px-2 py-1">
+      <nav className="space-y-0.5 px-2 py-1">
         <SidebarItem
           icon={<Home size={14} />}
           label="Home"

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -182,7 +182,7 @@ export function Sidebar(): React.JSX.Element {
           'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
           isActive
             ? 'bg-neutral-800 text-neutral-200'
-            : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300'
+            : 'pi-hover-highlight text-neutral-400 hover:text-neutral-300'
         )}
       >
         <Clock size={12} className="shrink-0" />
@@ -592,7 +592,7 @@ function SidebarItem({
         'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
         active
           ? 'bg-neutral-800 text-neutral-100'
-          : 'text-neutral-400 hover:bg-neutral-800/50 hover:text-neutral-300'
+          : 'pi-hover-highlight text-neutral-400 hover:text-neutral-300'
       )}
     >
       {icon}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -16,6 +16,15 @@
    plain `:hover` so hover states work in the desktop window as intended. */
 @custom-variant hover (&:hover);
 
+/* Theme-aware hover highlight. Each theme remaps the base `bg-neutral-900`
+   class (its "current session" card surface) but NOT the `hover:bg-neutral-900`
+   variant, so a fixed hover shade would ignore the active theme. Elements that
+   should highlight to the theme's card color on hover use this utility, which
+   references the per-theme `--pi-highlight` token instead. */
+.pi-hover-highlight:hover {
+  background-color: var(--pi-highlight);
+}
+
 @theme {
   --color-app-bg: #0a0a0a;
   --color-app-surface: #141414;
@@ -39,6 +48,10 @@
 @layer base {
   :root {
     --color-bg-primary: #0a0a0a;
+    /* Hover/selected surface — matches this theme's "current session" card
+       (its bg-neutral-900). Referenced by the .pi-hover-highlight utility so
+       hover states track the theme instead of a fixed neutral shade. */
+    --pi-highlight: #171717;
     --color-bg-secondary: #141414;
     --color-bg-tertiary: #1c1c1c;
     --color-bg-elevated: #242424;
@@ -79,6 +92,7 @@
 
   .light {
     --color-bg-primary: #ffffff;
+    --pi-highlight: #f5f5f5;
     --color-bg-secondary: #f5f5f5;
     --color-bg-tertiary: #e5e5e5;
     --color-bg-elevated: #ffffff;
@@ -377,6 +391,7 @@
 @layer base {
   .nord {
     --color-bg-primary:         #2E3440;
+    --pi-highlight:             #3B4252;
     --color-bg-secondary:       #3B4252;
     --color-bg-tertiary:        #434C5E;
     --color-bg-elevated:        #4C566A;
@@ -474,6 +489,7 @@
 @layer base {
   .gruvbox {
     --color-bg-primary:         #282828;
+    --pi-highlight:             #3C3836;
     --color-bg-secondary:       #3C3836;
     --color-bg-tertiary:        #504945;
     --color-bg-elevated:        #665C54;
@@ -568,6 +584,7 @@
 @layer base {
   .breeze-dark {
     --color-bg-primary:         #232629;
+    --pi-highlight:             #31363b;
     --color-bg-secondary:       #31363b;
     --color-bg-tertiary:        #2A2E32;
     --color-bg-elevated:        #3f4347;
@@ -664,6 +681,7 @@
 @layer base {
   .breeze-claudius {
     --color-bg-primary:         #232629;
+    --pi-highlight:             #31363b;
     --color-bg-secondary:       #31363b;
     --color-bg-tertiary:        #2A2E32;
     --color-bg-elevated:        #3f4347;
@@ -768,6 +786,7 @@
 @layer base {
   .breeze-light {
     --color-bg-primary:         #ffffff;
+    --pi-highlight:             #f8f7f6;
     --color-bg-secondary:       #f8f7f6;
     --color-bg-tertiary:        #ebebeb;
     --color-bg-elevated:        #ffffff;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -25,6 +25,13 @@
   background-color: var(--pi-highlight);
 }
 
+/* A stronger step (each theme's `bg-neutral-800`) for hover targets that sit
+   ON a `bg-neutral-900` surface — e.g. the composer action buttons inside the
+   input box, where the plain `--pi-highlight` (neutral-900) would be invisible. */
+.pi-hover-highlight-strong:hover {
+  background-color: var(--pi-highlight-strong);
+}
+
 @theme {
   --color-app-bg: #0a0a0a;
   --color-app-surface: #141414;
@@ -52,6 +59,7 @@
        (its bg-neutral-900). Referenced by the .pi-hover-highlight utility so
        hover states track the theme instead of a fixed neutral shade. */
     --pi-highlight: #171717;
+    --pi-highlight-strong: #262626;
     --color-bg-secondary: #141414;
     --color-bg-tertiary: #1c1c1c;
     --color-bg-elevated: #242424;
@@ -93,6 +101,7 @@
   .light {
     --color-bg-primary: #ffffff;
     --pi-highlight: #f5f5f5;
+    --pi-highlight-strong: #e5e5e5;
     --color-bg-secondary: #f5f5f5;
     --color-bg-tertiary: #e5e5e5;
     --color-bg-elevated: #ffffff;
@@ -392,6 +401,7 @@
   .nord {
     --color-bg-primary:         #2E3440;
     --pi-highlight:             #3B4252;
+    --pi-highlight-strong:      #434C5E;
     --color-bg-secondary:       #3B4252;
     --color-bg-tertiary:        #434C5E;
     --color-bg-elevated:        #4C566A;
@@ -490,6 +500,7 @@
   .gruvbox {
     --color-bg-primary:         #282828;
     --pi-highlight:             #3C3836;
+    --pi-highlight-strong:      #504945;
     --color-bg-secondary:       #3C3836;
     --color-bg-tertiary:        #504945;
     --color-bg-elevated:        #665C54;
@@ -585,6 +596,7 @@
   .breeze-dark {
     --color-bg-primary:         #232629;
     --pi-highlight:             #31363b;
+    --pi-highlight-strong:      #3f4347;
     --color-bg-secondary:       #31363b;
     --color-bg-tertiary:        #2A2E32;
     --color-bg-elevated:        #3f4347;
@@ -682,6 +694,7 @@
   .breeze-claudius {
     --color-bg-primary:         #232629;
     --pi-highlight:             #31363b;
+    --pi-highlight-strong:      #3f4347;
     --color-bg-secondary:       #31363b;
     --color-bg-tertiary:        #2A2E32;
     --color-bg-elevated:        #3f4347;
@@ -787,6 +800,7 @@
   .breeze-light {
     --color-bg-primary:         #ffffff;
     --pi-highlight:             #f8f7f6;
+    --pi-highlight-strong:      #ebebeb;
     --color-bg-secondary:       #f8f7f6;
     --color-bg-tertiary:        #ebebeb;
     --color-bg-elevated:        #ffffff;


### PR DESCRIPTION
> ⚠️ **Stacked on #34** (`fix/hover-polish`). Please merge **#34 first** — this branch reuses its `--pi-highlight` theme token for the new menu's hover. Until #34 merges, the diff below also includes that PR's `index.css` commit; afterward it reduces to the composer changes only (`chat-input.tsx` + `composer-permission-menu.tsx`).

## What
Reworks the chat composer footer for a cleaner, quieter look, and adds a per-session permission-mode shortcut.

**Before:** the input row carried the Attach and Notes buttons inline, and below it sat a strip of six keyboard hints (Enter / Shift+Enter / Esc / Ctrl+P / Ctrl+Shift+F / Ctrl+Shift+P).

**After:**
- The input box holds **only** the text field — no buttons crowding it.
- A single tidy actions row sits beneath it: a **permission-mode menu**, then **Attach**, **Notes**, and **Search** (opens the workspace file search, same as `Ctrl+Shift+F`) icon buttons.
- The six-hint strip collapses to one low-key, right-aligned **"Shift+Enter for newline"** tip (swaps to a "Streaming…" indicator while the agent responds). The search/notes shortcuts now live on their button tooltips.
- Placeholder trimmed from *"Ask Pi anything… (Enter to send, Shift+Enter for newline)"* to a simple **"Type / for commands"**.

## New: compact permission menu
`composer-permission-menu.tsx` — a compact, label-only picker for the same permission modes as the review panel, right where you type. It shows the current mode as a plain label and applies the choice for the session through the existing `setPermissionMode` path. Trusted mode is tinted yellow so an elevated permission level stays visible at a glance.

## Why
The old footer spent a lot of chrome on things that don't need permanent screen space: a wall of shortcut hints that turns into noise once learned, and action buttons wedged into the input field. Giving the buttons their own row and collapsing the hints to a single tip makes the composer calmer. Adding the permission menu was also the nudge for the move — rather than bolt another control onto an already-busy input row, all composer controls now sit **together** in one dedicated actions row, keeping related actions grouped and out of the text field. The net effect: the input is just for input, and the one control people reach for often — permission mode — is one click away without opening the review panel.

## Scope
- `chat-input.tsx` — footer restructure, placeholder, single tip, and the Attach/Notes/Search actions row.
- `composer-permission-menu.tsx` — new component.
- Hover states use the theme-aware `pi-hover-highlight` utility from the base branch (#34).
