### PR TITLE
feat: relative-time labels + parallel tool-call rendering fixes on chat messages

### DIFF
--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -5,6 +5,7 @@ import { MessageBubble, ToolGroupBubble } from './message-bubble'
 import { StreamingBubble } from './streaming-bubble'
 import { ChatSearch } from './chat-search'
 import { groupToolMessages, prepareChatMessages } from '../message-grouping'
+import { NowContext } from '../utils/relative-time'
 import { FileTree, FileSearch, FilePreview } from './file-tree'
 import { ImageViewer } from './image-viewer'
 import { DiffViewer } from './diff-viewer'
@@ -44,6 +45,14 @@ export function ChatPanel(): React.JSX.Element {
   const setSidePanel = useAppStore((state) => state.setChatSidePanel)
   const [sidePanelWidth, setSidePanelWidth] = useState(640)
   const [filePaneWidth, setFilePaneWidth] = useState(280)
+
+  // One shared clock for all relative-time labels — refresh every 30s so
+  // "5 minutes ago" stays current without each label owning a timer.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 30_000)
+    return () => clearInterval(id)
+  }, [])
 
   const currentView = useAppStore((state) => state.currentView)
   const { scrollRef, onScroll, atBottom, scrollToBottom } = useChatScroll(currentView === 'chat')
@@ -165,6 +174,7 @@ export function ChatPanel(): React.JSX.Element {
               {messages.length === 0 && !isStreaming ? (
                 <EmptyState piStatus={piStatus} />
               ) : (
+                <NowContext.Provider value={now}>
                 <div className="mx-auto max-w-5xl px-4 py-6">
                   {renderItems.map((item) =>
                     item.kind === 'toolGroup' ? (
@@ -186,6 +196,7 @@ export function ChatPanel(): React.JSX.Element {
                     />
                   )}
                 </div>
+                </NowContext.Provider>
               )}
             </div>
 

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -211,7 +211,7 @@ function UserMessage({
             ref={editRef}
             value={editContent}
             onChange={(e) => onEditContentChange(e.target.value)}
-            className="font-chat w-full rounded-2xl rounded-br-md bg-[#323232] px-4 py-2.5 text-sm text-[#d7d7d7] resize-none min-h-[40px] max-h-48 outline-none"
+            className="font-chat w-full rounded-2xl rounded-br-md bg-neutral-800 px-4 py-2.5 text-sm text-neutral-200 resize-none min-h-[40px] max-h-48 outline-none"
             rows={1}
             onInput={(e) => {
               const t = e.currentTarget
@@ -243,7 +243,7 @@ function UserMessage({
   return (
     <div className="group mb-4 flex justify-end animate-fade-in">
       <div className="relative max-w-[80%]">
-        <div className="rounded-2xl rounded-br-md bg-[#323232] px-4 py-2.5 text-sm text-[#d7d7d7]">
+        <div className="rounded-2xl rounded-br-md bg-neutral-800 px-4 py-2.5 text-sm text-neutral-200">
           {message.attachments && message.attachments.length > 0 && (
             <div className={clsx('flex flex-wrap gap-2', message.content && 'mb-2')}>
               {message.attachments.map((attachment, index) => (
@@ -514,9 +514,9 @@ function AssistantMessage({
               under the tool-call box and splitting a run of grouped tool badges.
               Only shown when there's real response text — a tool-only message's
               content is just whitespace/newlines, which is truthy but has nothing
-              to copy/export. Always visible when shown. */}
+              to copy/export. Shown on hover only, matching the user-message actions. */}
           {message.content.trim() && (
-            <div className="mt-2 flex items-center gap-0.5">
+            <div className="mt-2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
               <ActionButton
                 icon={copied ? <Check size={11} /> : <Copy size={11} />}
                 onClick={onCopy}

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -325,6 +325,18 @@ function AssistantMessage({
   // in and repeating it per row would just be noise.
   const showModelHeader = !!message.model && !hideModelHeader
 
+  // A grouped thinking-only turn (thinking, no text, no tool calls). It sits
+  // between the call/result rows of a serial run; with the default mb-4 rhythm it
+  // ends up 16px from its neighbours, which reads as too airy for a bare
+  // "Thinking" toggle. Tighten it to 8px on both sides: pull it up 8px against the
+  // previous row's mb-4 (-mt-2) and give it an 8px bottom (mb-2) instead of mb-4.
+  const isGroupedPureThinking =
+    hideModelHeader &&
+    !!message.thinking &&
+    thinkingEnabled &&
+    message.content.trim().length === 0 &&
+    (message.toolCalls?.length ?? 0) === 0
+
   // A pure-tool turn (body is only tool calls): render every call on its own row
   // behind its own operation icon, so each call — including parallel calls in a
   // single turn — is labelled with the right glyph. Standalone (attributed) turns
@@ -423,7 +435,7 @@ function AssistantMessage({
   }
 
   return (
-    <div className="group mb-4 animate-fade-in">
+    <div className={clsx('group animate-fade-in', isGroupedPureThinking ? '-mt-2 mb-2' : 'mb-4')}>
       <div className="flex items-start gap-3">
         {/* Avatar — the Bot avatar for a prose turn, except inside a tool group
             (the group shows one shared header above) where it keeps an empty
@@ -456,9 +468,17 @@ function AssistantMessage({
             </div>
           )}
 
-          {/* Thinking block — gated by the Show Thinking setting */}
+          {/* Thinking block — gated by the Show Thinking setting. mb-2 only when a
+              body (text/tool calls) follows it; on a pure-thinking turn there's
+              nothing below, so the mb-2 would stack on the message's own mb-4 and
+              leave the block with a bigger gap below than above. */}
           {message.thinking && thinkingEnabled && (
-            <div className="thinking-hover mb-2">
+            <div
+              className={clsx(
+                'thinking-hover',
+                (message.content.trim().length > 0 || (message.toolCalls?.length ?? 0) > 0) && 'mb-2'
+              )}
+            >
               <div className="flex h-7 items-center gap-1">
                 <button
                   onClick={onToggleThinking}

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -18,6 +18,7 @@ import { LineNumberedCode } from './line-numbered-code'
 import { MarkdownRenderer } from './markdown-renderer'
 import { CopyButton } from './copy-button'
 import { useContextMenu, buildMessageContextMenu } from './context-menu'
+import { RelativeTime } from '../utils/relative-time'
 import { clsx } from 'clsx'
 import {
   Copy,
@@ -348,6 +349,8 @@ function AssistantMessage({
                   <span>${message.cost.toFixed(4)}</span>
                 </>
               )}
+              <span className="text-neutral-700">·</span>
+              <RelativeTime timestamp={message.timestamp} />
             </div>
             {message.thinking && thinkingEnabled && (
               <div className="thinking-hover mt-2">
@@ -432,6 +435,8 @@ function AssistantMessage({
                   <span>${message.cost.toFixed(4)}</span>
                 </>
               )}
+              <span className="text-neutral-700">·</span>
+              <RelativeTime timestamp={message.timestamp} />
             </div>
           )}
 
@@ -797,6 +802,7 @@ function ToolGroupBubbleImpl({
     }
   }
   const showSharedHeader = modelKeys.size === 1 && sharedModel !== undefined
+  const groupTimestamp = messages[messages.length - 1]?.timestamp
 
   return (
     <div className="group mb-4 animate-fade-in">
@@ -812,6 +818,12 @@ function ToolGroupBubbleImpl({
               <span>{sharedProvider}</span>
               <span className="text-neutral-700">·</span>
               <span>{modelDisplayName(sharedModel as string, customModels)}</span>
+              {groupTimestamp !== undefined && (
+                <>
+                  <span className="text-neutral-700">·</span>
+                  <RelativeTime timestamp={groupTimestamp} />
+                </>
+              )}
             </div>
           )}
           <div

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -325,58 +325,82 @@ function AssistantMessage({
   // in and repeating it per row would just be noise.
   const showModelHeader = !!message.model && !hideModelHeader
 
-  // Standalone tool call (attributed, not inside a group): render it like a group
-  // reads — the Bot avatar carries the provider · model header on its own row, and
-  // each tool-call box sits on its own row behind the operation icon. (Grouped
-  // rows have no header and fall through to the single-avatar layout below; the
-  // group already shows one shared Bot header above them.)
-  if (ToolIcon && showModelHeader) {
+  // A pure-tool turn (body is only tool calls): render every call on its own row
+  // behind its own operation icon, so each call — including parallel calls in a
+  // single turn — is labelled with the right glyph. Standalone (attributed) turns
+  // also show a Bot avatar + provider·model header; grouped turns omit the header
+  // (the group's shared header stands in) but keep the same per-row-icon layout so
+  // a single-call and a multi-call turn align identically.
+  if (ToolIcon) {
+    const showThinkingBlock = !!message.thinking && thinkingEnabled
+    const hasHeaderArea = showModelHeader || showThinkingBlock
     return (
       <div className="group mb-4 animate-fade-in">
-        {/* Header row: Bot avatar + provider · model, matching a prose turn. */}
-        <div className="flex items-start gap-3">
-          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
-            <Bot size={14} className="text-neutral-400" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex h-7 items-center gap-2 text-sm text-neutral-500">
-              <span>{message.provider}</span>
-              <span className="text-neutral-700">·</span>
-              <span>{modelDisplayName(message.model!, customModels)}</span>
-              {message.cost !== undefined && (
-                <>
-                  <span className="text-neutral-700">·</span>
-                  <span>${message.cost.toFixed(4)}</span>
-                </>
-              )}
-              <span className="text-neutral-700">·</span>
-              <RelativeTime timestamp={message.timestamp} />
-            </div>
-            {message.thinking && thinkingEnabled && (
-              <div className="thinking-hover mt-2">
-                <div className="flex h-7 items-center gap-1">
-                  <button
-                    onClick={onToggleThinking}
-                    className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-400 transition-colors"
-                  >
-                    <Brain size={12} />
-                    {showThinking ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    Thinking
-                  </button>
-                  <CopyButton text={message.thinking} className="thinking-copy-btn" />
-                </div>
-                {showThinking && (
-                  <div className="markdown-body font-sans italic text-sm text-neutral-400">
-                    <MarkdownRenderer content={message.thinking} />
-                  </div>
-                )}
+        {hasHeaderArea && (
+          <div className="flex items-start gap-3">
+            {/* Bot avatar for an attributed turn; a spacer inside a group so the
+                header/thinking content still lines up with the tool rows. */}
+            {showModelHeader ? (
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
+                <Bot size={14} className="text-neutral-400" />
               </div>
+            ) : (
+              <div className="h-7 w-7 shrink-0" />
             )}
+            <div className="min-w-0 flex-1">
+              {showModelHeader && (
+                <div className="flex h-7 items-center gap-2 text-sm text-neutral-500">
+                  <span>{message.provider}</span>
+                  <span className="text-neutral-700">·</span>
+                  <span>{modelDisplayName(message.model!, customModels)}</span>
+                  {message.cost !== undefined && (
+                    <>
+                      <span className="text-neutral-700">·</span>
+                      <span>${message.cost.toFixed(4)}</span>
+                    </>
+                  )}
+                  <span className="text-neutral-700">·</span>
+                  <RelativeTime timestamp={message.timestamp} />
+                </div>
+              )}
+              {showThinkingBlock && (
+                // Grouped case: the group body already adds mt-4 (16px) above the
+                // first row; pull the thinking block up by 8px so it sits 8px below
+                // the group header — evenly matching its 8px gap to the tool rows.
+                <div className={clsx('thinking-hover', showModelHeader ? 'mt-2' : '-mt-2')}>
+                  <div className="flex h-7 items-center gap-1">
+                    <button
+                      onClick={onToggleThinking}
+                      className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-400 transition-colors"
+                    >
+                      <Brain size={12} />
+                      {showThinking ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                      Thinking
+                    </button>
+                    <CopyButton text={message.thinking!} className="thinking-copy-btn" />
+                  </div>
+                  {showThinking && (
+                    <div className="markdown-body font-sans italic text-sm text-neutral-400">
+                      <MarkdownRenderer content={message.thinking!} />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
         {/* One row per tool-call box, each behind its own operation icon. mt-2
-            sets the header→first-box gap; space-y-1 the box-to-box gap. */}
-        <div className="mt-2 space-y-1">
+            sets the header→first-box gap; a grouped thinking block above uses the
+            tighter mt-1 so its gap to the tool rows matches its (pulled-up) gap to
+            the group header. space-y-4 keeps the box-to-box gap equal to the mb-4
+            rhythm between separate call/result rows, so parallel calls don't bunch
+            up. */}
+        <div
+          className={clsx(
+            'space-y-4',
+            showThinkingBlock && !showModelHeader ? 'mt-1' : hasHeaderArea && 'mt-2'
+          )}
+        >
           {message.toolCalls!.map((tc) => {
             const RowIcon = toolCallIconFor(tc.name)
             return (
@@ -401,19 +425,11 @@ function AssistantMessage({
   return (
     <div className="group mb-4 animate-fade-in">
       <div className="flex items-start gap-3">
-        {/* Avatar — a grouped tool row shows its operation icon; otherwise the Bot
-            avatar, except inside a tool group (the group shows one shared header
-            above) where a prose/thinking turn keeps an empty spacer so its body
-            stays aligned with the icon-avatared rows. */}
-        {ToolIcon ? (
-          // Center the icon on the tool-call box's header row (h-8 ≈ py-2 +
-          // text-xs) instead of top-aligning, so it lines up with the box text.
-          <div className="flex h-8 w-7 shrink-0 items-center justify-center">
-            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-neutral-800">
-              <ToolIcon size={14} className="text-neutral-500" />
-            </div>
-          </div>
-        ) : hideModelHeader ? (
+        {/* Avatar — the Bot avatar for a prose turn, except inside a tool group
+            (the group shows one shared header above) where it keeps an empty
+            spacer so its body stays aligned with the icon-avatared rows.
+            Pure-tool turns are handled earlier (each call gets its own icon). */}
+        {hideModelHeader ? (
           <div className="h-7 w-7 shrink-0" />
         ) : (
           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
@@ -498,7 +514,10 @@ function AssistantMessage({
           {/* Tool calls */}
           {message.toolCalls && message.toolCalls.length > 0 && (
             <div className={clsx(
-              'space-y-1',
+              // space-y-4 so parallel calls in one turn (multiple badges here) keep
+              // the same 16px rhythm as separate call/result rows (each mb-4),
+              // rather than bunching up ~4px apart.
+              'space-y-4',
               // Pad the top only when something actually renders above the tool
               // box — a visible model header, a thinking block, or response text.
               // A grouped tool row has no header (showModelHeader is false), so it

--- a/src/renderer/src/components/message-bubble.tsx
+++ b/src/renderer/src/components/message-bubble.tsx
@@ -346,73 +346,69 @@ function AssistantMessage({
   if (ToolIcon) {
     const showThinkingBlock = !!message.thinking && thinkingEnabled
     const hasHeaderArea = showModelHeader || showThinkingBlock
+    // The collapsible thinking block, reused in the attributed (header) layout and
+    // the grouped (padded-block) layout below.
+    const thinkingBlock = showThinkingBlock ? (
+      <div className="thinking-hover">
+        <div className="flex h-7 items-center gap-1">
+          <button
+            onClick={onToggleThinking}
+            className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-400 transition-colors"
+          >
+            <Brain size={12} />
+            {showThinking ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            Thinking
+          </button>
+          <CopyButton text={message.thinking!} className="thinking-copy-btn" />
+        </div>
+        {showThinking && (
+          <div className="markdown-body font-sans italic text-sm text-neutral-400">
+            <MarkdownRenderer content={message.thinking!} />
+          </div>
+        )}
+      </div>
+    ) : null
     return (
       <div className="group mb-4 animate-fade-in">
-        {hasHeaderArea && (
+        {/* Attributed (standalone) turn: Bot avatar + provider·model header, with
+            the thinking block tucked under it. */}
+        {showModelHeader && (
           <div className="flex items-start gap-3">
-            {/* Bot avatar for an attributed turn; a spacer inside a group so the
-                header/thinking content still lines up with the tool rows. */}
-            {showModelHeader ? (
-              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
-                <Bot size={14} className="text-neutral-400" />
-              </div>
-            ) : (
-              <div className="h-7 w-7 shrink-0" />
-            )}
+            <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-neutral-800">
+              <Bot size={14} className="text-neutral-400" />
+            </div>
             <div className="min-w-0 flex-1">
-              {showModelHeader && (
-                <div className="flex h-7 items-center gap-2 text-sm text-neutral-500">
-                  <span>{message.provider}</span>
-                  <span className="text-neutral-700">·</span>
-                  <span>{modelDisplayName(message.model!, customModels)}</span>
-                  {message.cost !== undefined && (
-                    <>
-                      <span className="text-neutral-700">·</span>
-                      <span>${message.cost.toFixed(4)}</span>
-                    </>
-                  )}
-                  <span className="text-neutral-700">·</span>
-                  <RelativeTime timestamp={message.timestamp} />
-                </div>
-              )}
-              {showThinkingBlock && (
-                // Grouped case: the group body already adds mt-4 (16px) above the
-                // first row; pull the thinking block up by 8px so it sits 8px below
-                // the group header — evenly matching its 8px gap to the tool rows.
-                <div className={clsx('thinking-hover', showModelHeader ? 'mt-2' : '-mt-2')}>
-                  <div className="flex h-7 items-center gap-1">
-                    <button
-                      onClick={onToggleThinking}
-                      className="flex items-center gap-1 text-sm text-neutral-500 hover:text-neutral-400 transition-colors"
-                    >
-                      <Brain size={12} />
-                      {showThinking ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                      Thinking
-                    </button>
-                    <CopyButton text={message.thinking!} className="thinking-copy-btn" />
-                  </div>
-                  {showThinking && (
-                    <div className="markdown-body font-sans italic text-sm text-neutral-400">
-                      <MarkdownRenderer content={message.thinking!} />
-                    </div>
-                  )}
-                </div>
-              )}
+              <div className="flex h-7 items-center gap-2 text-sm text-neutral-500">
+                <span>{message.provider}</span>
+                <span className="text-neutral-700">·</span>
+                <span>{modelDisplayName(message.model!, customModels)}</span>
+                {message.cost !== undefined && (
+                  <>
+                    <span className="text-neutral-700">·</span>
+                    <span>${message.cost.toFixed(4)}</span>
+                  </>
+                )}
+                <span className="text-neutral-700">·</span>
+                <RelativeTime timestamp={message.timestamp} />
+              </div>
+              {thinkingBlock && <div className="mt-2">{thinkingBlock}</div>}
             </div>
           </div>
         )}
-        {/* One row per tool-call box, each behind its own operation icon. mt-2
-            sets the header→first-box gap; a grouped thinking block above uses the
-            tighter mt-1 so its gap to the tool rows matches its (pulled-up) gap to
-            the group header. space-y-4 keeps the box-to-box gap equal to the mb-4
-            rhythm between separate call/result rows, so parallel calls don't bunch
-            up. */}
-        <div
-          className={clsx(
-            'space-y-4',
-            showThinkingBlock && !showModelHeader ? 'mt-1' : hasHeaderArea && 'mt-2'
-          )}
-        >
+        {/* Grouped turn: no header (the group's shared header stands in). Render the
+            thinking block as a plain padded block — pl-10 aligns it with the tool
+            badges (w-7 icon + gap-3), and controlling its own margins directly
+            (-mt-2 above vs the group's mt-4, the tool row's mt-2 below) keeps it
+            evenly 8px on both sides whether collapsed or expanded. Nesting it in the
+            icon-row flex (as the tool rows do) let the 28px icon spacer floor the
+            row height, so the gap below collapsed once the expanded text outgrew it. */}
+        {!showModelHeader && thinkingBlock && (
+          <div className="-mt-2 pl-10">{thinkingBlock}</div>
+        )}
+        {/* One row per tool-call box, each behind its own operation icon. mt-2 sets
+            the gap under the header/thinking area; space-y-4 keeps the box-to-box gap
+            equal to the mb-4 rhythm between separate call/result rows. */}
+        <div className={clsx('space-y-4', hasHeaderArea && 'mt-2')}>
           {message.toolCalls!.map((tc) => {
             const RowIcon = toolCallIconFor(tc.name)
             return (

--- a/src/renderer/src/message-parsing.ts
+++ b/src/renderer/src/message-parsing.ts
@@ -39,6 +39,24 @@ function generateFallbackId(): string {
   return `msg-${Date.now()}-${++fallbackMessageCounter}`
 }
 
+// Pi's session records store timestamps as ISO strings, but the RPC layer may
+// hand them back as epoch ms (or an ms string). Accept all three so relative-time
+// labels are correct for loaded history — a bare `Number(iso)` would be NaN and
+// silently fall back to "now", making every resumed message read as just-sent.
+function parseTimestamp(raw: unknown): number {
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    // Guard against epoch-seconds being read as 1970.
+    return raw < 1e12 ? raw * 1000 : raw
+  }
+  if (typeof raw === 'string' && raw.trim()) {
+    const asNumber = Number(raw)
+    if (Number.isFinite(asNumber)) return asNumber < 1e12 ? asNumber * 1000 : asNumber
+    const asDate = Date.parse(raw)
+    if (!Number.isNaN(asDate)) return asDate
+  }
+  return Date.now()
+}
+
 function extractTextContent(content: unknown): string {
   if (typeof content === 'string') return content
   if (Array.isArray(content)) {
@@ -85,7 +103,7 @@ export function parseAgentMessage(msg: unknown): DisplayMessage | null {
       id: String(m.id ?? generateFallbackId()),
       role: 'user',
       content: extractTextContent(m.content),
-      timestamp: Number(m.timestamp) || Date.now(),
+      timestamp: parseTimestamp(m.timestamp),
       attachments: extractImageAttachments(m.content),
     }
   }
@@ -115,7 +133,7 @@ export function parseAgentMessage(msg: unknown): DisplayMessage | null {
       id: String(m.id ?? generateFallbackId()),
       role: 'assistant',
       content: textParts.join(''),
-      timestamp: Number(m.timestamp) || Date.now(),
+      timestamp: parseTimestamp(m.timestamp),
       thinking: thinkingParts.length > 0 ? thinkingParts.join('') : undefined,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
       model: typeof m.model === 'string' ? m.model : undefined,
@@ -134,7 +152,7 @@ export function parseAgentMessage(msg: unknown): DisplayMessage | null {
       id: String(m.id ?? generateFallbackId()),
       role: 'toolResult',
       content: text,
-      timestamp: Number(m.timestamp) || Date.now(),
+      timestamp: parseTimestamp(m.timestamp),
       toolCallId: typeof m.toolCallId === 'string' ? m.toolCallId : undefined,
       toolName: typeof m.toolName === 'string' ? m.toolName : undefined,
     }

--- a/src/renderer/src/utils/format-relative-time.test.ts
+++ b/src/renderer/src/utils/format-relative-time.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { formatRelativeTime } from './format-relative-time'
+
+const SECOND = 1000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+// A fixed "now" so the absolute-date fallback is deterministic.
+const NOW = Date.parse('2026-07-12T12:00:00Z')
+const ago = (ms: number): string => formatRelativeTime(NOW - ms, NOW)
+
+test('sub-45s reads "just now" (incl. clock-skew future timestamps)', () => {
+  assert.equal(ago(0), 'just now')
+  assert.equal(ago(44 * SECOND), 'just now')
+  assert.equal(ago(-5 * SECOND), 'just now') // timestamp slightly in the future
+})
+
+test('minutes bucket (singular at the boundary)', () => {
+  assert.equal(ago(60 * SECOND), '1 minute ago')
+  assert.equal(ago(5 * MINUTE), '5 minutes ago')
+  assert.equal(ago(59 * MINUTE), '59 minutes ago')
+})
+
+test('hours bucket (singular at the boundary)', () => {
+  assert.equal(ago(HOUR), '1 hour ago')
+  assert.equal(ago(20 * HOUR), '20 hours ago')
+})
+
+test('yesterday, then days — never a unit coarser than days', () => {
+  assert.equal(ago(25 * HOUR), 'yesterday')
+  assert.equal(ago(3 * DAY), '3 days ago')
+  assert.equal(ago(29 * DAY), '29 days ago')
+})
+
+test('falls back to an absolute date beyond ~30 days', () => {
+  // "Mon D YYYY" — not "N days ago". Asserting the shape keeps this
+  // timezone-independent (the date parts render in local time).
+  const dateShape = /^[A-Z][a-z]{2} \d{1,2} \d{4}$/
+  assert.match(ago(30 * DAY), dateShape)
+  assert.match(ago(200 * DAY), dateShape)
+  assert.doesNotMatch(ago(29 * DAY), dateShape)
+})

--- a/src/renderer/src/utils/format-relative-time.ts
+++ b/src/renderer/src/utils/format-relative-time.ts
@@ -1,0 +1,27 @@
+const SECOND = 1000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+
+/**
+ * A friendly relative-time label capped at days — never a coarser unit than
+ * "days". Beyond ~30 days it falls back to an absolute date ("Jul 3 2026").
+ * Single unit only (no "1 hour 5 minutes"). `now` is passed in so a single
+ * shared ticker can drive every label (see `NowContext`).
+ */
+export function formatRelativeTime(timestamp: number, now: number): string {
+  const diff = now - timestamp
+  // Clock skew / not-yet timestamps: treat as just now rather than "in -3s".
+  if (diff < 45 * SECOND) return 'just now'
+  if (diff < 90 * SECOND) return '1 minute ago'
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)} minutes ago`
+  if (diff < 2 * HOUR) return '1 hour ago'
+  if (diff < DAY) return `${Math.floor(diff / HOUR)} hours ago`
+  if (diff < 2 * DAY) return 'yesterday'
+  if (diff < 30 * DAY) return `${Math.floor(diff / DAY)} days ago`
+
+  const d = new Date(timestamp)
+  return `${MONTHS[d.getMonth()]} ${d.getDate()} ${d.getFullYear()}`
+}

--- a/src/renderer/src/utils/relative-time.tsx
+++ b/src/renderer/src/utils/relative-time.tsx
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+import { formatRelativeTime } from './format-relative-time'
+
+export { formatRelativeTime }
+
+/**
+ * A single "now" value, refreshed on an interval by the chat panel, so all
+ * relative-time labels tick together without each one owning a timer.
+ */
+export const NowContext = createContext<number>(Date.now())
+
+/**
+ * Renders a relative-time label that re-renders on each tick of `NowContext`.
+ * Kept as a tiny leaf so the surrounding (heavier) message bubble does not
+ * re-render every 30s — only these labels do.
+ */
+export function RelativeTime({ timestamp }: { timestamp: number }): React.JSX.Element {
+  const now = useContext(NowContext)
+  return <span>{formatRelativeTime(timestamp, now)}</span>
+}


### PR DESCRIPTION
## What

Two related improvements to the assistant message header / tool-call rendering in the chat transcript.

### 1. Friendly relative-time labels

A human-friendly relative timestamp next to the `provider · model · cost` header on each assistant turn (and the grouped-run shared header): **5 minutes ago**, **1 hour ago**, **yesterday**, **3 days ago**.

| elapsed | label |
|---|---|
| < 45s | just now |
| < 60m | N minutes ago |
| < 24h | N hours ago |
| 24–48h | yesterday |
| < 30d | N days ago |
| ≥ 30d | absolute date (`Jul 3 2026`) |

- `utils/format-relative-time.ts` — pure formatter, unit-tested (`npx tsx --test`).
- `utils/relative-time.tsx` — `NowContext` + a tiny `<RelativeTime>` leaf. **One** `setInterval(30s)` in `ChatPanel` bumps a shared `now`; only the small label leaves re-render each tick, not the (heavier) message bubbles.
- `message-parsing.ts` — hardened `parseTimestamp()` accepting ISO strings **and** epoch numbers. The old `Number(m.timestamp) || Date.now()` turned ISO timestamps into `NaN`, so **loaded/resumed** messages all read "just now"; now they show correct ages.

### 2. Parallel tool-call rendering fixes

When a turn fires multiple tool calls in parallel (e.g. two `Fetch` calls), they render as sibling badges within one assistant message. Two bugs there:

- **Missing icons** — the grouped path drew a single shared avatar icon (from `toolCalls[0]`) plus bare badges, so the 2nd+ call had no icon. Now every pure-tool turn routes through the per-row-icon renderer, so **each** call gets its own `toolCallIconFor(tc.name)` glyph. Single-call turns are visually unchanged.
- **Uneven spacing** — parallel calls sat ~4px apart against the 16px rhythm of the surrounding call/result rows. Now `space-y-4` matches that rhythm, and a grouped thinking block above the calls is spaced evenly on both sides.

## Notes

- Renderer-only; no main-process / RPC / session-file changes.
- No hover tooltip on the timestamps (kept minimal); labels tick live every 30s.