### PR TITLE
feat(chat): render user prompts injected by Pi extensions

### DIFF
--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -24,6 +24,7 @@ import type {
   SessionStats,
   SessionListItem,
   AppSettings,
+  PiMessageStartEvent,
   PiMessageUpdateEvent,
   PiToolExecutionStartEvent,
   PiToolExecutionEndEvent,
@@ -520,6 +521,38 @@ function generateId(): string {
 // results from a previous switch are dropped instead of fighting the UI.
 let sessionLoadGeneration = 0
 
+/**
+ * Texts of prompts this GUI just sent to Pi, awaiting their echo on the RPC
+ * event stream. Pi emits a `message_start` for every user message added to
+ * the session — both ours and ones injected inside the Pi process by
+ * extensions (e.g. pi-nvim's socket bridge). Externally injected prompts must
+ * be rendered from that event or they never appear in the thread; our own
+ * prompts must be skipped, since sendPrompt already adds the bubble locally
+ * at send time. Entries expire so a prompt whose echo never arrives (send
+ * failure, process restart) cannot swallow an identical future external
+ * message.
+ */
+const pendingLocalEchoes: { text: string; sentAt: number }[] = []
+const LOCAL_ECHO_TTL_MS = 5 * 60 * 1000
+const LOCAL_ECHO_MAX = 50
+
+function recordLocalEcho(text: string): void {
+  pendingLocalEchoes.push({ text, sentAt: Date.now() })
+  if (pendingLocalEchoes.length > LOCAL_ECHO_MAX) pendingLocalEchoes.shift()
+}
+
+/** Consume the oldest pending local echo matching this content, if any. */
+function consumeLocalEcho(text: string): boolean {
+  const now = Date.now()
+  for (let i = pendingLocalEchoes.length - 1; i >= 0; i--) {
+    if (now - pendingLocalEchoes[i].sentAt > LOCAL_ECHO_TTL_MS) pendingLocalEchoes.splice(i, 1)
+  }
+  const idx = pendingLocalEchoes.findIndex((entry) => entry.text === text)
+  if (idx === -1) return false
+  pendingLocalEchoes.splice(idx, 1)
+  return true
+}
+
 // Latest path requested for switch — rapid clicks only run the final one.
 let pendingSwitchPath: string | null = null
 let switchCoalesceTimer: ReturnType<typeof setTimeout> | null = null
@@ -839,11 +872,15 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     try {
       if (isStreaming) {
         // Queue as steering during streaming, carrying any image attachments.
+        recordLocalEcho(message)
         await window.piDesktop.commands.steer(message, options?.images)
       } else {
         const prompt = settings?.permissionMode === 'plan-readonly'
           ? buildPlanningPrompt(message)
           : message
+        // Record the text actually sent (plan mode wraps it), not the text
+        // displayed — Pi's message_start echo carries the sent form.
+        recordLocalEcho(prompt)
         await window.piDesktop.commands.prompt(prompt, options)
       }
     } catch (err) {
@@ -1494,6 +1531,40 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   handlePiEvent: (event) => {
     switch (event.type) {
+      case 'message_start': {
+        // User messages can enter the session without passing through this
+        // GUI — pi-nvim and other socket/extension bridges inject prompts
+        // directly inside the Pi process. Render those here, or the thread
+        // shows only the assistant's replies. Our own prompts arrive on this
+        // event too, but sendPrompt already rendered them at send time, so a
+        // matching pending echo means skip. Assistant-role message_start is
+        // ignored: assistant content renders via message_update / message_end.
+        const startedMessage = (event as PiMessageStartEvent).message
+        if (startedMessage && (startedMessage as { role?: unknown }).role === 'user') {
+          const parsed = parseAgentMessage(startedMessage)
+          if (parsed && parsed.content.trim() && !consumeLocalEcho(parsed.content)) {
+            get().addMessage(parsed)
+            // Mirror sendPrompt's turn-start state so the external turn gets
+            // a live streaming bubble instead of content appearing only at
+            // message_end. agent_end clears isStreaming as usual.
+            set({
+              isStreaming: true,
+              streamingContent: '',
+              streamingThinking: '',
+              streamingToolCalls: new Map(),
+            })
+            get().addTimelineEvent({
+              id: generateId(),
+              type: 'system',
+              timestamp: Date.now(),
+              title: 'External prompt received',
+              status: 'success',
+            })
+          }
+        }
+        break
+      }
+
       case 'message_update':
         handleMessageUpdate(event as PiMessageUpdateEvent, set)
         break


### PR DESCRIPTION
## Summary

User messages injected directly into the Pi process by extensions — e.g. pi-nvim's
socket bridge — never appear in the conversation thread; only the assistant's
responses render. User bubbles are only created locally in `sendPrompt`, and
`handlePiEvent` has no `message_start` case, so externally-injected prompts are
dropped. (Reloading the session shows them, confirming they're stored — only live
rendering misses them.)

This PR handles user-role `message_start` events in the renderer: parse via the
existing `parseAgentMessage` and append to the thread, mirroring `sendPrompt`'s
turn-start streaming state so the external turn gets a live streaming bubble, plus
an "External prompt received" timeline entry. A small TTL'd pending-echo FIFO makes
`sendPrompt` record the exact text it sends (the plan-wrapped form in plan-readonly
mode), so the GUI's own prompts — which are already rendered at send time — are
skipped rather than duplicated. Assistant-role `message_start` remains ignored
(that content renders via `message_update`/`message_end`).

Scope note: `sendSteer`/`sendFollowUp` never rendered local bubbles, so their
messages now also appear when Pi echoes them. If steers should stay invisible,
adding `recordLocalEcho(message)` to those two functions restores the old
behavior — happy to adjust.

## Related issues

None

## Type of change

- [x] `feat` — New feature

## How was this tested?

Manually on Linux (NixOS, Electron 43), built from source:

- Prompts injected from Neovim via pi-nvim's socket extension now render live in
  the thread, with a streaming bubble for the resulting turn
- GUI-typed prompts render exactly once (echo dedupe verified in both normal and
  plan-readonly modes)
- Pre-flight: `npm run typecheck`, `npm run lint`, `npx tsx --test`,
  `npm run build` all pass; `npm run dev` launches with no regressions observed

## Checklist

- [x] This PR targets the `Dev` branch (not `master`)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npx tsx --test` passes
- [x] `npm run build` succeeds
- [x] The app launches and works (`npm run dev`) with no regressions
- [ ] Tests added or updated for changed modules (colocated `*.test.ts`) —
      not yet: the echo FIFO is module-private to `store.ts`. Happy to add a
      `store-external-prompts.test.ts` exercising `handlePiEvent` with a
      synthetic user-role `message_start` if you'd like it in this PR.
- [x] Electron security posture preserved (renderer-only change; no IPC, preload,
      or main-process modifications)
- [x] Commit messages follow Conventional Commits
- [x] If AI-assisted, the agent was pointed at `AGENT.md` and its Final Delivery
      Checklist (AI-assisted with Claude; audited against the checklist — the
      test gap above is the one open item)
- [x] I have read and agree to the CLA
