### PR TITLE
feat(lan): remote chat server with mobile-friendly web UI

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -65,6 +65,7 @@ src/
 │   ├── archived-sessions.ts      # Archived session persistence
 │   ├── app-data-paths.ts         # Resolve app data directories
 │   ├── attachment-reader.ts      # Read chat attachments (image base64 / text)
+│   ├── lan-server.ts             # LAN HTTP + SSE remote chat server
 │   └── fs-errors.ts              # Friendly file-system error messages
 ├── preload/
 │   └── index.ts                  # contextBridge API
@@ -195,6 +196,12 @@ src/
 - Full ANSI/VT100 support including 256-color and true-color
 - Runs the user's shell directly — independent of the Pi process
 - PTY managed by `terminal-service.ts`; IPC channels relay input/output/resize
+
+### LAN Remote
+
+- Optional HTTP server (default port `4747`) so phones/other devices on the LAN can chat with the active Pi session
+- Token-authenticated mobile web UI under `resources/lan-web/` (SSE for live events)
+- Toggle/port/token in Settings → LAN Remote; copy a full URL with token for easy phone access
 
 ### Home / Activity Dashboard
 

--- a/resources/lan-web/app.js
+++ b/resources/lan-web/app.js
@@ -1,0 +1,364 @@
+/* Pi Desktop LAN remote — mobile chat client */
+;(() => {
+  const $ = (id) => document.getElementById(id)
+
+  const loginScreen = $('login')
+  const chatScreen = $('chat')
+  const tokenInput = $('token-input')
+  const loginBtn = $('login-btn')
+  const loginError = $('login-error')
+  const messagesEl = $('messages')
+  const promptEl = $('prompt')
+  const sendBtn = $('send-btn')
+  const abortBtn = $('abort-btn')
+  const logoutBtn = $('logout-btn')
+  const piStatusEl = $('pi-status')
+  const wsNameEl = $('ws-name')
+
+  const STORAGE_KEY = 'pi_lan_token'
+  let token = localStorage.getItem(STORAGE_KEY) || ''
+  let es = null
+  let streaming = false
+  let streamBubble = null
+
+  function authHeaders() {
+    return {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+  }
+
+  async function api(path, opts = {}) {
+    const res = await fetch(path, {
+      ...opts,
+      headers: { ...authHeaders(), ...(opts.headers || {}) },
+    })
+    const text = await res.text()
+    let data = null
+    try {
+      data = text ? JSON.parse(text) : null
+    } catch {
+      data = { raw: text }
+    }
+    if (!res.ok) {
+      const err = new Error((data && data.error) || res.statusText || 'Request failed')
+      err.status = res.status
+      err.data = data
+      throw err
+    }
+    return data
+  }
+
+  function showLogin(errMsg) {
+    chatScreen.hidden = true
+    loginScreen.hidden = false
+    if (errMsg) {
+      loginError.hidden = false
+      loginError.textContent = errMsg
+    } else {
+      loginError.hidden = true
+    }
+    if (es) {
+      es.close()
+      es = null
+    }
+  }
+
+  function showChat() {
+    loginScreen.hidden = true
+    chatScreen.hidden = false
+  }
+
+  function setStatus(text, cls) {
+    piStatusEl.textContent = text
+    piStatusEl.className = 'status ' + (cls || 'muted')
+  }
+
+  function scrollToBottom() {
+    messagesEl.scrollTop = messagesEl.scrollHeight
+  }
+
+  function addBubble(role, text, opts = {}) {
+    const div = document.createElement('div')
+    div.className = 'bubble ' + role + (opts.thinking ? ' thinking' : '')
+    if (opts.meta) {
+      const meta = document.createElement('div')
+      meta.className = 'meta'
+      meta.textContent = opts.meta
+      div.appendChild(meta)
+    }
+    const body = document.createElement('div')
+    body.className = 'body'
+    body.textContent = text
+    div.appendChild(body)
+    if (opts.streaming) {
+      const cur = document.createElement('span')
+      cur.className = 'stream-cursor'
+      body.appendChild(cur)
+    }
+    messagesEl.appendChild(div)
+    scrollToBottom()
+    return { root: div, body }
+  }
+
+  function extractTextFromMessage(msg) {
+    if (!msg || typeof msg !== 'object') return ''
+    const content = msg.content
+    if (typeof content === 'string') return content
+    if (!Array.isArray(content)) return ''
+    return content
+      .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+      .map((b) => b.text)
+      .join('')
+  }
+
+  function extractThinking(msg) {
+    if (!msg || !Array.isArray(msg.content)) return ''
+    return msg.content
+      .filter((b) => b && b.type === 'thinking' && typeof b.thinking === 'string')
+      .map((b) => b.thinking)
+      .join('')
+  }
+
+  async function loadMessages() {
+    messagesEl.innerHTML = ''
+    streamBubble = null
+    try {
+      const data = await api('/api/messages')
+      // Pi may return { messages: [...] } or nested data
+      const list =
+        (data && data.data && data.data.messages) ||
+        (data && data.messages) ||
+        (Array.isArray(data) ? data : [])
+      if (!Array.isArray(list) || list.length === 0) {
+        addBubble('system', 'No messages yet. Say hi.')
+        return
+      }
+      for (const msg of list) {
+        const role = msg.role === 'user' ? 'user' : msg.role === 'assistant' ? 'assistant' : 'system'
+        const thinking = extractThinking(msg)
+        if (thinking) addBubble('assistant', thinking, { thinking: true, meta: 'Thinking' })
+        const text = extractTextFromMessage(msg).trim()
+        if (text) {
+          const meta =
+            role === 'assistant' && (msg.model || msg.provider)
+              ? [msg.provider, msg.model].filter(Boolean).join(' · ')
+              : undefined
+          addBubble(role, text, { meta })
+        }
+      }
+    } catch (err) {
+      if (err.status === 401) {
+        logout('Session expired — sign in again')
+        return
+      }
+      addBubble('system', 'Could not load history: ' + err.message)
+    }
+  }
+
+  async function refreshStatus() {
+    try {
+      const data = await api('/api/status')
+      const st = data.pi && data.pi.status
+      if (data.workspace && data.workspace.name) {
+        wsNameEl.textContent = data.workspace.name
+      }
+      if (st === 'running') setStatus('Pi running', 'live')
+      else if (st === 'starting') setStatus('Pi starting…', 'busy')
+      else setStatus(st || 'stopped', st === 'error' ? 'err' : 'muted')
+    } catch (err) {
+      if (err.status === 401) logout('Unauthorized')
+      else setStatus('offline', 'err')
+    }
+  }
+
+  function connectEvents() {
+    if (es) es.close()
+    const url = '/api/events?token=' + encodeURIComponent(token)
+    es = new EventSource(url)
+    es.addEventListener('ready', () => {
+      setStatus('live', 'live')
+    })
+    es.addEventListener('pi', (ev) => {
+      let data
+      try {
+        data = JSON.parse(ev.data)
+      } catch {
+        return
+      }
+      handlePiEvent(data)
+    })
+    es.onerror = () => {
+      setStatus('reconnecting…', 'busy')
+    }
+  }
+
+  function handlePiEvent(ev) {
+    if (!ev || typeof ev !== 'object') return
+    const t = ev.type
+
+    if (t === 'status_change') {
+      if (ev.status === 'running') setStatus('Pi running', 'live')
+      else setStatus(String(ev.status || 'unknown'), ev.status === 'error' ? 'err' : 'muted')
+      return
+    }
+
+    if (t === 'agent_start') {
+      streaming = true
+      abortBtn.hidden = false
+      setStatus('working…', 'busy')
+      return
+    }
+
+    if (t === 'agent_end') {
+      streaming = false
+      abortBtn.hidden = true
+      if (streamBubble) {
+        const cur = streamBubble.body.querySelector('.stream-cursor')
+        if (cur) cur.remove()
+        streamBubble = null
+      }
+      setStatus('Pi running', 'live')
+      return
+    }
+
+    // Assistant stream deltas
+    if (t === 'message_update' || t === 'message_delta') {
+      const delta = ev.assistantMessageEvent
+      if (!delta) return
+      if (delta.type === 'text_delta' && typeof delta.delta === 'string') {
+        if (!streamBubble) {
+          streamBubble = addBubble('assistant', '', { streaming: true })
+        }
+        const cur = streamBubble.body.querySelector('.stream-cursor')
+        if (cur) {
+          streamBubble.body.insertBefore(document.createTextNode(delta.delta), cur)
+        } else {
+          streamBubble.body.appendChild(document.createTextNode(delta.delta))
+        }
+        scrollToBottom()
+      }
+      if (delta.type === 'thinking_delta' && typeof delta.delta === 'string') {
+        // Append to a dashed thinking bubble
+        let think = messagesEl.querySelector('.bubble.thinking.stream')
+        if (!think) {
+          const b = addBubble('assistant', delta.delta, { thinking: true, meta: 'Thinking' })
+          b.root.classList.add('stream')
+        } else {
+          think.querySelector('.body').textContent += delta.delta
+          scrollToBottom()
+        }
+      }
+      return
+    }
+
+    if (t === 'tool_execution_start') {
+      addBubble('system', 'Tool: ' + (ev.toolName || '…'))
+    }
+  }
+
+  async function sendPrompt() {
+    const message = promptEl.value.trim()
+    if (!message || streaming) return
+    promptEl.value = ''
+    autosize()
+    addBubble('user', message)
+    streaming = true
+    abortBtn.hidden = false
+    sendBtn.disabled = true
+    try {
+      await api('/api/prompt', { method: 'POST', body: JSON.stringify({ message }) })
+      setStatus('working…', 'busy')
+    } catch (err) {
+      streaming = false
+      abortBtn.hidden = true
+      addBubble('system', 'Send failed: ' + err.message)
+      if (err.status === 401) logout('Unauthorized')
+    } finally {
+      sendBtn.disabled = false
+    }
+  }
+
+  async function abort() {
+    try {
+      await api('/api/abort', { method: 'POST', body: '{}' })
+    } catch (err) {
+      addBubble('system', 'Abort failed: ' + err.message)
+    }
+  }
+
+  async function login() {
+    const t = tokenInput.value.trim()
+    if (!t) {
+      loginError.hidden = false
+      loginError.textContent = 'Token required'
+      return
+    }
+    loginBtn.disabled = true
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: t }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || 'Invalid token')
+      }
+      token = t
+      localStorage.setItem(STORAGE_KEY, token)
+      showChat()
+      await refreshStatus()
+      await loadMessages()
+      connectEvents()
+    } catch (err) {
+      showLogin(err.message)
+    } finally {
+      loginBtn.disabled = false
+    }
+  }
+
+  function logout(msg) {
+    token = ''
+    localStorage.removeItem(STORAGE_KEY)
+    showLogin(msg)
+  }
+
+  function autosize() {
+    promptEl.style.height = 'auto'
+    promptEl.style.height = Math.min(promptEl.scrollHeight, 140) + 'px'
+  }
+
+  // Wire UI
+  loginBtn.addEventListener('click', () => void login())
+  tokenInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') void login()
+  })
+  sendBtn.addEventListener('click', () => void sendPrompt())
+  abortBtn.addEventListener('click', () => void abort())
+  logoutBtn.addEventListener('click', () => logout())
+  promptEl.addEventListener('input', autosize)
+  promptEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void sendPrompt()
+    }
+  })
+
+  // Boot
+  if (token) {
+    showChat()
+    refreshStatus()
+      .then(() => loadMessages())
+      .then(() => connectEvents())
+      .catch(() => logout('Could not reconnect'))
+  } else {
+    showLogin()
+  }
+
+  // Prefill token from query for QR / deep links
+  const q = new URLSearchParams(location.search)
+  if (q.get('token') && !token) {
+    tokenInput.value = q.get('token')
+  }
+})()

--- a/resources/lan-web/index.html
+++ b/resources/lan-web/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#0a0a0a" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <title>Pi Remote</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="app">
+    <!-- Login -->
+    <section id="login" class="screen">
+      <div class="login-card">
+        <div class="logo">π</div>
+        <h1>Pi Remote</h1>
+        <p class="muted">Enter the access token from Pi Desktop → Settings → LAN Remote.</p>
+        <label class="field">
+          <span>Token</span>
+          <input id="token-input" type="password" autocomplete="current-password" placeholder="Paste token" />
+        </label>
+        <button id="login-btn" class="primary" type="button">Connect</button>
+        <p id="login-error" class="error" hidden></p>
+      </div>
+    </section>
+
+    <!-- Chat -->
+    <section id="chat" class="screen" hidden>
+      <header class="top-bar">
+        <div class="top-left">
+          <span class="logo-sm">π</span>
+          <div>
+            <div id="ws-name" class="title">Pi</div>
+            <div id="pi-status" class="status muted">connecting…</div>
+          </div>
+        </div>
+        <button id="logout-btn" class="ghost" type="button" title="Disconnect">✕</button>
+      </header>
+
+      <main id="messages" class="messages" aria-live="polite"></main>
+
+      <footer class="composer">
+        <textarea
+          id="prompt"
+          rows="1"
+          placeholder="Message Pi…"
+          enterkeyhint="send"
+        ></textarea>
+        <div class="composer-actions">
+          <button id="abort-btn" class="ghost danger" type="button" hidden>Stop</button>
+          <button id="send-btn" class="primary send" type="button" aria-label="Send">↑</button>
+        </div>
+      </footer>
+    </section>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/resources/lan-web/styles.css
+++ b/resources/lan-web/styles.css
@@ -1,0 +1,258 @@
+:root {
+  color-scheme: dark;
+  --bg: #0a0a0a;
+  --surface: #141414;
+  --card: #1c1c1c;
+  --border: #2a2a2a;
+  --text: #e5e5e5;
+  --muted: #a3a3a3;
+  --faint: #737373;
+  --accent: #3b82f6;
+  --accent-fg: #93c5fd;
+  --danger: #ef4444;
+  --success: #22c55e;
+  --radius: 16px;
+  --safe-b: env(safe-area-inset-bottom, 0px);
+  --safe-t: env(safe-area-inset-top, 0px);
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  -webkit-tap-highlight-color: transparent;
+}
+
+#app, .screen {
+  min-height: 100%;
+  min-height: 100dvh;
+}
+
+.screen { display: flex; flex-direction: column; }
+
+[hidden] { display: none !important; }
+
+.muted { color: var(--muted); font-size: 0.875rem; }
+.error { color: var(--danger); font-size: 0.875rem; margin-top: 0.75rem; }
+.ghost {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 1.1rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 10px;
+}
+.ghost:active { background: var(--card); }
+.ghost.danger { color: var(--danger); }
+
+.primary {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  width: 100%;
+}
+.primary:active { filter: brightness(0.92); }
+.primary:disabled { opacity: 0.45; }
+
+/* Login */
+#login {
+  align-items: center;
+  justify-content: center;
+  padding: calc(1.25rem + var(--safe-t)) 1.25rem calc(1.25rem + var(--safe-b));
+}
+.login-card {
+  width: min(100%, 400px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.75rem 1.25rem;
+}
+.logo {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 12px;
+  background: #1e3a5f;
+  color: var(--accent-fg);
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+.login-card h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.35rem;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 1.25rem 0 1rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+.field input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.85rem 0.9rem;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+/* Chat chrome */
+.top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: calc(0.65rem + var(--safe-t)) 0.75rem 0.65rem;
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.top-left { display: flex; align-items: center; gap: 0.65rem; min-width: 0; }
+.logo-sm {
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 9px;
+  background: #1e3a5f;
+  color: var(--accent-fg);
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.status { font-size: 0.75rem; }
+.status.live { color: var(--success); }
+.status.busy { color: #eab308; }
+.status.err { color: var(--danger); }
+
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.bubble {
+  max-width: 100%;
+  border-radius: 14px;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+.bubble.user {
+  align-self: flex-end;
+  background: #1e3a5f;
+  color: #dbeafe;
+  border-bottom-right-radius: 4px;
+  max-width: 92%;
+}
+.bubble.assistant {
+  align-self: stretch;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+.bubble.system {
+  align-self: center;
+  background: transparent;
+  color: var(--faint);
+  font-size: 0.8rem;
+  text-align: center;
+}
+.bubble.thinking {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 0.88rem;
+  border-style: dashed;
+}
+.bubble .meta {
+  font-size: 0.7rem;
+  color: var(--faint);
+  margin-bottom: 0.35rem;
+}
+.bubble .stream-cursor {
+  display: inline-block;
+  width: 0.45rem;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.composer {
+  position: sticky;
+  bottom: 0;
+  padding: 0.55rem 0.65rem calc(0.55rem + var(--safe-b));
+  background: color-mix(in srgb, var(--bg) 94%, transparent);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.composer textarea {
+  width: 100%;
+  resize: none;
+  max-height: 140px;
+  min-height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  padding: 0.7rem 0.85rem;
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.4;
+}
+.composer textarea:focus {
+  outline: none;
+  border-color: #3b82f680;
+}
+.composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.35rem;
+}
+.send {
+  width: auto;
+  min-width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 999px;
+  padding: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+@media (min-width: 640px) {
+  .messages { padding-left: max(0.85rem, calc(50% - 22rem)); padding-right: max(0.85rem, calc(50% - 22rem)); }
+  .composer { padding-left: max(0.65rem, calc(50% - 22rem)); padding-right: max(0.65rem, calc(50% - 22rem)); }
+}

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -53,6 +53,13 @@ import type {
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
 import { COUNCIL_AGENT_IDS, clampTimeoutSeconds } from '../shared/council-config'
 import { DEFAULT_SETTINGS } from '../shared/default-settings'
+import {
+  createLanServer,
+  generateLanToken,
+  DEFAULT_LAN_PORT,
+  type LanServer,
+} from './lan-server'
+import type { LanServerStatus } from '../shared/ipc-contracts'
 import type { CouncilAgentId, ConsensusMode, ConsultantResult } from '../shared/council-config'
 import { detectAgents } from './agent-detection'
 import { readAttachment } from './attachment-reader'
@@ -373,6 +380,7 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
   const archivedSessions = new ArchivedSessionsManager()
   const terminalService = new TerminalService()
   const notesManager = new NotesManager()
+  const lanServer: LanServer = createLanServer(workspaceManager)
 
   // Helper: get Pi manager for active workspace
   function getActivePi(): PiRpcManager {
@@ -389,6 +397,10 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
         win.webContents.send(channel, data)
       }
     }
+  }
+
+  function publishLan(event: unknown): void {
+    lanServer.publishPiEvent(event as PiRpcEvent)
   }
 
   // ─── Pi Process Lifecycle ───────────────────────────────────────────────
@@ -674,20 +686,97 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
 
   ipcMain.handle(IPC_CHANNELS.SETTINGS_SAVE, async (_event, settings: unknown) => {
     if (!isObject(settings)) throw new Error('settings must be an object')
-    await saveAppSettings(settings as Partial<AppSettings>)
+    const partial = settings as Partial<AppSettings>
+    // Ensure a token exists before enabling LAN remote.
+    if (partial.lanServerEnabled === true) {
+      const current = await loadAppSettings(workspaceManager)
+      if (!(partial.lanServerToken ?? current.lanServerToken)) {
+        partial.lanServerToken = generateLanToken()
+      }
+    }
+    await saveAppSettings(partial)
     // Reflect a "run on startup" change to the OS immediately (login item on
     // macOS/Windows, autostart entry on Linux). Only applied when the field is
     // part of this save to avoid redundant OS writes.
-    if ('runOnStartup' in settings) {
-      await applyRunOnStartup(Boolean((settings as Partial<AppSettings>).runOnStartup))
+    if ('runOnStartup' in partial) {
+      await applyRunOnStartup(Boolean(partial.runOnStartup))
     }
     // Reflect a "minimize to tray" change immediately: create/destroy the tray
     // icon so the close behavior matches the new setting without a restart.
-    if ('minimizeToTrayOnClose' in settings) {
-      setTrayEnabled(Boolean((settings as Partial<AppSettings>).minimizeToTrayOnClose))
+    if ('minimizeToTrayOnClose' in partial) {
+      setTrayEnabled(Boolean(partial.minimizeToTrayOnClose))
+    }
+    if (
+      'lanServerEnabled' in partial ||
+      'lanServerPort' in partial ||
+      'lanServerToken' in partial
+    ) {
+      const saved = await loadAppSettings(workspaceManager)
+      try {
+        await lanServer.applyConfig({
+          enabled: saved.lanServerEnabled,
+          port: saved.lanServerPort || DEFAULT_LAN_PORT,
+          token: saved.lanServerToken,
+        })
+      } catch (err) {
+        console.error('[lan] failed to apply config:', err)
+      }
     }
     return loadAppSettings(workspaceManager)
   })
+
+  // ─── LAN Remote ─────────────────────────────────────────────────────────
+
+  ipcMain.handle(IPC_CHANNELS.LAN_GET_STATUS, async (): Promise<LanServerStatus> => {
+    return lanServer.getStatus()
+  })
+
+  ipcMain.handle(IPC_CHANNELS.LAN_APPLY, async (_event, options?: unknown): Promise<LanServerStatus> => {
+    const current = await loadAppSettings(workspaceManager)
+    const opts = isObject(options) ? options as Partial<AppSettings> : {}
+    const enabled = typeof opts.lanServerEnabled === 'boolean' ? opts.lanServerEnabled : current.lanServerEnabled
+    const port = typeof opts.lanServerPort === 'number' ? opts.lanServerPort : current.lanServerPort
+    let token = typeof opts.lanServerToken === 'string' ? opts.lanServerToken : current.lanServerToken
+    if (enabled && !token) token = generateLanToken()
+    await saveAppSettings({
+      lanServerEnabled: enabled,
+      lanServerPort: port || DEFAULT_LAN_PORT,
+      lanServerToken: token,
+    })
+    return lanServer.applyConfig({
+      enabled,
+      port: port || DEFAULT_LAN_PORT,
+      token,
+    })
+  })
+
+  ipcMain.handle(IPC_CHANNELS.LAN_REGENERATE_TOKEN, async (): Promise<LanServerStatus> => {
+    const token = generateLanToken()
+    const current = await loadAppSettings(workspaceManager)
+    await saveAppSettings({ lanServerToken: token })
+    return lanServer.applyConfig({
+      enabled: current.lanServerEnabled,
+      port: current.lanServerPort || DEFAULT_LAN_PORT,
+      token,
+    })
+  })
+
+  // Start LAN server from saved settings (background; never blocks IPC setup).
+  void loadAppSettings(workspaceManager)
+    .then(async (settings) => {
+      if (!settings.lanServerEnabled) return
+      let token = settings.lanServerToken
+      if (!token) {
+        token = generateLanToken()
+        await saveAppSettings({ lanServerToken: token })
+      }
+      await lanServer.applyConfig({
+        enabled: true,
+        port: settings.lanServerPort || DEFAULT_LAN_PORT,
+        token,
+      })
+    })
+    .catch((err) => console.error('[lan] failed to start from settings:', err))
 
   // Reconcile the OS-level "run on startup" state with the saved preference on
   // launch. Self-healing: repairs a stale Linux autostart Exec path after an
@@ -1404,15 +1493,18 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
     piManager.on('event', (event: PiRpcEvent) => {
       if (isActiveManager(piManager)) {
         broadcast(IPC_CHANNELS.EVENT_PI, event)
+        publishLan(event)
       }
     })
 
     piManager.on('status-change', () => {
       if (isActiveManager(piManager)) {
-        broadcast(IPC_CHANNELS.EVENT_PI, {
+        const payload = {
           type: 'status_change',
           ...piManager.getStatus(),
-        })
+        }
+        broadcast(IPC_CHANNELS.EVENT_PI, payload)
+        publishLan(payload)
       }
     })
   })
@@ -1423,10 +1515,12 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
   const broadcastActiveStatus = (): void => {
     const pi = workspaceManager.getActivePiManager()
     if (!pi) return
-    broadcast(IPC_CHANNELS.EVENT_PI, {
+    const payload = {
       type: 'status_change',
       ...pi.getStatus(),
-    })
+    }
+    broadcast(IPC_CHANNELS.EVENT_PI, payload)
+    publishLan(payload)
   }
   workspaceManager.onActiveWorkspaceChanged(broadcastActiveStatus)
 

--- a/src/main/lan-server.test.ts
+++ b/src/main/lan-server.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  buildLanUrls,
+  generateLanToken,
+  listLanAddresses,
+  DEFAULT_LAN_PORT,
+} from './lan-server'
+
+test('generateLanToken returns a non-empty url-safe string', () => {
+  const a = generateLanToken()
+  const b = generateLanToken()
+  assert.ok(a.length >= 16)
+  assert.notEqual(a, b)
+  assert.match(a, /^[A-Za-z0-9_-]+$/)
+})
+
+test('buildLanUrls uses DEFAULT_LAN_PORT and http scheme', () => {
+  const urls = buildLanUrls(DEFAULT_LAN_PORT)
+  assert.ok(urls.length >= 1)
+  for (const u of urls) {
+    assert.ok(u.startsWith('http://'))
+    assert.ok(u.endsWith(`:${DEFAULT_LAN_PORT}`))
+  }
+})
+
+test('listLanAddresses returns only IPv4-looking strings', () => {
+  for (const addr of listLanAddresses()) {
+    assert.match(addr, /^\d{1,3}(\.\d{1,3}){3}$/)
+  }
+})

--- a/src/main/lan-server.ts
+++ b/src/main/lan-server.ts
@@ -1,0 +1,440 @@
+/**
+ * LAN remote access: HTTP + SSE so phones/other devices on the network can
+ * chat with the active Pi session. Static UI is served from resources/lan-web.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'http'
+import { networkInterfaces } from 'os'
+import { randomBytes } from 'crypto'
+import { createReadStream, existsSync, statSync } from 'fs'
+import { extname, join, normalize } from 'path'
+import { app } from 'electron'
+import type { WorkspaceManager } from './workspace-manager'
+import type { PiRpcManager } from './pi-rpc-manager'
+import type { PiRpcEvent } from '../shared/ipc-contracts'
+
+export const DEFAULT_LAN_PORT = 4747
+
+export interface LanServerConfig {
+  enabled: boolean
+  port: number
+  /** Shared secret; clients send Authorization: Bearer <token> or ?token= */
+  token: string
+}
+
+export interface LanServerStatus {
+  running: boolean
+  port: number
+  token: string
+  urls: string[]
+  error: string | null
+}
+
+type SseClient = {
+  res: ServerResponse
+  id: number
+}
+
+const MIME: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.json': 'application/json',
+  '.woff2': 'font/woff2',
+}
+
+export function generateLanToken(): string {
+  return randomBytes(18).toString('base64url')
+}
+
+/** IPv4 addresses on non-internal interfaces (LAN-facing). */
+export function listLanAddresses(): string[] {
+  const nets = networkInterfaces()
+  const out: string[] = []
+  for (const entries of Object.values(nets)) {
+    if (!entries) continue
+    for (const e of entries) {
+      if (e.family === 'IPv4' && !e.internal) out.push(e.address)
+    }
+  }
+  return out
+}
+
+export function buildLanUrls(port: number): string[] {
+  const addrs = listLanAddresses()
+  const hosts = addrs.length > 0 ? addrs : ['127.0.0.1']
+  return hosts.map((h) => `http://${h}:${port}`)
+}
+
+export function resolveLanWebRoot(): string {
+  // Packaged: extraResources → resources/lan-web
+  // Dev: repo resources/lan-web
+  const candidates = [
+    join(process.resourcesPath ?? '', 'resources', 'lan-web'),
+    join(app.getAppPath(), 'resources', 'lan-web'),
+    join(__dirname, '../../resources/lan-web'),
+    join(process.cwd(), 'resources', 'lan-web'),
+  ]
+  for (const dir of candidates) {
+    if (dir && existsSync(join(dir, 'index.html'))) return dir
+  }
+  return candidates[candidates.length - 1]
+}
+
+function readBody(req: IncomingMessage, limit = 2_000_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let size = 0
+    req.on('data', (c: Buffer) => {
+      size += c.length
+      if (size > limit) {
+        reject(new Error('Body too large'))
+        req.destroy()
+        return
+      }
+      chunks.push(c)
+    })
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    req.on('error', reject)
+  })
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const data = JSON.stringify(body)
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(data),
+    'Cache-Control': 'no-store',
+  })
+  res.end(data)
+}
+
+export class LanServer {
+  private server: Server | null = null
+  private config: LanServerConfig = {
+    enabled: false,
+    port: DEFAULT_LAN_PORT,
+    token: '',
+  }
+  private error: string | null = null
+  private sseClients = new Map<number, SseClient>()
+  private nextSseId = 1
+  private webRoot = resolveLanWebRoot()
+
+  constructor(private readonly workspaceManager: WorkspaceManager) {}
+
+  getStatus(): LanServerStatus {
+    const running = this.server !== null
+    return {
+      running,
+      port: this.config.port,
+      token: this.config.token,
+      urls: running ? buildLanUrls(this.config.port) : [],
+      error: this.error,
+    }
+  }
+
+  /** Apply settings; start/stop/restart as needed. */
+  async applyConfig(partial: Partial<LanServerConfig>): Promise<LanServerStatus> {
+    const next: LanServerConfig = {
+      enabled: partial.enabled ?? this.config.enabled,
+      port: partial.port ?? this.config.port,
+      token: partial.token ?? this.config.token,
+    }
+    if (!next.token) next.token = generateLanToken()
+    if (next.port < 1 || next.port > 65535) next.port = DEFAULT_LAN_PORT
+
+    const wasRunning = this.server !== null
+    const changed =
+      next.enabled !== this.config.enabled ||
+      next.port !== this.config.port ||
+      next.token !== this.config.token
+
+    this.config = next
+
+    if (!next.enabled) {
+      await this.stop()
+      return this.getStatus()
+    }
+
+    if (wasRunning && changed) await this.stop()
+    if (!this.server) await this.start()
+    return this.getStatus()
+  }
+
+  async start(): Promise<void> {
+    if (this.server) return
+    this.error = null
+    this.webRoot = resolveLanWebRoot()
+
+    const server = createServer((req, res) => {
+      void this.handle(req, res)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', (err: NodeJS.ErrnoException) => {
+        this.error = err.message
+        this.server = null
+        reject(err)
+      })
+      server.listen(this.config.port, '0.0.0.0', () => {
+        this.server = server
+        resolve()
+      })
+    })
+  }
+
+  async stop(): Promise<void> {
+    for (const client of this.sseClients.values()) {
+      try {
+        client.res.end()
+      } catch {
+        // ignore
+      }
+    }
+    this.sseClients.clear()
+
+    const server = this.server
+    this.server = null
+    if (!server) return
+
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve())
+    })
+  }
+
+  /** Forward active-workspace Pi events to SSE clients. */
+  publishPiEvent(event: PiRpcEvent | Record<string, unknown>): void {
+    if (this.sseClients.size === 0) return
+    const payload = `event: pi\ndata: ${JSON.stringify(event)}\n\n`
+    for (const [id, client] of this.sseClients) {
+      try {
+        client.res.write(payload)
+      } catch {
+        this.sseClients.delete(id)
+      }
+    }
+  }
+
+  private isAuthorized(req: IncomingMessage, url: URL): boolean {
+    const token = this.config.token
+    if (!token) return false
+    const header = req.headers.authorization
+    if (header?.startsWith('Bearer ') && header.slice(7) === token) return true
+    if (url.searchParams.get('token') === token) return true
+    // Cookie set by /api/login for browser convenience
+    const cookie = req.headers.cookie ?? ''
+    if (cookie.split(';').some((c) => c.trim() === `pi_lan_token=${token}`)) return true
+    return false
+  }
+
+  private getActivePi(): PiRpcManager | null {
+    return this.workspaceManager.getActivePiManager()
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const host = req.headers.host ?? `127.0.0.1:${this.config.port}`
+      const url = new URL(req.url ?? '/', `http://${host}`)
+      const path = url.pathname
+
+      // CORS for API (LAN browsers)
+      if (path.startsWith('/api/')) {
+        res.setHeader('Access-Control-Allow-Origin', '*')
+        res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type')
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+        if (req.method === 'OPTIONS') {
+          res.writeHead(204)
+          res.end()
+          return
+        }
+      }
+
+      if (path === '/api/health') {
+        sendJson(res, 200, { ok: true })
+        return
+      }
+
+      // Login page always public; sets cookie then redirects
+      if (path === '/api/login' && req.method === 'POST') {
+        const raw = await readBody(req)
+        let body: { token?: string } = {}
+        try {
+          body = JSON.parse(raw) as { token?: string }
+        } catch {
+          body = {}
+        }
+        if (body.token !== this.config.token) {
+          sendJson(res, 401, { error: 'Invalid token' })
+          return
+        }
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Set-Cookie': `pi_lan_token=${this.config.token}; Path=/; SameSite=Lax; HttpOnly`,
+        })
+        res.end(JSON.stringify({ ok: true }))
+        return
+      }
+
+      if (path.startsWith('/api/') && path !== '/api/login') {
+        if (!this.isAuthorized(req, url)) {
+          sendJson(res, 401, { error: 'Unauthorized' })
+          return
+        }
+      }
+
+      if (path === '/api/status' && req.method === 'GET') {
+        const pi = this.getActivePi()
+        const ws = this.workspaceManager.getActiveWorkspace()
+        sendJson(res, 200, {
+          pi: pi?.getStatus() ?? { status: 'stopped', pid: null, error: null },
+          workspace: ws ? { name: ws.name, path: ws.path } : null,
+        })
+        return
+      }
+
+      if (path === '/api/messages' && req.method === 'GET') {
+        const pi = this.getActivePi()
+        if (!pi) {
+          sendJson(res, 503, { error: 'Pi not running' })
+          return
+        }
+        try {
+          const result = await pi.sendCommand({ type: 'get_messages' })
+          sendJson(res, 200, result)
+        } catch (err) {
+          sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) })
+        }
+        return
+      }
+
+      if (path === '/api/prompt' && req.method === 'POST') {
+        const pi = this.getActivePi()
+        if (!pi) {
+          sendJson(res, 503, { error: 'Pi not running' })
+          return
+        }
+        const raw = await readBody(req)
+        let message = ''
+        try {
+          const body = JSON.parse(raw) as { message?: string }
+          message = typeof body.message === 'string' ? body.message : ''
+        } catch {
+          message = ''
+        }
+        if (!message.trim()) {
+          sendJson(res, 400, { error: 'message required' })
+          return
+        }
+        try {
+          const result = await pi.sendCommand({ type: 'prompt', message })
+          sendJson(res, 200, result ?? { ok: true })
+        } catch (err) {
+          sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) })
+        }
+        return
+      }
+
+      if (path === '/api/abort' && req.method === 'POST') {
+        const pi = this.getActivePi()
+        if (!pi) {
+          sendJson(res, 503, { error: 'Pi not running' })
+          return
+        }
+        try {
+          const result = await pi.sendCommand({ type: 'abort' })
+          sendJson(res, 200, result ?? { ok: true })
+        } catch (err) {
+          sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) })
+        }
+        return
+      }
+
+      if (path === '/api/events' && req.method === 'GET') {
+        if (!this.isAuthorized(req, url)) {
+          sendJson(res, 401, { error: 'Unauthorized' })
+          return
+        }
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache, no-transform',
+          Connection: 'keep-alive',
+          'Access-Control-Allow-Origin': '*',
+        })
+        res.write(`event: ready\ndata: ${JSON.stringify({ ok: true })}\n\n`)
+        const id = this.nextSseId++
+        this.sseClients.set(id, { res, id })
+        req.on('close', () => {
+          this.sseClients.delete(id)
+        })
+        return
+      }
+
+      // Static files (mobile UI). Auth optional for HTML shell so login can load;
+      // API still protected. Prefer requiring token for static in production LAN —
+      // we allow public static + cookie after login.
+      await this.serveStatic(req, res, path)
+    } catch (err) {
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) })
+      }
+    }
+  }
+
+  private async serveStatic(
+    _req: IncomingMessage,
+    res: ServerResponse,
+    pathname: string
+  ): Promise<void> {
+    let rel = pathname === '/' ? '/index.html' : pathname
+    rel = normalize(rel).replace(/^(\.\.[/\\])+/, '').replace(/^[/\\]+/, '')
+    if (rel.includes('..')) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+
+    const root = normalize(this.webRoot)
+    const filePath = normalize(join(root, rel))
+    const rootPrefix = root.endsWith('\\') || root.endsWith('/') ? root : root + (process.platform === 'win32' ? '\\' : '/')
+    const rootOk =
+      process.platform === 'win32'
+        ? filePath.toLowerCase().startsWith(rootPrefix.toLowerCase())
+        : filePath.startsWith(rootPrefix)
+    if (!rootOk) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+      // SPA fallback
+      const index = join(this.webRoot, 'index.html')
+      if (existsSync(index)) {
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+        createReadStream(index).pipe(res)
+        return
+      }
+      res.writeHead(404)
+      res.end('LAN web UI not found. Ensure resources/lan-web is packaged.')
+      return
+    }
+
+    const ext = extname(filePath).toLowerCase()
+    res.writeHead(200, { 'Content-Type': MIME[ext] ?? 'application/octet-stream' })
+    createReadStream(filePath).pipe(res)
+  }
+}
+
+let lanServerSingleton: LanServer | null = null
+
+export function getLanServer(): LanServer | null {
+  return lanServerSingleton
+}
+
+export function createLanServer(workspaceManager: WorkspaceManager): LanServer {
+  lanServerSingleton = new LanServer(workspaceManager)
+  return lanServerSingleton
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -48,6 +48,7 @@ import type {
   PermissionRulesExportResult,
   PermissionRulesWorkspaceStatus,
   PermissionRulesRemoveResult,
+  LanServerStatus,
 } from '../shared/ipc-contracts'
 import type { ThemeFile } from '../shared/theme/theme-file'
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
@@ -112,6 +113,13 @@ interface PiDesktopAPI {
   settings: {
     getAll(): Promise<AppSettings>
     save(settings: Partial<AppSettings>): Promise<AppSettings>
+  }
+
+  // LAN remote
+  lan: {
+    getStatus(): Promise<LanServerStatus>
+    apply(options?: Partial<AppSettings>): Promise<LanServerStatus>
+    regenerateToken(): Promise<LanServerStatus>
   }
 
   // Permission rules
@@ -311,6 +319,12 @@ const api: PiDesktopAPI = {
   settings: {
     getAll: () => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_GET_ALL),
     save: (settings) => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_SAVE, settings),
+  },
+
+  lan: {
+    getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.LAN_GET_STATUS),
+    apply: (options) => ipcRenderer.invoke(IPC_CHANNELS.LAN_APPLY, options),
+    regenerateToken: () => ipcRenderer.invoke(IPC_CHANNELS.LAN_REGENERATE_TOKEN),
   },
 
   permissionRules: {

--- a/src/renderer/src/components/settings-panel.tsx
+++ b/src/renderer/src/components/settings-panel.tsx
@@ -7,6 +7,7 @@ import type {
   CouncilConfig,
   PermissionRule,
   PermissionRulesScope,
+  LanServerStatus,
 } from '../../../shared/ipc-contracts'
 import type { ThemeFile } from '../../../shared/theme/theme-file'
 import { Settings, Save, RotateCcw, FolderOpen, Check, ChevronDown } from 'lucide-react'
@@ -76,6 +77,11 @@ export function SettingsPanel(): React.JSX.Element {
   const [openToHomeOnLaunch, setOpenToHomeOnLaunch] = useState(draft0.openToHomeOnLaunch ?? settings?.openToHomeOnLaunch ?? DEFAULT_SETTINGS.openToHomeOnLaunch)
   const [runOnStartup, setRunOnStartup] = useState(draft0.runOnStartup ?? settings?.runOnStartup ?? DEFAULT_SETTINGS.runOnStartup)
   const [minimizeToTrayOnClose, setMinimizeToTrayOnClose] = useState(draft0.minimizeToTrayOnClose ?? settings?.minimizeToTrayOnClose ?? DEFAULT_SETTINGS.minimizeToTrayOnClose)
+  const [lanEnabled, setLanEnabled] = useState(draft0.lanServerEnabled ?? settings?.lanServerEnabled ?? DEFAULT_SETTINGS.lanServerEnabled)
+  const [lanPort, setLanPort] = useState(String(draft0.lanServerPort ?? settings?.lanServerPort ?? DEFAULT_SETTINGS.lanServerPort))
+  const [lanStatus, setLanStatus] = useState<LanServerStatus | null>(null)
+  const [lanBusy, setLanBusy] = useState(false)
+  const [lanCopied, setLanCopied] = useState(false)
   const [permissionMode, setPermissionMode] = useState<PermissionMode>(
     draft0.permissionMode ?? settings?.permissionMode ?? DEFAULT_SETTINGS.permissionMode,
   )
@@ -208,8 +214,34 @@ export function SettingsPanel(): React.JSX.Element {
     setOpenToHomeOnLaunch(draft.openToHomeOnLaunch ?? settings.openToHomeOnLaunch)
     setRunOnStartup(draft.runOnStartup ?? settings.runOnStartup)
     setMinimizeToTrayOnClose(draft.minimizeToTrayOnClose ?? settings.minimizeToTrayOnClose)
+    setLanEnabled(draft.lanServerEnabled ?? settings.lanServerEnabled)
+    setLanPort(String(draft.lanServerPort ?? settings.lanServerPort))
     setPermissionMode(draft.permissionMode ?? settings.permissionMode)
+    void window.piDesktop.lan.getStatus().then(setLanStatus).catch(() => setLanStatus(null))
   }, [settings])
+
+  const refreshLanStatus = useCallback(async (): Promise<void> => {
+    try {
+      setLanStatus(await window.piDesktop.lan.getStatus())
+    } catch {
+      setLanStatus(null)
+    }
+  }, [])
+
+  const applyLan = async (patch: {
+    lanServerEnabled?: boolean
+    lanServerPort?: number
+  }): Promise<void> => {
+    setLanBusy(true)
+    try {
+      const status = await window.piDesktop.lan.apply(patch)
+      setLanStatus(status)
+      setLanEnabled(status.running || Boolean(patch.lanServerEnabled))
+      await loadSettings()
+    } finally {
+      setLanBusy(false)
+    }
+  }
 
   const handleSelectPath = async () => {
     const path = await window.piDesktop.system.openDialog({ title: 'Select Pi Executable', mode: 'file' })
@@ -772,6 +804,105 @@ export function SettingsPanel(): React.JSX.Element {
           >
             <Toggle checked={minimizeToTrayOnClose} onChange={(v) => { setMinimizeToTrayOnClose(v); void applyImmediate({ minimizeToTrayOnClose: v }) }} />
           </SettingsRow>
+        </SettingsSection>
+
+        <SettingsSection title="LAN Remote">
+          <SettingsRow
+            label="Enable LAN Server"
+            description="Serve a mobile-friendly chat UI on your local network so phones and other devices can talk to Pi"
+          >
+            <Toggle
+              checked={lanEnabled}
+              onChange={(v) => {
+                setLanEnabled(v)
+                void applyLan({ lanServerEnabled: v })
+              }}
+            />
+          </SettingsRow>
+          <SettingsRow label="Port" description="HTTP port (default 4747). Applied when you enable or save.">
+            <input
+              type="number"
+              min={1}
+              max={65535}
+              value={lanPort}
+              disabled={lanBusy}
+              onChange={(e) => setLanPort(e.target.value)}
+              onBlur={() => {
+                const n = Number(lanPort)
+                if (!Number.isFinite(n) || n < 1 || n > 65535) {
+                  setLanPort(String(DEFAULT_SETTINGS.lanServerPort))
+                  return
+                }
+                void applyLan({ lanServerPort: Math.floor(n), lanServerEnabled: lanEnabled })
+              }}
+              className="w-24 rounded-md border border-border bg-card px-2 py-1 text-sm text-primary"
+            />
+          </SettingsRow>
+          {(lanStatus?.running || lanEnabled) && (
+            <>
+              <SettingsRow label="Access URLs" description="Open one of these on your phone (same Wi‑Fi). Token is required." stack>
+                <div className="space-y-1.5 w-full">
+                  {(lanStatus?.urls ?? []).length === 0 ? (
+                    <p className="text-xs text-dim">Server not running yet.</p>
+                  ) : (
+                    lanStatus!.urls.map((url) => (
+                      <div key={url} className="flex items-center gap-2">
+                        <code className="min-w-0 flex-1 truncate rounded bg-card px-2 py-1 text-xs text-accent-fg">
+                          {url}
+                        </code>
+                        <button
+                          type="button"
+                          className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted hover:text-primary"
+                          onClick={async () => {
+                            const full = `${url}/?token=${encodeURIComponent(lanStatus?.token ?? '')}`
+                            await navigator.clipboard.writeText(full)
+                            setLanCopied(true)
+                            setTimeout(() => setLanCopied(false), 1500)
+                          }}
+                        >
+                          {lanCopied ? 'Copied' : 'Copy link'}
+                        </button>
+                      </div>
+                    ))
+                  )}
+                  {lanStatus?.error && (
+                    <p className="text-xs text-error">{lanStatus.error}</p>
+                  )}
+                </div>
+              </SettingsRow>
+              <SettingsRow label="Access Token" description="Required to use the remote UI. Keep this private on shared networks." stack>
+                <div className="flex w-full items-center gap-2">
+                  <code className="min-w-0 flex-1 truncate rounded bg-card px-2 py-1 text-xs text-secondary">
+                    {lanStatus?.token || settings?.lanServerToken || '—'}
+                  </code>
+                  <button
+                    type="button"
+                    disabled={lanBusy}
+                    className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted hover:text-primary"
+                    onClick={async () => {
+                      setLanBusy(true)
+                      try {
+                        const status = await window.piDesktop.lan.regenerateToken()
+                        setLanStatus(status)
+                        await loadSettings()
+                      } finally {
+                        setLanBusy(false)
+                      }
+                    }}
+                  >
+                    Rotate
+                  </button>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted hover:text-primary"
+                    onClick={() => void refreshLanStatus()}
+                  >
+                    Refresh
+                  </button>
+                </div>
+              </SettingsRow>
+            </>
+          )}
         </SettingsSection>
 
         {/* Multi-Agent Council Planning */}

--- a/src/shared/default-settings.ts
+++ b/src/shared/default-settings.ts
@@ -28,4 +28,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   minimizeToTrayOnClose: false,
   hasSeenTrayHint: false,
   council: DEFAULT_COUNCIL_CONFIG,
+  lanServerEnabled: false,
+  lanServerPort: 4747,
+  lanServerToken: '',
 }

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -54,6 +54,11 @@ export const IPC_CHANNELS = {
   SETTINGS_GET_ALL: 'settings:get-all',
   SETTINGS_SAVE: 'settings:save',
 
+  // LAN remote (phone / other devices on the network)
+  LAN_GET_STATUS: 'lan:get-status',
+  LAN_APPLY: 'lan:apply',
+  LAN_REGENERATE_TOKEN: 'lan:regenerate-token',
+
   // Permission rules
   PERMISSION_RULES_GET: 'permission-rules:get',
   PERMISSION_RULES_SET: 'permission-rules:set',
@@ -742,6 +747,20 @@ export interface AppSettings {
   hasSeenTrayHint: boolean
   // Multi-agent council planning configuration.
   council: CouncilConfig
+  // LAN remote access: HTTP server so phones/other devices can chat with Pi.
+  lanServerEnabled: boolean
+  lanServerPort: number
+  // Shared secret for the LAN remote UI. Generated on first enable if empty.
+  lanServerToken: string
+}
+
+/** Runtime status of the LAN remote HTTP server. */
+export interface LanServerStatus {
+  running: boolean
+  port: number
+  token: string
+  urls: string[]
+  error: string | null
 }
 
 // ─── Update Check Types ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Optional **LAN remote access** so you can use Pi from a phone or another machine on the same network.

- HTTP server in the main process (`src/main/lan-server.ts`), default port **4747**, bind `0.0.0.0`
- Token auth (Bearer / cookie / `?token=`); token auto-generated on first enable
- Mobile-first UI in `resources/lan-web/` (login, chat, streaming via SSE)
- Settings → **LAN Remote**: enable, port, URLs, copy link with token, rotate token
- Forwards active-workspace Pi events to connected mobile clients

## Security

- **Disabled by default**
- Shared secret required; do not share the token on untrusted networks
- Not a full replacement for the desktop app (chat-focused remote UI)

## Test plan

- [x] `npm run typecheck` / `lint` / `build`
- [x] `npx tsx --test src/main/lan-server.test.ts`
- [ ] Enable LAN Remote in Settings; open URL+token on a phone on the same Wi‑Fi
- [ ] Send a prompt; confirm streaming text appears
- [ ] Abort mid-run; rotate token and confirm old token fails

## Notes

- Targets **`Dev`** per CONTRIBUTING.
- By opening this PR I acknowledge the [CLA](https://github.com/FaqFirebase/pi-desktop/blob/master/CLA.md).