### PR TITLE
feat(chat): render user prompts injected by Pi extensions

### DIFF
--- a/src/renderer/src/store-external-prompts.test.ts
+++ b/src/renderer/src/store-external-prompts.test.ts
@@ -1,0 +1,161 @@
+import { test, before, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import type { PiRpcEvent } from '../../shared/ipc-contracts'
+import { buildPlanningPrompt } from './utils/planning-prompt'
+
+// sendPrompt/sendSteer reach the Pi process through the preload bridge; these
+// stubs accept the calls so the echo bookkeeping under test can run.
+const piDesktopStub = {
+  pi: {
+    getStatus: async () => ({ status: 'stopped' as const, pid: null, error: null }),
+  },
+  commands: {
+    prompt: async () => {},
+    steer: async () => {},
+    followUp: async () => {},
+  },
+}
+
+type AppStore = typeof import('./store')['useAppStore']
+let useAppStore: AppStore
+
+before(async () => {
+  ;(globalThis as unknown as { window: unknown }).window = { piDesktop: piDesktopStub }
+  ;({ useAppStore } = await import('./store'))
+})
+
+beforeEach(() => {
+  useAppStore.setState({
+    piStatus: 'running',
+    settings: null,
+    isStreaming: false,
+    messages: [],
+    timelineEvents: [],
+    streamingContent: '',
+    streamingThinking: '',
+    streamingToolCalls: new Map(),
+  })
+})
+
+function userMessageStart(content: string): PiRpcEvent {
+  return { type: 'message_start', message: { role: 'user', content } } as PiRpcEvent
+}
+
+function userBubbles(): string[] {
+  return useAppStore
+    .getState()
+    .messages.filter((m) => m.role === 'user')
+    .map((m) => m.content)
+}
+
+function externalPromptEvents(): number {
+  return useAppStore
+    .getState()
+    .timelineEvents.filter((e) => e.title === 'External prompt received').length
+}
+
+// A prompt injected inside the Pi process (e.g. pi-nvim's socket bridge) only
+// reaches the GUI through the message_start echo. It must render.
+test('external user message_start renders a bubble and timeline entry', () => {
+  useAppStore.getState().handlePiEvent(userMessageStart('from nvim'))
+
+  assert.deepEqual(userBubbles(), ['from nvim'])
+  assert.equal(externalPromptEvents(), 1)
+  assert.equal(useAppStore.getState().isStreaming, true)
+})
+
+test('assistant message_start renders nothing', () => {
+  useAppStore.getState().handlePiEvent({
+    type: 'message_start',
+    message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+  } as PiRpcEvent)
+
+  assert.deepEqual(useAppStore.getState().messages, [])
+  assert.equal(externalPromptEvents(), 0)
+})
+
+test('whitespace-only external message renders nothing', () => {
+  useAppStore.getState().handlePiEvent(userMessageStart('   '))
+
+  assert.deepEqual(useAppStore.getState().messages, [])
+  assert.equal(externalPromptEvents(), 0)
+})
+
+// The GUI's own prompt is rendered locally at send time; its echo on the
+// event stream must be swallowed or every prompt would render twice.
+test('own prompt echo is deduped', async () => {
+  await useAppStore.getState().sendPrompt('hello there')
+  useAppStore.getState().handlePiEvent(userMessageStart('hello there'))
+
+  assert.deepEqual(userBubbles(), ['hello there'])
+  assert.equal(externalPromptEvents(), 0)
+})
+
+// Plan mode sends a wrapped prompt but displays the raw text; the echo
+// carries the wrapped form and must still be recognized as our own.
+test('plan-mode prompt echo is deduped against the wrapped form', async () => {
+  useAppStore.setState({
+    settings: { permissionMode: 'plan-readonly' } as ReturnType<
+      typeof useAppStore.getState
+    >['settings'],
+  })
+  await useAppStore.getState().sendPrompt('plan this')
+  useAppStore.getState().handlePiEvent(userMessageStart(buildPlanningPrompt('plan this')))
+
+  assert.deepEqual(userBubbles(), ['plan this'])
+  assert.equal(externalPromptEvents(), 0)
+})
+
+// Steering while a turn is streaming goes through commands.steer with the raw
+// message text; its echo must be swallowed like a prompt echo.
+test('steering prompt echo during streaming is deduped', async () => {
+  useAppStore.setState({ isStreaming: true })
+  await useAppStore.getState().sendPrompt('change course')
+  useAppStore.getState().handlePiEvent(userMessageStart('change course'))
+
+  assert.deepEqual(userBubbles(), ['change course'])
+  assert.equal(externalPromptEvents(), 0)
+})
+
+// sendSteer/sendFollowUp never rendered bubbles; their echoes must not start
+// rendering them as external prompts now.
+test('sendSteer and sendFollowUp echoes render nothing', async () => {
+  await useAppStore.getState().sendSteer('quiet steer')
+  await useAppStore.getState().sendFollowUp('quiet follow-up')
+  useAppStore.getState().handlePiEvent(userMessageStart('quiet steer'))
+  useAppStore.getState().handlePiEvent(userMessageStart('quiet follow-up'))
+
+  assert.deepEqual(useAppStore.getState().messages, [])
+  assert.equal(externalPromptEvents(), 0)
+})
+
+// Each recorded echo covers exactly one message_start; a second identical
+// message is a genuinely new (external) prompt and must render.
+test('an echo is consumed once; a repeat of the same text renders', async () => {
+  await useAppStore.getState().sendPrompt('same text')
+  useAppStore.getState().handlePiEvent(userMessageStart('same text'))
+  useAppStore.getState().handlePiEvent(userMessageStart('same text'))
+
+  assert.deepEqual(userBubbles(), ['same text', 'same text'])
+  assert.equal(externalPromptEvents(), 1)
+})
+
+// An external steer can land mid-turn; the live streaming buffers for the
+// in-progress assistant response must survive it.
+test('external prompt mid-stream preserves streaming state', () => {
+  const toolCalls = new Map([['t1', { name: 'bash', args: '{}', isExecuting: true }]])
+  useAppStore.setState({
+    isStreaming: true,
+    streamingContent: 'partial answer',
+    streamingThinking: 'partial thought',
+    streamingToolCalls: toolCalls,
+  })
+
+  useAppStore.getState().handlePiEvent(userMessageStart('injected mid-turn'))
+
+  const state = useAppStore.getState()
+  assert.deepEqual(userBubbles(), ['injected mid-turn'])
+  assert.equal(state.streamingContent, 'partial answer')
+  assert.equal(state.streamingThinking, 'partial thought')
+  assert.equal(state.streamingToolCalls.size, 1)
+})

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -934,6 +934,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   sendSteer: async (message) => {
     try {
+      // Steers are intentionally not rendered as bubbles; record the echo so
+      // the message_start handler does not render one as an external prompt.
+      recordLocalEcho(message)
       await window.piDesktop.commands.steer(message)
     } catch (err) {
       get().addMessage({
@@ -947,6 +950,8 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   sendFollowUp: async (message) => {
     try {
+      // Same as sendSteer: suppress the echo-rendered external bubble.
+      recordLocalEcho(message)
       await window.piDesktop.commands.followUp(message)
     } catch (err) {
       get().addMessage({
@@ -1665,13 +1670,17 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
             get().addMessage(parsed)
             // Mirror sendPrompt's turn-start state so the external turn gets
             // a live streaming bubble instead of content appearing only at
-            // message_end. agent_end clears isStreaming as usual.
-            set({
-              isStreaming: true,
-              streamingContent: '',
-              streamingThinking: '',
-              streamingToolCalls: new Map(),
-            })
+            // message_end. agent_end clears isStreaming as usual. When a turn
+            // is already streaming (an external steer injected mid-turn), the
+            // in-progress content and tool-call state must survive.
+            if (!get().isStreaming) {
+              set({
+                isStreaming: true,
+                streamingContent: '',
+                streamingThinking: '',
+                streamingToolCalls: new Map(),
+              })
+            }
             get().addTimelineEvent({
               id: generateId(),
               type: 'system',

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -24,6 +24,7 @@ import type {
   SessionStats,
   SessionListItem,
   AppSettings,
+  PiMessageStartEvent,
   PiMessageUpdateEvent,
   PiToolExecutionStartEvent,
   PiToolExecutionEndEvent,
@@ -545,6 +546,38 @@ function generateId(): string {
 // results from a previous switch are dropped instead of fighting the UI.
 let sessionLoadGeneration = 0
 
+/**
+ * Texts of prompts this GUI just sent to Pi, awaiting their echo on the RPC
+ * event stream. Pi emits a `message_start` for every user message added to
+ * the session — both ours and ones injected inside the Pi process by
+ * extensions (e.g. pi-nvim's socket bridge). Externally injected prompts must
+ * be rendered from that event or they never appear in the thread; our own
+ * prompts must be skipped, since sendPrompt already adds the bubble locally
+ * at send time. Entries expire so a prompt whose echo never arrives (send
+ * failure, process restart) cannot swallow an identical future external
+ * message.
+ */
+const pendingLocalEchoes: { text: string; sentAt: number }[] = []
+const LOCAL_ECHO_TTL_MS = 5 * 60 * 1000
+const LOCAL_ECHO_MAX = 50
+
+function recordLocalEcho(text: string): void {
+  pendingLocalEchoes.push({ text, sentAt: Date.now() })
+  if (pendingLocalEchoes.length > LOCAL_ECHO_MAX) pendingLocalEchoes.shift()
+}
+
+/** Consume the oldest pending local echo matching this content, if any. */
+function consumeLocalEcho(text: string): boolean {
+  const now = Date.now()
+  for (let i = pendingLocalEchoes.length - 1; i >= 0; i--) {
+    if (now - pendingLocalEchoes[i].sentAt > LOCAL_ECHO_TTL_MS) pendingLocalEchoes.splice(i, 1)
+  }
+  const idx = pendingLocalEchoes.findIndex((entry) => entry.text === text)
+  if (idx === -1) return false
+  pendingLocalEchoes.splice(idx, 1)
+  return true
+}
+
 // Latest path requested for switch — rapid clicks only run the final one.
 let pendingSwitchPath: string | null = null
 let switchCoalesceTimer: ReturnType<typeof setTimeout> | null = null
@@ -877,11 +910,15 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     try {
       if (isStreaming) {
         // Queue as steering during streaming, carrying any image attachments.
+        recordLocalEcho(message)
         await window.piDesktop.commands.steer(message, options?.images)
       } else {
         const prompt = settings?.permissionMode === 'plan-readonly'
           ? buildPlanningPrompt(message)
           : message
+        // Record the text actually sent (plan mode wraps it), not the text
+        // displayed — Pi's message_start echo carries the sent form.
+        recordLocalEcho(prompt)
         await window.piDesktop.commands.prompt(prompt, options)
       }
     } catch (err) {
@@ -1613,6 +1650,40 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   handlePiEvent: (event) => {
     switch (event.type) {
+      case 'message_start': {
+        // User messages can enter the session without passing through this
+        // GUI — pi-nvim and other socket/extension bridges inject prompts
+        // directly inside the Pi process. Render those here, or the thread
+        // shows only the assistant's replies. Our own prompts arrive on this
+        // event too, but sendPrompt already rendered them at send time, so a
+        // matching pending echo means skip. Assistant-role message_start is
+        // ignored: assistant content renders via message_update / message_end.
+        const startedMessage = (event as PiMessageStartEvent).message
+        if (startedMessage && (startedMessage as { role?: unknown }).role === 'user') {
+          const parsed = parseAgentMessage(startedMessage)
+          if (parsed && parsed.content.trim() && !consumeLocalEcho(parsed.content)) {
+            get().addMessage(parsed)
+            // Mirror sendPrompt's turn-start state so the external turn gets
+            // a live streaming bubble instead of content appearing only at
+            // message_end. agent_end clears isStreaming as usual.
+            set({
+              isStreaming: true,
+              streamingContent: '',
+              streamingThinking: '',
+              streamingToolCalls: new Map(),
+            })
+            get().addTimelineEvent({
+              id: generateId(),
+              type: 'system',
+              timestamp: Date.now(),
+              title: 'External prompt received',
+              status: 'success',
+            })
+          }
+        }
+        break
+      }
+
       case 'message_update':
         handleMessageUpdate(event as PiMessageUpdateEvent, set)
         break


### PR DESCRIPTION
## Summary

Takeover of #53 by @u3192696, rebased onto `Dev` with the original commit and authorship preserved. User messages injected directly into the Pi process by extensions (e.g. pi-nvim's socket bridge) only reach the GUI through user-role `message_start` events; the renderer previously had no handler for them, so those prompts never appeared in the thread until a session reload.

The original change renders user-role `message_start` events and uses a TTL'd pending-echo FIFO so the GUI's own prompts (already rendered at send time) are skipped instead of duplicated.

On top of that, this PR fixes the review findings:

- Preserve in-progress streaming content, thinking, and tool-call state when an external prompt lands mid-turn (previously wiped)
- Record local echoes in `sendSteer`/`sendFollowUp` so GUI-originated steers and follow-ups are not rendered as external prompts
- Add `store-external-prompts.test.ts` covering external rendering, echo dedupe (normal, plan-readonly, and steering paths), single-consumption semantics, and mid-stream state preservation

Closes #53.

## Related issues

#53

## Type of change

- [x] `feat` — New feature

## How was this tested?

- `npm run typecheck` passes
- `npm run lint` passes
- `npx tsx --test src/**/*.test.ts` — 771 tests pass, including the 9 new ones
- `npm run build` succeeds

## Checklist

- [x] This PR targets the `Dev` branch (not `master`)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npx tsx --test` passes
- [x] `npm run build` succeeds
- [x] Tests added or updated for changed modules (colocated `*.test.ts`)
- [x] Electron security posture preserved (renderer-only change; no IPC, preload, or main-process modifications)
- [x] Commit messages follow Conventional Commits