### PR TITLE
feat: drag-and-drop a folder to open it as a project

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -47,6 +47,7 @@ src/
 │   ├── package-filter.ts         # Tokenized catalog search, shared main+renderer
 │   ├── package-spec.ts           # Validate package specs before the Pi CLI runs
 │   ├── path-compare.ts           # Platform-aware path equality (win32 case-fold); main+renderer
+│   ├── folder-drop.ts            # Pure helpers for drag-drop folder → workspace
 │   ├── untrusted-data.ts         # Wrap file/agent text as a labeled untrusted-data block
 │   ├── pi-command.ts             # Slash-command filtering
 │   ├── fork-point.ts             # Fork/branch message helpers
@@ -147,6 +148,7 @@ src/
 - Default workspace: user's home directory
 - Workspace switcher in sidebar
 - Auto-creates workspace when switching to a session from a different project
+- **Drag-and-drop a folder** onto the window to open it as a project (create workspace if needed, switch, show Chat) — same path as File → Open Project
 
 ### Session Management
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1466,6 +1466,19 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
     throw new Error(`Invalid path name: ${name}`)
   })
 
+  /** Classify a filesystem path for drag-drop (folder → open as workspace). */
+  ipcMain.handle(IPC_CHANNELS.SYSTEM_PATH_KIND, async (_event, filePath: unknown) => {
+    if (!isString(filePath) || filePath.trim().length === 0) {
+      return { exists: false, isDirectory: false }
+    }
+    try {
+      const st = await stat(filePath)
+      return { exists: true, isDirectory: st.isDirectory() }
+    } catch {
+      return { exists: false, isDirectory: false }
+    }
+  })
+
   ipcMain.handle(IPC_CHANNELS.SYSTEM_OPEN_EXTERNAL, async (_event, url: unknown) => {
     if (!isString(url)) throw new Error('url must be a string')
     if (!url.startsWith('https://') && !url.startsWith('http://')) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import type {
   PiRpcEvent,
   PiStartOptions,
@@ -33,6 +33,7 @@ import type {
   CouncilProgressEvent,
   AttachmentReadResult,
   OpenDialogOptions,
+  PathKindResult,
   PromptImage,
   ActivityStatsResult,
   ThemesListResult,
@@ -222,6 +223,10 @@ interface PiDesktopAPI {
   system: {
     openDialog(options?: OpenDialogOptions): Promise<string | null>
     getPath(name: string): Promise<string>
+    /** Absolute path for a File from a drag-drop (Electron webUtils). */
+    getPathForFile(file: File): string
+    /** Whether a path exists and is a directory (folder open). */
+    pathKind(path: string): Promise<PathKindResult>
     openExternal(url: string): Promise<void>
     getVersion(): Promise<string>
     /**
@@ -430,6 +435,8 @@ const api: PiDesktopAPI = {
   system: {
     openDialog: (options) => ipcRenderer.invoke(IPC_CHANNELS.SYSTEM_OPEN_DIALOG, options),
     getPath: (name) => ipcRenderer.invoke(IPC_CHANNELS.SYSTEM_GET_PATH, name),
+    getPathForFile: (file) => webUtils.getPathForFile(file),
+    pathKind: (path) => ipcRenderer.invoke(IPC_CHANNELS.SYSTEM_PATH_KIND, path),
     // Sandboxed preload still has a process polyfill with platform.
     platform: process.platform,
     openExternal: (url) => ipcRenderer.invoke(IPC_CHANNELS.SYSTEM_OPEN_EXTERNAL, url),

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -100,7 +100,7 @@ export function App(): React.JSX.Element {
                 Drop folder to open as project
               </div>
               <div className="mt-1 text-sm text-dim">
-                A new workspace will be created at that path
+                Opens that folder as a workspace (creates one if needed)
               </div>
             </div>
           </div>

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -15,15 +15,17 @@ import { ExtensionUiDialog, AppConfirmDialog } from './components/extension-ui-d
 import { ReviewRail } from './components/review-rail'
 import { useContextMenu, buildDefaultContextMenu } from './components/context-menu'
 import { usePiEvents, useMenuActions, useInitialize, useNotePickerShortcut } from './hooks'
+import { useFolderDrop } from './hooks/use-folder-drop'
 import { useAppStore } from './store'
 import { useEffect } from 'react'
-import { ArrowUpCircle, PanelLeft, X } from 'lucide-react'
+import { ArrowUpCircle, FolderOpen, PanelLeft, X } from 'lucide-react'
 
 export function App(): React.JSX.Element {
   usePiEvents()
   useMenuActions()
   useInitialize()
   useNotePickerShortcut()
+  const { isDraggingFolder, dropBusy } = useFolderDrop()
 
   const currentView = useAppStore((state) => state.currentView)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
@@ -85,7 +87,27 @@ export function App(): React.JSX.Element {
   const showUpdateBanner = !!updateInfo?.updateAvailable && !updateDismissed
 
   return (
-    <div className="flex h-screen flex-col bg-app text-primary">
+    <div className="relative flex h-screen flex-col bg-app text-primary">
+      {(isDraggingFolder || dropBusy) && (
+        <div
+          className="pointer-events-none absolute inset-0 z-[100] flex items-center justify-center bg-app/80 backdrop-blur-sm"
+          aria-live="polite"
+        >
+          <div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-accent bg-surface/95 px-10 py-8 shadow-xl shadow-black/40">
+            <FolderOpen size={36} className="text-accent" />
+            <div className="text-center">
+              <div className="text-base font-semibold text-primary">
+                {dropBusy ? 'Opening project…' : 'Drop folder to open as project'}
+              </div>
+              <div className="mt-1 text-sm text-dim">
+                {dropBusy
+                  ? 'Creating workspace and starting Pi'
+                  : 'A new workspace will be created at that path'}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
       {showUpdateBanner && updateInfo && (
         <div className="flex shrink-0 items-center justify-center gap-3 bg-accent px-4 py-1.5 text-xs text-white">
           <ArrowUpCircle size={14} className="shrink-0" />

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -25,7 +25,7 @@ export function App(): React.JSX.Element {
   useMenuActions()
   useInitialize()
   useNotePickerShortcut()
-  const { isDraggingFolder, dropBusy } = useFolderDrop()
+  const { isDraggingFolder } = useFolderDrop()
 
   const currentView = useAppStore((state) => state.currentView)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
@@ -88,7 +88,7 @@ export function App(): React.JSX.Element {
 
   return (
     <div className="relative flex h-screen flex-col bg-app text-primary">
-      {(isDraggingFolder || dropBusy) && (
+      {isDraggingFolder && (
         <div
           className="pointer-events-none absolute inset-0 z-[100] flex items-center justify-center bg-app/80 backdrop-blur-sm"
           aria-live="polite"
@@ -97,12 +97,10 @@ export function App(): React.JSX.Element {
             <FolderOpen size={36} className="text-accent" />
             <div className="text-center">
               <div className="text-base font-semibold text-primary">
-                {dropBusy ? 'Opening project…' : 'Drop folder to open as project'}
+                Drop folder to open as project
               </div>
               <div className="mt-1 text-sm text-dim">
-                {dropBusy
-                  ? 'Creating workspace and starting Pi'
-                  : 'A new workspace will be created at that path'}
+                A new workspace will be created at that path
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/chat-project-picker.tsx
+++ b/src/renderer/src/components/chat-project-picker.tsx
@@ -3,6 +3,7 @@ import { clsx } from 'clsx'
 import { Check, ChevronDown, FolderOpen, Layers } from 'lucide-react'
 import { useAppStore } from '../store'
 import type { Workspace } from '../../../shared/ipc-contracts'
+import { workspaceNameFromFolderPath } from '../../../shared/folder-drop'
 import { pathsEqual } from '../../../shared/path-compare'
 
 /**
@@ -103,8 +104,7 @@ export function ChatProjectPicker(): React.JSX.Element {
     try {
       let ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, path))
       if (!ws) {
-        const name = path.split(/[\\/]/).filter(Boolean).pop() ?? path
-        await createWorkspace(name, path)
+        await createWorkspace(workspaceNameFromFolderPath(path), path)
         ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, path))
       }
       if (ws) await applySelection(ws.id)

--- a/src/renderer/src/components/home-screen.tsx
+++ b/src/renderer/src/components/home-screen.tsx
@@ -15,6 +15,8 @@ import piLogo from '../assets/pi-logo.svg'
 import { formatGitStatus } from './review-rail'
 import { StatsPanel } from './stats-panel'
 import type { GitFileStatus, SessionListItem } from '../../../shared/ipc-contracts'
+import { workspaceNameFromFolderPath } from '../../../shared/folder-drop'
+import { pathsEqual } from '../../../shared/path-compare'
 
 const MAX_RECENT_WORKSPACES = 6
 const MAX_RECENT_SESSIONS = 5
@@ -95,10 +97,10 @@ export function HomeInfoSummary({ compact }: { compact?: boolean }): React.JSX.E
     try {
       let targetId: string | undefined
       if (session.projectPath) {
-        let ws = useAppStore.getState().workspaces.find((w) => w.path === session.projectPath)
+        let ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, session.projectPath))
         if (!ws) {
           await createWorkspace(session.projectName, session.projectPath)
-          ws = useAppStore.getState().workspaces.find((w) => w.path === session.projectPath)
+          ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, session.projectPath))
         }
         targetId = ws?.id
       }
@@ -299,11 +301,10 @@ function HomeScreenInfo(): React.JSX.Element {
     if (!path) return
     setBusy(true)
     try {
-      let ws = useAppStore.getState().workspaces.find((w) => w.path === path)
+      let ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, path))
       if (!ws) {
-        const name = path.split(/[\\/]/).filter(Boolean).pop() ?? path
-        await createWorkspace(name, path)
-        ws = useAppStore.getState().workspaces.find((w) => w.path === path)
+        await createWorkspace(workspaceNameFromFolderPath(path), path)
+        ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, path))
       }
       if (ws) {
         if (!(await switchWorkspace(ws.id))) return

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -44,15 +44,8 @@ export function useMenuActions(): void {
           setCurrentView('settings') // Open settings where workspace creation lives
           break
         case 'menu:open-project': {
-          // Open dialog to select project folder
-          window.piDesktop.system.openDialog({ title: 'Open Project' }).then((path) => {
-            if (path) {
-              const name = path.split('/').pop() ?? path
-              useAppStore.getState().createWorkspace(name, path).then(() => {
-                const ws = useAppStore.getState().workspaces.find((w) => w.path === path)
-                if (ws) useAppStore.getState().switchWorkspace(ws.id)
-              })
-            }
+          void window.piDesktop.system.openDialog({ title: 'Open Project' }).then((path) => {
+            if (path) void useAppStore.getState().openFolderAsWorkspace(path)
           })
           break
         }

--- a/src/renderer/src/hooks/use-folder-drop.ts
+++ b/src/renderer/src/hooks/use-folder-drop.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { collectDroppedPaths, isFileDrag } from '../../../shared/folder-drop'
+import { useEffect, useRef, useState } from 'react'
+import { firstDroppedFolderPath, isFileDrag } from '../../../shared/folder-drop'
 import { useAppStore } from '../store'
 
 /**
@@ -19,12 +19,12 @@ export function useFolderDrop(): {
   /** Prevent stacking concurrent openFolderAsWorkspace calls; no overlay. */
   const openInFlight = useRef(false)
 
-  const clearDrag = useCallback((): void => {
-    dragDepth.current = 0
-    setIsDraggingFolder(false)
-  }, [])
-
   useEffect(() => {
+    const clearDrag = (): void => {
+      dragDepth.current = 0
+      setIsDraggingFolder(false)
+    }
+
     const onDragEnter = (e: DragEvent): void => {
       if (!isFileDrag(e.dataTransfer)) return
       e.preventDefault()
@@ -32,9 +32,9 @@ export function useFolderDrop(): {
       setIsDraggingFolder(true)
     }
 
-    const onDragLeave = (e: DragEvent): void => {
-      if (!isFileDrag(e.dataTransfer) && dragDepth.current === 0) return
-      e.preventDefault()
+    const onDragLeave = (): void => {
+      // Depth only increments for file drags; leave just unwinds the counter.
+      if (dragDepth.current === 0) return
       dragDepth.current = Math.max(0, dragDepth.current - 1)
       if (dragDepth.current === 0) setIsDraggingFolder(false)
     }
@@ -48,18 +48,15 @@ export function useFolderDrop(): {
     const onDrop = (e: DragEvent): void => {
       if (!isFileDrag(e.dataTransfer)) return
       e.preventDefault()
-      e.stopPropagation()
       // Dismiss overlay immediately — do not wait for workspace create/switch.
       clearDrag()
       if (!e.dataTransfer || openInFlight.current) return
 
-      const { paths } = collectDroppedPaths(e.dataTransfer, (file) =>
+      const folderPath = firstDroppedFolderPath(e.dataTransfer, (file) =>
         window.piDesktop.system.getPathForFile(file)
       )
-      if (paths.length === 0) return
+      if (!folderPath) return
 
-      // One folder per drop — multi-folder would stack ambiguous switches.
-      const folderPath = paths[0]
       openInFlight.current = true
       void useAppStore
         .getState()
@@ -79,7 +76,7 @@ export function useFolderDrop(): {
       window.removeEventListener('dragover', onDragOver)
       window.removeEventListener('drop', onDrop)
     }
-  }, [clearDrag])
+  }, [])
 
   return { isDraggingFolder }
 }

--- a/src/renderer/src/hooks/use-folder-drop.ts
+++ b/src/renderer/src/hooks/use-folder-drop.ts
@@ -6,16 +6,18 @@ import { useAppStore } from '../store'
  * Window-level folder drag-and-drop: drop a directory onto the app to open it
  * as a workspace (create if needed, switch, show Chat).
  *
+ * The drop overlay is only shown while dragging — it dismisses immediately on
+ * drop so the UI is not blocked while the workspace opens in the background.
+ *
  * Files (non-directories) are ignored so future attachment drops can coexist.
  */
 export function useFolderDrop(): {
   isDraggingFolder: boolean
-  dropBusy: boolean
 } {
   const [isDraggingFolder, setIsDraggingFolder] = useState(false)
-  const [dropBusy, setDropBusy] = useState(false)
   const dragDepth = useRef(0)
-  const busyRef = useRef(false)
+  /** Prevent stacking concurrent openFolderAsWorkspace calls; no overlay. */
+  const openInFlight = useRef(false)
 
   const clearDrag = useCallback((): void => {
     dragDepth.current = 0
@@ -47,8 +49,9 @@ export function useFolderDrop(): {
       if (!isFileDrag(e.dataTransfer)) return
       e.preventDefault()
       e.stopPropagation()
+      // Dismiss overlay immediately — do not wait for workspace create/switch.
       clearDrag()
-      if (!e.dataTransfer || busyRef.current) return
+      if (!e.dataTransfer || openInFlight.current) return
 
       const { paths } = collectDroppedPaths(e.dataTransfer, (file) =>
         window.piDesktop.system.getPathForFile(file)
@@ -57,14 +60,12 @@ export function useFolderDrop(): {
 
       // One folder per drop — multi-folder would stack ambiguous switches.
       const folderPath = paths[0]
-      busyRef.current = true
-      setDropBusy(true)
+      openInFlight.current = true
       void useAppStore
         .getState()
         .openFolderAsWorkspace(folderPath)
         .finally(() => {
-          busyRef.current = false
-          setDropBusy(false)
+          openInFlight.current = false
         })
     }
 
@@ -80,5 +81,5 @@ export function useFolderDrop(): {
     }
   }, [clearDrag])
 
-  return { isDraggingFolder, dropBusy }
+  return { isDraggingFolder }
 }

--- a/src/renderer/src/hooks/use-folder-drop.ts
+++ b/src/renderer/src/hooks/use-folder-drop.ts
@@ -1,0 +1,84 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { collectDroppedPaths, isFileDrag } from '../../../shared/folder-drop'
+import { useAppStore } from '../store'
+
+/**
+ * Window-level folder drag-and-drop: drop a directory onto the app to open it
+ * as a workspace (create if needed, switch, show Chat).
+ *
+ * Files (non-directories) are ignored so future attachment drops can coexist.
+ */
+export function useFolderDrop(): {
+  isDraggingFolder: boolean
+  dropBusy: boolean
+} {
+  const [isDraggingFolder, setIsDraggingFolder] = useState(false)
+  const [dropBusy, setDropBusy] = useState(false)
+  const dragDepth = useRef(0)
+  const busyRef = useRef(false)
+
+  const clearDrag = useCallback((): void => {
+    dragDepth.current = 0
+    setIsDraggingFolder(false)
+  }, [])
+
+  useEffect(() => {
+    const onDragEnter = (e: DragEvent): void => {
+      if (!isFileDrag(e.dataTransfer)) return
+      e.preventDefault()
+      dragDepth.current += 1
+      setIsDraggingFolder(true)
+    }
+
+    const onDragLeave = (e: DragEvent): void => {
+      if (!isFileDrag(e.dataTransfer) && dragDepth.current === 0) return
+      e.preventDefault()
+      dragDepth.current = Math.max(0, dragDepth.current - 1)
+      if (dragDepth.current === 0) setIsDraggingFolder(false)
+    }
+
+    const onDragOver = (e: DragEvent): void => {
+      if (!isFileDrag(e.dataTransfer)) return
+      e.preventDefault()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy'
+    }
+
+    const onDrop = (e: DragEvent): void => {
+      if (!isFileDrag(e.dataTransfer)) return
+      e.preventDefault()
+      e.stopPropagation()
+      clearDrag()
+      if (!e.dataTransfer || busyRef.current) return
+
+      const { paths } = collectDroppedPaths(e.dataTransfer, (file) =>
+        window.piDesktop.system.getPathForFile(file)
+      )
+      if (paths.length === 0) return
+
+      // One folder per drop — multi-folder would stack ambiguous switches.
+      const folderPath = paths[0]
+      busyRef.current = true
+      setDropBusy(true)
+      void useAppStore
+        .getState()
+        .openFolderAsWorkspace(folderPath)
+        .finally(() => {
+          busyRef.current = false
+          setDropBusy(false)
+        })
+    }
+
+    window.addEventListener('dragenter', onDragEnter)
+    window.addEventListener('dragleave', onDragLeave)
+    window.addEventListener('dragover', onDragOver)
+    window.addEventListener('drop', onDrop)
+    return () => {
+      window.removeEventListener('dragenter', onDragEnter)
+      window.removeEventListener('dragleave', onDragLeave)
+      window.removeEventListener('dragover', onDragOver)
+      window.removeEventListener('drop', onDrop)
+    }
+  }, [clearDrag])
+
+  return { isDraggingFolder, dropBusy }
+}

--- a/src/renderer/src/store-session-transitions.test.ts
+++ b/src/renderer/src/store-session-transitions.test.ts
@@ -17,6 +17,7 @@ let setActiveFailure: string | null = null
 let pendingPromptsFailure: string | null = null
 let pendingPromptsSnapshot: Record<string, number> = {}
 let activeWorkspaceResult: Workspace | null = null
+let workspaceListResult: Workspace[] = []
 
 const SESSION_PATH = '/tmp/session-b.jsonl'
 const FORK_ENTRY_ID = 'entry-7'
@@ -60,22 +61,55 @@ const piDesktopStub = {
     setActive: async (id: string) => {
       if (setActiveFailure) throw new Error(setActiveFailure)
       calls.push(`setActiveWorkspace:${id}`)
-      return { id, name: 'other', path: '/tmp/other', createdAt: 0, lastActiveAt: 0, color: '#000' }
+      const hit = workspaceListResult.find((w) => w.id === id)
+      if (hit) activeWorkspaceResult = hit
+      return hit ?? { id, name: 'other', path: '/tmp/other', createdAt: 0, lastActiveAt: 0, color: '#000' }
     },
-    list: async () => [],
+    list: async () => workspaceListResult,
     getActive: async () => activeWorkspaceResult,
     create: async (name: string, path: string) => {
       calls.push(`createWorkspace:${name}:${path}`)
-      return activeWorkspaceResult ?? WORKSPACE_ONE
+      // Mirror main: existing path activates that workspace.
+      const existing = workspaceListResult.find((w) => w.path === path)
+      if (existing) {
+        activeWorkspaceResult = existing
+        return existing
+      }
+      // Tests that pre-set getActive for create→activate without a prior list.
+      if (activeWorkspaceResult && activeWorkspaceResult.path === path) {
+        return activeWorkspaceResult
+      }
+      const created = {
+        id: `ws-new-${name}`,
+        name,
+        path,
+        createdAt: 0,
+        lastActiveAt: 0,
+        color: '#000',
+      }
+      workspaceListResult = [...workspaceListResult, created]
+      // First workspace becomes active; otherwise leave active alone.
+      if (!activeWorkspaceResult) activeWorkspaceResult = created
+      return created
     },
     remove: async (id: string) => {
       calls.push(`removeWorkspace:${id}`)
+    },
+  },
+  system: {
+    pathKind: async (filePath: string) => {
+      calls.push(`pathKind:${filePath}`)
+      return { exists: true, isDirectory: true }
     },
   },
   pi: {
     getStatus: async () => {
       if (getStatusFailure) throw new Error(getStatusFailure)
       return { status: 'stopped' as const, pid: null, error: null }
+    },
+    start: async () => {
+      calls.push('pi.start')
+      return { status: 'running' as const, pid: 1, error: null }
     },
   },
   ui: {
@@ -186,6 +220,7 @@ beforeEach(() => {
   pendingPromptsFailure = null
   pendingPromptsSnapshot = {}
   activeWorkspaceResult = null
+  workspaceListResult = []
   useAppStore.setState({
     isStreaming: false,
     streamingContent: '',
@@ -201,6 +236,9 @@ beforeEach(() => {
     extensionNotify: null,
     pendingPromptCounts: {},
     activeWorkspace: null,
+    workspaces: [],
+    piStatus: 'stopped',
+    currentView: 'home',
   })
 })
 
@@ -542,6 +580,8 @@ test('a create that main turns into an activation adopts the new workspace', asy
 test('a create that leaves the active workspace alone touches neither slot nor prompts', async () => {
   useAppStore.setState({ activeWorkspace: WORKSPACE_ONE, extensionUiRequest: EXTENSION_DIALOG })
   activeWorkspaceResult = WORKSPACE_ONE
+  // New path while one is already active — main does not switch away.
+  workspaceListResult = [WORKSPACE_ONE]
 
   await useAppStore.getState().createWorkspace(WORKSPACE_TWO.name, WORKSPACE_TWO.path)
 
@@ -551,6 +591,67 @@ test('a create that leaves the active workspace alone touches neither slot nor p
     false,
     'the workspace on screen did not change, so nothing needs replaying'
   )
+})
+
+// Regression: openFolderAsWorkspace must not treat "main activated the target on
+// create" as "we were already on that workspace". Skipping switchWorkspace leaves
+// the previous chat/messages and a stale piStatus that blocks starting the new Pi.
+test('openFolderAsWorkspace switches when the dropped folder is an existing other workspace', async () => {
+  workspaceListResult = [WORKSPACE_ONE, WORKSPACE_TWO]
+  activeWorkspaceResult = WORKSPACE_ONE
+  useAppStore.setState({
+    activeWorkspace: WORKSPACE_ONE,
+    workspaces: [WORKSPACE_ONE, WORKSPACE_TWO],
+    messages: [{ id: 'old', role: 'user', content: 'from workspace one', timestamp: 0 }],
+    piStatus: 'running',
+    currentView: 'home',
+  })
+
+  const ok = await useAppStore.getState().openFolderAsWorkspace(WORKSPACE_TWO.path)
+
+  assert.equal(ok, true)
+  assert.equal(
+    calls.includes(`setActiveWorkspace:${WORKSPACE_TWO.id}`),
+    true,
+    'must route through switchWorkspace so messages and Pi status resync'
+  )
+  assert.deepEqual(
+    useAppStore.getState().messages,
+    [],
+    'previous workspace chat must clear on switch'
+  )
+  assert.equal(useAppStore.getState().currentView, 'chat')
+  assert.equal(
+    useAppStore.getState().piStatus,
+    'running',
+    'switchWorkspace resyncs status then startPi can start the target manager'
+  )
+  // After create main already activated TWO; startPi still runs because status
+  // was resynced to stopped from getStatus before start.
+  assert.equal(calls.includes('pi.start'), true)
+})
+
+test('openFolderAsWorkspace skips switch when the dropped folder is already active', async () => {
+  workspaceListResult = [WORKSPACE_ONE, WORKSPACE_TWO]
+  activeWorkspaceResult = WORKSPACE_TWO
+  useAppStore.setState({
+    activeWorkspace: WORKSPACE_TWO,
+    workspaces: [WORKSPACE_ONE, WORKSPACE_TWO],
+    messages: [{ id: 'keep', role: 'user', content: 'already here', timestamp: 0 }],
+    piStatus: 'running',
+    currentView: 'home',
+  })
+
+  const ok = await useAppStore.getState().openFolderAsWorkspace(WORKSPACE_TWO.path)
+
+  assert.equal(ok, true)
+  assert.equal(
+    calls.some((c) => c.startsWith('setActiveWorkspace:')),
+    false,
+    're-dropping the current project must not tear down the session via switch'
+  )
+  assert.equal(useAppStore.getState().messages[0]?.id, 'keep')
+  assert.equal(useAppStore.getState().currentView, 'chat')
 })
 
 // ─── Boot/reload recovery ────────────────────────────────────────────────────

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -6,6 +6,8 @@ import type { PiCommand } from '../../shared/pi-command'
 import { normalizeForkMessages, type ForkPoint } from '../../shared/fork-point'
 import { buildLineageTree, type LineageNode } from '../../shared/session-lineage'
 import { clampSidebarWidth } from '../../shared/sidebar-width'
+import { workspaceNameFromFolderPath } from '../../shared/folder-drop'
+import { pathsEqual } from '../../shared/path-compare'
 import { validateModelsConfig, mergeModelsConfig, type ModelsConfig } from '../../shared/models-config'
 import {
   resolveActiveMembers,
@@ -413,6 +415,12 @@ interface AppActions {
   // Workspaces
   loadWorkspaces: () => Promise<void>
   createWorkspace: (name: string, path: string) => Promise<void>
+  /**
+   * Open a folder as a workspace (create if needed, switch into it, show Chat).
+   * Used by File → Open Project and by drag-dropping a folder onto the window.
+   * Resolves false if the still-working confirm was declined or switch failed.
+   */
+  openFolderAsWorkspace: (folderPath: string) => Promise<boolean>
   /**
    * Resolves false when the user declined the still-working warning, or the switch failed.
    * skipSessionLoad: when opening a specific session next, skip resume+history —
@@ -1762,6 +1770,46 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         content: `Create workspace error: ${err instanceof Error ? err.message : String(err)}`,
         timestamp: Date.now(),
       })
+    }
+  },
+
+  openFolderAsWorkspace: async (folderPath) => {
+    const trimmed = folderPath.trim()
+    if (!trimmed) return false
+    try {
+      const kind = await window.piDesktop.system.pathKind(trimmed)
+      if (!kind.exists || !kind.isDirectory) {
+        get().addMessage({
+          id: generateId(),
+          role: 'system',
+          content: `Cannot open as project — not a folder: ${trimmed}`,
+          timestamp: Date.now(),
+        })
+        get().setCurrentView('chat')
+        return false
+      }
+      const name = workspaceNameFromFolderPath(trimmed)
+      await get().createWorkspace(name, trimmed)
+      const ws = get().workspaces.find((w) => pathsEqual(w.path, trimmed))
+      if (!ws) return false
+      // Already active after create (duplicate path or first workspace): still
+      // ensure Chat is visible and Pi is running for that project.
+      if (get().activeWorkspace?.id === ws.id) {
+        get().setCurrentView('chat')
+        if (get().piStatus !== 'running') await get().startPi()
+        return true
+      }
+      const switched = await get().switchWorkspace(ws.id)
+      if (switched) get().setCurrentView('chat')
+      return switched
+    } catch (err) {
+      get().addMessage({
+        id: generateId(),
+        role: 'system',
+        content: `Open folder error: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      })
+      return false
     }
   },
 

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -1788,13 +1788,21 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         get().setCurrentView('chat')
         return false
       }
+      // Snapshot BEFORE create: main's createWorkspace activates an existing
+      // workspace for a duplicate path, which makes activeWorkspace look like
+      // the target after loadWorkspaces — even though we never ran
+      // switchWorkspace (messages/piStatus stay from the previous workspace).
+      const active = get().activeWorkspace
+      const wasAlreadyActive = active ? pathsEqual(active.path, trimmed) : false
       const name = workspaceNameFromFolderPath(trimmed)
       await get().createWorkspace(name, trimmed)
       const ws = get().workspaces.find((w) => pathsEqual(w.path, trimmed))
       if (!ws) return false
-      // Already active after create (duplicate path or first workspace): still
-      // ensure Chat is visible and Pi is running for that project.
-      if (get().activeWorkspace?.id === ws.id) {
+      // Only skip switchWorkspace when this folder was already the active
+      // project before the drop (re-drop / re-open current). First workspace
+      // and cross-workspace opens go through switchWorkspace for message clear,
+      // status resync, still-working confirm, and session load.
+      if (wasAlreadyActive) {
         get().setCurrentView('chat')
         if (get().piStatus !== 'running') await get().startPi()
         return true

--- a/src/shared/folder-drop.test.ts
+++ b/src/shared/folder-drop.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import {
-  collectDroppedPaths,
+  firstDroppedFolderPath,
   isFileDrag,
   workspaceNameFromFolderPath,
   type FileDragTransfer,
@@ -18,25 +18,25 @@ test('workspaceNameFromFolderPath falls back when empty-ish', () => {
   assert.equal(workspaceNameFromFolderPath(''), '')
 })
 
-test('isFileDrag detects Files type', () => {
-  assert.equal(isFileDrag({ types: ['Files'], files: { length: 0 } }), true)
-  assert.equal(isFileDrag({ types: ['text/plain'], files: { length: 0 } }), false)
+test('isFileDrag detects the Files type (Chromium array)', () => {
+  assert.equal(isFileDrag({ types: ['Files'] }), true)
+  assert.equal(isFileDrag({ types: ['text/plain'] }), false)
   assert.equal(isFileDrag(null), false)
 })
 
-test('collectDroppedPaths keeps directory entries only when entry API exists', () => {
+test('firstDroppedFolderPath returns the first directory entry path', () => {
   const dirFile = { name: 'proj' } as File
   const plainFile = { name: 'readme.md' } as File
   const items = [
     {
       kind: 'file',
-      webkitGetAsEntry: () => ({ isDirectory: true, isFile: false }),
-      getAsFile: () => dirFile,
+      webkitGetAsEntry: () => ({ isDirectory: false, isFile: true }),
+      getAsFile: () => plainFile,
     },
     {
       kind: 'file',
-      webkitGetAsEntry: () => ({ isDirectory: false, isFile: true }),
-      getAsFile: () => plainFile,
+      webkitGetAsEntry: () => ({ isDirectory: true, isFile: false }),
+      getAsFile: () => dirFile,
     },
   ]
   const dt: FileDragTransfer = {
@@ -46,28 +46,46 @@ test('collectDroppedPaths keeps directory entries only when entry API exists', (
       0: items[0],
       1: items[1],
     },
-    files: { length: 0 },
   }
 
   const paths = new Map<File, string>([
     [dirFile, '/tmp/proj'],
     [plainFile, '/tmp/readme.md'],
   ])
-  const result = collectDroppedPaths(dt, (f) => paths.get(f) ?? '')
-  assert.deepEqual(result.paths, ['/tmp/proj'])
-  assert.equal(result.hadNonDirectoryEntry, true)
+  assert.equal(
+    firstDroppedFolderPath(dt, (f) => paths.get(f) ?? ''),
+    '/tmp/proj'
+  )
 })
 
-test('collectDroppedPaths falls back to files when entry API is missing', () => {
+test('firstDroppedFolderPath uses getAsFile when webkitGetAsEntry is null', () => {
   const f = { name: 'maybe-dir' } as File
   const dt: FileDragTransfer = {
     types: ['Files'],
-    items: null,
-    files: {
+    items: {
       length: 1,
-      0: f,
+      0: {
+        kind: 'file',
+        webkitGetAsEntry: () => null,
+        getAsFile: () => f,
+      },
     },
   }
-  const result = collectDroppedPaths(dt, () => '/tmp/maybe-dir')
-  assert.deepEqual(result.paths, ['/tmp/maybe-dir'])
+  assert.equal(firstDroppedFolderPath(dt, () => '/tmp/maybe-dir'), '/tmp/maybe-dir')
+})
+
+test('firstDroppedFolderPath returns null when only files are present', () => {
+  const plainFile = { name: 'readme.md' } as File
+  const dt: FileDragTransfer = {
+    types: ['Files'],
+    items: {
+      length: 1,
+      0: {
+        kind: 'file',
+        webkitGetAsEntry: () => ({ isDirectory: false, isFile: true }),
+        getAsFile: () => plainFile,
+      },
+    },
+  }
+  assert.equal(firstDroppedFolderPath(dt, () => '/tmp/readme.md'), null)
 })

--- a/src/shared/folder-drop.test.ts
+++ b/src/shared/folder-drop.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  collectDroppedPaths,
+  isFileDrag,
+  workspaceNameFromFolderPath,
+  type FileDragTransfer,
+} from './folder-drop'
+
+test('workspaceNameFromFolderPath uses the last path segment', () => {
+  assert.equal(workspaceNameFromFolderPath('/home/alice/my-app'), 'my-app')
+  assert.equal(workspaceNameFromFolderPath('C:\\Users\\bob\\proj'), 'proj')
+  assert.equal(workspaceNameFromFolderPath('/home/alice/my-app/'), 'my-app')
+})
+
+test('workspaceNameFromFolderPath falls back when empty-ish', () => {
+  assert.equal(workspaceNameFromFolderPath('/'), '/')
+  assert.equal(workspaceNameFromFolderPath(''), '')
+})
+
+test('isFileDrag detects Files type', () => {
+  assert.equal(isFileDrag({ types: ['Files'], files: { length: 0 } }), true)
+  assert.equal(isFileDrag({ types: ['text/plain'], files: { length: 0 } }), false)
+  assert.equal(isFileDrag(null), false)
+})
+
+test('collectDroppedPaths keeps directory entries only when entry API exists', () => {
+  const dirFile = { name: 'proj' } as File
+  const plainFile = { name: 'readme.md' } as File
+  const items = [
+    {
+      kind: 'file',
+      webkitGetAsEntry: () => ({ isDirectory: true, isFile: false }),
+      getAsFile: () => dirFile,
+    },
+    {
+      kind: 'file',
+      webkitGetAsEntry: () => ({ isDirectory: false, isFile: true }),
+      getAsFile: () => plainFile,
+    },
+  ]
+  const dt: FileDragTransfer = {
+    types: ['Files'],
+    items: {
+      length: items.length,
+      0: items[0],
+      1: items[1],
+    },
+    files: { length: 0 },
+  }
+
+  const paths = new Map<File, string>([
+    [dirFile, '/tmp/proj'],
+    [plainFile, '/tmp/readme.md'],
+  ])
+  const result = collectDroppedPaths(dt, (f) => paths.get(f) ?? '')
+  assert.deepEqual(result.paths, ['/tmp/proj'])
+  assert.equal(result.hadNonDirectoryEntry, true)
+})
+
+test('collectDroppedPaths falls back to files when entry API is missing', () => {
+  const f = { name: 'maybe-dir' } as File
+  const dt: FileDragTransfer = {
+    types: ['Files'],
+    items: null,
+    files: {
+      length: 1,
+      0: f,
+    },
+  }
+  const result = collectDroppedPaths(dt, () => '/tmp/maybe-dir')
+  assert.deepEqual(result.paths, ['/tmp/maybe-dir'])
+})

--- a/src/shared/folder-drop.ts
+++ b/src/shared/folder-drop.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure helpers for opening a dragged folder as a workspace.
+ * Kept free of Electron/DOM globals so main, renderer, and tests share one path.
+ */
+
+/** Minimal shape of DataTransfer used by the drop helpers (no full DOM types). */
+export interface FileDragTransfer {
+  types: ArrayLike<string> | { contains?: (type: string) => boolean; [i: number]: string; length: number }
+  files: ArrayLike<{ name?: string }>
+  items?: ArrayLike<FileDragItem> | null
+}
+
+export interface FileDragItem {
+  kind: string
+  webkitGetAsEntry?: () => { isDirectory: boolean; isFile: boolean } | null
+  getAsFile: () => File | null
+}
+
+/** Display name for a workspace created from a folder path. */
+export function workspaceNameFromFolderPath(folderPath: string): string {
+  const name = folderPath.split(/[\\/]/).filter(Boolean).pop()
+  return name && name.length > 0 ? name : folderPath
+}
+
+/**
+ * Whether a DataTransfer looks like an OS file/folder drag (not internal
+ * text/HTML drags). Used to decide when to show the drop overlay and accept drops.
+ */
+export function isFileDrag(dataTransfer: FileDragTransfer | null | undefined): boolean {
+  if (!dataTransfer) return false
+  const types = dataTransfer.types
+  if (types && typeof (types as { contains?: (t: string) => boolean }).contains === 'function') {
+    if ((types as { contains: (t: string) => boolean }).contains('Files')) return true
+  }
+  if (types && typeof (types as ArrayLike<string>).length === 'number') {
+    for (let i = 0; i < (types as ArrayLike<string>).length; i++) {
+      if ((types as ArrayLike<string>)[i] === 'Files') return true
+    }
+  }
+  return dataTransfer.files.length > 0
+}
+
+/**
+ * Prefer directory entries from a drop. When webkitGetAsEntry is available,
+ * only directory entries are kept. Falls back to all File objects (caller must
+ * verify isDirectory via main) when entry API is missing.
+ */
+export function collectDroppedPaths(
+  dataTransfer: FileDragTransfer,
+  getPathForFile: (file: File) => string
+): { paths: string[]; hadNonDirectoryEntry: boolean } {
+  const paths: string[] = []
+  const seen = new Set<string>()
+  let hadNonDirectoryEntry = false
+
+  const items = dataTransfer.items
+  if (items && items.length > 0) {
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      if (item.kind !== 'file') continue
+      const entry =
+        typeof item.webkitGetAsEntry === 'function' ? item.webkitGetAsEntry() : null
+      if (entry) {
+        if (entry.isDirectory) {
+          const file = item.getAsFile()
+          if (!file) continue
+          const p = getPathForFile(file)
+          if (p && !seen.has(p)) {
+            seen.add(p)
+            paths.push(p)
+          }
+        } else if (entry.isFile) {
+          hadNonDirectoryEntry = true
+        }
+        continue
+      }
+      // No entry API — take the file and let main confirm directory-ness.
+      const file = item.getAsFile()
+      if (!file) continue
+      const p = getPathForFile(file)
+      if (p && !seen.has(p)) {
+        seen.add(p)
+        paths.push(p)
+      }
+    }
+    return { paths, hadNonDirectoryEntry }
+  }
+
+  for (let i = 0; i < dataTransfer.files.length; i++) {
+    const file = dataTransfer.files[i] as File
+    const p = getPathForFile(file)
+    if (p && !seen.has(p)) {
+      seen.add(p)
+      paths.push(p)
+    }
+  }
+  return { paths, hadNonDirectoryEntry }
+}

--- a/src/shared/folder-drop.ts
+++ b/src/shared/folder-drop.ts
@@ -1,12 +1,14 @@
 /**
  * Pure helpers for opening a dragged folder as a workspace.
  * Kept free of Electron/DOM globals so main, renderer, and tests share one path.
+ *
+ * Written for Chromium/Electron only: DataTransfer.types is a frozen string
+ * array with a "Files" entry for OS file drags.
  */
 
 /** Minimal shape of DataTransfer used by the drop helpers (no full DOM types). */
 export interface FileDragTransfer {
-  types: ArrayLike<string> | { contains?: (type: string) => boolean; [i: number]: string; length: number }
-  files: ArrayLike<{ name?: string }>
+  types: ArrayLike<string>
   items?: ArrayLike<FileDragItem> | null
 }
 
@@ -27,72 +29,50 @@ export function workspaceNameFromFolderPath(folderPath: string): string {
  * text/HTML drags). Used to decide when to show the drop overlay and accept drops.
  */
 export function isFileDrag(dataTransfer: FileDragTransfer | null | undefined): boolean {
-  if (!dataTransfer) return false
+  if (!dataTransfer?.types) return false
   const types = dataTransfer.types
-  if (types && typeof (types as { contains?: (t: string) => boolean }).contains === 'function') {
-    if ((types as { contains: (t: string) => boolean }).contains('Files')) return true
+  for (let i = 0; i < types.length; i++) {
+    if (types[i] === 'Files') return true
   }
-  if (types && typeof (types as ArrayLike<string>).length === 'number') {
-    for (let i = 0; i < (types as ArrayLike<string>).length; i++) {
-      if ((types as ArrayLike<string>)[i] === 'Files') return true
-    }
-  }
-  return dataTransfer.files.length > 0
+  return false
 }
 
 /**
- * Prefer directory entries from a drop. When webkitGetAsEntry is available,
- * only directory entries are kept. Falls back to all File objects (caller must
- * verify isDirectory via main) when entry API is missing.
+ * Absolute path of the first directory in a drop, or null if none.
+ *
+ * Prefer directory entries via webkitGetAsEntry. When that returns null for an
+ * item (some drag sources), fall back to getAsFile + getPathForFile and let
+ * main confirm directory-ness via pathKind.
  */
-export function collectDroppedPaths(
+export function firstDroppedFolderPath(
   dataTransfer: FileDragTransfer,
   getPathForFile: (file: File) => string
-): { paths: string[]; hadNonDirectoryEntry: boolean } {
-  const paths: string[] = []
-  const seen = new Set<string>()
-  let hadNonDirectoryEntry = false
-
+): string | null {
   const items = dataTransfer.items
-  if (items && items.length > 0) {
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i]
-      if (item.kind !== 'file') continue
-      const entry =
-        typeof item.webkitGetAsEntry === 'function' ? item.webkitGetAsEntry() : null
-      if (entry) {
-        if (entry.isDirectory) {
-          const file = item.getAsFile()
-          if (!file) continue
-          const p = getPathForFile(file)
-          if (p && !seen.has(p)) {
-            seen.add(p)
-            paths.push(p)
-          }
-        } else if (entry.isFile) {
-          hadNonDirectoryEntry = true
-        }
-        continue
-      }
-      // No entry API — take the file and let main confirm directory-ness.
+  if (!items || items.length === 0) return null
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item.kind !== 'file') continue
+
+    const entry =
+      typeof item.webkitGetAsEntry === 'function' ? item.webkitGetAsEntry() : null
+
+    if (entry) {
+      if (!entry.isDirectory) continue
       const file = item.getAsFile()
       if (!file) continue
       const p = getPathForFile(file)
-      if (p && !seen.has(p)) {
-        seen.add(p)
-        paths.push(p)
-      }
+      if (p) return p
+      continue
     }
-    return { paths, hadNonDirectoryEntry }
+
+    // webkitGetAsEntry can return null; take the path and let main verify dir.
+    const file = item.getAsFile()
+    if (!file) continue
+    const p = getPathForFile(file)
+    if (p) return p
   }
 
-  for (let i = 0; i < dataTransfer.files.length; i++) {
-    const file = dataTransfer.files[i] as File
-    const p = getPathForFile(file)
-    if (p && !seen.has(p)) {
-      seen.add(p)
-      paths.push(p)
-    }
-  }
-  return { paths, hadNonDirectoryEntry }
+  return null
 }

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -74,6 +74,7 @@ export const IPC_CHANNELS = {
   // System
   SYSTEM_OPEN_DIALOG: 'system:open-dialog',
   SYSTEM_GET_PATH: 'system:get-path',
+  SYSTEM_PATH_KIND: 'system:path-kind',
   SYSTEM_OPEN_EXTERNAL: 'system:open-external',
   SYSTEM_GET_VERSION: 'system:get-version',
   UPDATE_CHECK: 'update:check',
@@ -549,6 +550,12 @@ export interface OpenDialogOptions {
   title?: string
   mode?: 'file' | 'directory'
   filters?: Array<{ name: string; extensions: string[] }>
+}
+
+/** Result of SYSTEM_PATH_KIND (drag-drop folder open). */
+export interface PathKindResult {
+  exists: boolean
+  isDirectory: boolean
 }
 
 export type { SessionLineageRecord } from './session-lineage'


### PR DESCRIPTION
## Summary

- Drag a folder onto the Pi Desktop window to open it as a project (create workspace if needed, switch into it, show Chat)
- Same path as **File → Open Project** via shared `openFolderAsWorkspace`
- Overlay only while dragging — dismisses immediately on drop so create/switch is not blocked by blur
- Non-folder file drops are ignored (leaves room for future attachment drops)
- Directory verified in main (`system:path-kind`); path from drop via preload `webUtils.getPathForFile`

## Test plan

- [ ] Drag a project folder from Explorer onto the window → workspace created/switched, Chat opens
- [ ] Overlay appears while dragging and **disappears on drop** (not held until Pi starts)
- [ ] Drop the same folder again → reuses existing workspace (no duplicate)
- [ ] Drop a file (not folder) → ignored
- [ ] File → Open Project still works (same code path)
- [ ] While Pi is streaming, drop a folder → still-working confirm still gates switch
- [ ] `npm run typecheck` && `npm run lint` && `npx tsx --test src/shared/folder-drop.test.ts`
