### PR TITLE
fix(skills): cache and coalesce skill list scans to stop startup stall

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -24,6 +24,7 @@ import { readSessionMetadataCached } from './session-metadata'
 import { mapWithConcurrency } from './map-concurrent'
 import { readSessionLineage } from './session-lineage-reader'
 import { trimGetMessagesResponse } from './get-messages-trim'
+import { listSkills } from './skills-lister'
 import { activityStatsStore } from './activity-stats'
 import type {
   PiStartOptions,
@@ -1116,7 +1117,8 @@ export function registerIpcHandlers(workspaceManager: WorkspaceManager): void {
   ipcMain.handle(IPC_CHANNELS.SKILLS_LIST, async () => {
     const ws = workspaceManager.getActiveWorkspace()
     const cwd = ws?.path ?? process.cwd()
-    return listSkills(cwd)
+    const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? ''
+    return listSkills(cwd, homeDir)
   })
 
   ipcMain.handle(IPC_CHANNELS.COMMANDS_LIST, async () => {
@@ -1809,117 +1811,8 @@ async function updatePackage(spec: string | undefined, cwd: string): Promise<{ s
 // reads over the whole store and an injectable root to be testable.
 
 // ─── Skills Listing ──────────────────────────────────────────────────────────
-
-interface InstalledSkill {
-  name: string
-  description: string
-  path: string
-  source: string
-  enabled: boolean
-}
-
-async function listSkills(cwd: string): Promise<InstalledSkill[]> {
-  const skills: InstalledSkill[] = []
-  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? ''
-
-  // Global skills
-  const globalPaths = [
-    join(homeDir, '.pi', 'agent', 'skills'),
-    join(homeDir, '.agents', 'skills'),
-  ]
-
-  for (const skillsDir of globalPaths) {
-    await collectSkills(skillsDir, skills, 'global')
-  }
-
-  // Project skills
-  const projectPaths = [
-    join(cwd, '.pi', 'skills'),
-    join(cwd, '.agents', 'skills'),
-  ]
-
-  for (const skillsDir of projectPaths) {
-    await collectSkills(skillsDir, skills, 'project')
-  }
-
-  return skills
-}
-
-async function collectSkills(
-  dir: string,
-  skills: InstalledSkill[],
-  source: string
-): Promise<void> {
-  try {
-    if (!existsSync(dir)) return
-
-    const items = await readdir(dir, { withFileTypes: true })
-
-    for (const item of items) {
-      const fullPath = join(dir, item.name)
-
-      if (item.isFile() && item.name.endsWith('.md') && item.name !== 'SKILL.md') {
-        // Root .md file as individual skill
-        try {
-          const content = await readFile(fullPath, 'utf-8')
-          const parsed = parseSkillFrontmatter(content)
-          if (parsed) {
-            skills.push({
-              name: parsed.name,
-              description: parsed.description,
-              path: fullPath,
-              source,
-              enabled: true,
-            })
-          }
-        } catch {
-          // Skip unreadable files
-        }
-      } else if (item.isDirectory()) {
-        // Directory with SKILL.md
-        const skillFile = join(fullPath, 'SKILL.md')
-        if (existsSync(skillFile)) {
-          try {
-            const content = await readFile(skillFile, 'utf-8')
-            const parsed = parseSkillFrontmatter(content)
-            if (parsed) {
-              skills.push({
-                name: parsed.name,
-                description: parsed.description,
-                path: skillFile,
-                source,
-                enabled: true,
-              })
-            }
-          } catch {
-            // Skip unreadable files
-          }
-        }
-
-        // Recurse into subdirectories
-        await collectSkills(fullPath, skills, source)
-      }
-    }
-  } catch {
-    // Directory doesn't exist or isn't readable
-  }
-}
-
-function parseSkillFrontmatter(content: string): { name: string; description: string } | null {
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
-  if (!frontmatterMatch) return null
-
-  const frontmatter = frontmatterMatch[1]
-  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m)
-  const descMatch = frontmatter.match(/^description:\s*(.+)$/m)
-
-  if (!nameMatch || !descMatch) return null
-
-  return {
-    name: nameMatch[1].trim(),
-    description: descMatch[1].trim(),
-  }
-}
+// The recursive scan with bounded-concurrency reads and the startup-burst
+// cache live in ./skills-lister so they can be tested without Electron.
 
 // ─── App Settings Persistence ────────────────────────────────────────────────
 

--- a/src/main/skills-lister.test.ts
+++ b/src/main/skills-lister.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { collectSkills, listSkills, parseSkillFrontmatter, type InstalledSkill } from './skills-lister'
+
+function makeSkillDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'skills-lister-'))
+}
+
+const SKILL_MD = '---\nname: test-skill\ndescription: A test skill\n---\n# Body\n'
+
+async function writeSkill(root: string, rel: string, content: string): Promise<string> {
+  const full = join(root, rel)
+  await mkdir(join(full, '..'), { recursive: true })
+  await writeFile(full, content, 'utf-8')
+  return full
+}
+
+test('parseSkillFrontmatter extracts name and description', () => {
+  const parsed = parseSkillFrontmatter(SKILL_MD)
+  assert.deepEqual(parsed, { name: 'test-skill', description: 'A test skill' })
+})
+
+test('parseSkillFrontmatter returns null for files without frontmatter', () => {
+  assert.equal(parseSkillFrontmatter('# no frontmatter'), null)
+})
+
+test('collectSkills finds SKILL.md in nested directories and root .md files', async () => {
+  const root = await makeSkillDir()
+  try {
+    await writeSkill(root, 'alpha/SKILL.md', SKILL_MD)
+    await writeSkill(root, 'nested/beta/SKILL.md', '---\nname: beta\ndescription: B\n---\n')
+    // Root .md file (non-SKILL.md) counts as a skill; SKILL.md at root does not.
+    await writeSkill(root, 'root-skill.md', '---\nname: rooty\ndescription: R\n---\n')
+    await writeSkill(root, 'SKILL.md', SKILL_MD)
+    // Non-skill files are ignored.
+    await writeSkill(root, 'notes.txt', 'not a skill')
+
+    const skills: InstalledSkill[] = []
+    await collectSkills(root, skills, 'test')
+    const names = skills.map((s) => s.name).sort()
+    assert.deepEqual(names, ['beta', 'rooty', 'test-skill'])
+    assert.ok(skills.every((s) => s.source === 'test' && s.enabled))
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('collectSkills ignores unreadable files without throwing', async () => {
+  const root = await makeSkillDir()
+  try {
+    await writeSkill(root, 'ok/SKILL.md', SKILL_MD)
+    const skills: InstalledSkill[] = []
+    // Should not throw even with a nonexistent dir or broken file.
+    await collectSkills(join(root, 'missing'), skills, 'test')
+    await collectSkills(root, skills, 'test')
+    assert.equal(skills.length, 1)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('listSkills scans global and project roots and caches per cwd', async () => {
+  const home = await makeSkillDir()
+  const cwd = await makeSkillDir()
+  try {
+    await writeSkill(join(home, '.agents', 'skills'), 'global-skill/SKILL.md', '---\nname: global-skill\ndescription: G\n---\n')
+    await writeSkill(join(cwd, '.pi', 'skills'), 'proj-skill/SKILL.md', '---\nname: proj\ndescription: P\n---\n')
+
+    const skills = await listSkills(cwd, home)
+    const names = skills.map((s) => s.name).sort()
+    assert.deepEqual(names, ['global-skill', 'proj'])
+    assert.ok(skills.some((s) => s.source === 'global'))
+    assert.ok(skills.some((s) => s.source === 'project'))
+
+    // Second call hits the cache: same array identity proves no re-scan.
+    const again = await listSkills(cwd, home)
+    assert.equal(again, skills)
+
+    // A different cwd is a separate cache entry and still scans.
+    const cwd2 = await mkdtemp(join(tmpdir(), 'skills-lister-cwd2-'))
+    try {
+      const other = await listSkills(cwd2, home)
+      assert.deepEqual(other.map((s) => s.name), ['global-skill'])
+    } finally {
+      await rm(cwd2, { recursive: true, force: true })
+    }
+  } finally {
+    await rm(home, { recursive: true, force: true })
+    await rm(cwd, { recursive: true, force: true })
+  }
+})
+
+test('listSkills coalesces concurrent calls into a single scan', async () => {
+  const home = await makeSkillDir()
+  const cwd = await makeSkillDir()
+  try {
+    await writeSkill(join(home, '.agents', 'skills'), 'a/SKILL.md', SKILL_MD)
+
+    const [r1, r2, r3] = await Promise.all([listSkills(cwd, home), listSkills(cwd, home), listSkills(cwd, home)])
+    // Same result array identity: the three callers shared one in-flight scan.
+    assert.equal(r1, r2)
+    assert.equal(r2, r3)
+    assert.equal(r1.length, 1)
+  } finally {
+    await rm(home, { recursive: true, force: true })
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/src/main/skills-lister.ts
+++ b/src/main/skills-lister.ts
@@ -1,0 +1,148 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { mapWithConcurrency } from './map-concurrent'
+
+export interface InstalledSkill {
+  name: string
+  description: string
+  path: string
+  source: string
+  enabled: boolean
+}
+
+// listSkills is called from several paths at startup (the Packages & Skills
+// view on mount, the command palette, and every `status_change → running`
+// event). Each call scans every skills root recursively and readFile()s each
+// SKILL.md, so a burst of overlapping calls (window mount racing the Pi
+// process becoming ready) used to fan out thousands of file reads at once and
+// peg the main process. Cache the result per (cwd, home) and coalesce
+// in-flight scans so concurrent callers share one pass.
+const SKILLS_CACHE_TTL_MS = 10_000
+const skillListCache = new Map<string, { expiresAt: number; skills: InstalledSkill[] }>()
+const skillListInFlight = new Map<string, Promise<InstalledSkill[]>>()
+
+function skillsCacheKey(cwd: string, homeDir: string): string {
+  return `${cwd}\u0000${homeDir}`
+}
+
+export async function listSkills(cwd: string, homeDir: string): Promise<InstalledSkill[]> {
+  const key = skillsCacheKey(cwd, homeDir)
+
+  const cached = skillListCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) {
+    // Keep the cache fresh on hit so a busy consumer can't starve it out.
+    cached.expiresAt = Date.now() + SKILLS_CACHE_TTL_MS
+    return cached.skills
+  }
+
+  const inFlight = skillListInFlight.get(key)
+  if (inFlight) return inFlight
+
+  const scan = (async () => {
+    const skills: InstalledSkill[] = []
+
+    // Global skills
+    const globalPaths = [
+      join(homeDir, '.pi', 'agent', 'skills'),
+      join(homeDir, '.agents', 'skills'),
+    ]
+
+    for (const skillsDir of globalPaths) {
+      await collectSkills(skillsDir, skills, 'global')
+    }
+
+    // Project skills
+    const projectPaths = [
+      join(cwd, '.pi', 'skills'),
+      join(cwd, '.agents', 'skills'),
+    ]
+
+    for (const skillsDir of projectPaths) {
+      await collectSkills(skillsDir, skills, 'project')
+    }
+
+    return skills
+  })()
+
+  skillListInFlight.set(key, scan)
+  try {
+    const skills = await scan
+    skillListCache.set(key, { expiresAt: Date.now() + SKILLS_CACHE_TTL_MS, skills })
+    return skills
+  } finally {
+    skillListInFlight.delete(key)
+  }
+}
+
+export async function collectSkills(
+  dir: string,
+  skills: InstalledSkill[],
+  source: string
+): Promise<void> {
+  try {
+    if (!existsSync(dir)) return
+
+    const items = await readdir(dir, { withFileTypes: true })
+
+    // Gather every candidate (root .md files and SKILL.md files) first, then
+    // read them with bounded concurrency. The previous loop awaited each
+    // readFile serially; with many roots that is slow, and with many callers
+    // racing it multiplied into a file-descriptor burst.
+    const files: Array<{ path: string; name: string }> = []
+    const subdirs: string[] = []
+
+    for (const item of items) {
+      const fullPath = join(dir, item.name)
+      if (item.isFile() && item.name.endsWith('.md') && item.name !== 'SKILL.md') {
+        files.push({ path: fullPath, name: item.name })
+      } else if (item.isDirectory()) {
+        const skillFile = join(fullPath, 'SKILL.md')
+        if (existsSync(skillFile)) files.push({ path: skillFile, name: 'SKILL.md' })
+        subdirs.push(fullPath)
+      }
+    }
+
+    await mapWithConcurrency(files, 8, async (file) => {
+      try {
+        const content = await readFile(file.path, 'utf-8')
+        const parsed = parseSkillFrontmatter(content)
+        if (parsed) {
+          skills.push({
+            name: parsed.name,
+            description: parsed.description,
+            path: file.path,
+            source,
+            enabled: true,
+          })
+        }
+      } catch {
+        // Skip unreadable files
+      }
+    })
+
+    // Recurse into subdirectories, one level at a time, so file reads stay
+    // bounded by the concurrency limit above.
+    for (const subdir of subdirs) {
+      await collectSkills(subdir, skills, source)
+    }
+  } catch {
+    // Directory doesn't exist or isn't readable
+  }
+}
+
+export function parseSkillFrontmatter(content: string): { name: string; description: string } | null {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!frontmatterMatch) return null
+
+  const frontmatter = frontmatterMatch[1]
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m)
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m)
+
+  if (!nameMatch || !descMatch) return null
+
+  return {
+    name: nameMatch[1].trim(),
+    description: descMatch[1].trim(),
+  }
+}


### PR DESCRIPTION
## Problem

Startup pegs the main process at 35-40% CPU for minutes, making the window unresponsive, on machines with many installed skills (observed with ~39 skill dirs / 46 files in `~/.agents/skills`). The main process held **50,000+ open file descriptors**, hundreds of which were the same `SKILL.md` files re-opened.

## Root cause

`listSkills` is called from several startup paths at once:
- Packages & Skills view on mount (`package-browser.tsx` useEffect)
- every `status_change → running` event (`store.ts` handlePiEvent)
- the command palette / status popover

Each call recursively scans every skills root and `readFile()`s each SKILL.md. A burst of overlapping calls (window mount racing the Pi process becoming ready) fanned out thousands of file reads, and the unclosed descriptors accumulated into the 50k leak.

## Fix (`src/main/skills-lister.ts`)

Extracted the scan into a testable module (no Electron import), per the project's existing pattern (`extension-ui-ipc.ts`, `session-lineage-reader.ts`):

1. **Cache** results per (cwd, home) with a sliding 10s TTL — repeated calls after startup hit memory, not disk.
2. **Coalesce in-flight scans** — concurrent callers share one scan instead of each starting their own.
3. **Bound file reads** with the existing `mapWithConcurrency` (8 in flight) instead of the unbounded per-file awaits.
4. **Skip root-level `SKILL.md`** — it was counted as a skill file *and* recursed into, doubling work.

`ipc-handlers.ts` shrinks by ~110 lines (5 added / 112 removed); it now just calls `listSkills(cwd, homeDir)`.

## Tests

New `skills-lister.test.ts` (6 tests): frontmatter parsing, nested/root .md discovery, unreadable-file tolerance, global+project root scanning, cache identity (same array on repeat call), and concurrent-call coalescing (same array identity across 3 parallel callers).

Full suite: **730/730 pass**, typecheck and lint clean.

## How to verify

1. Install the desktop app with a large `~/.agents/skills` tree.
2. Before: app is frozen at ~40% CPU for minutes after launch.
3. After: app is responsive immediately; skills list still appears in Packages & Skills.