### PR TITLE
feat: add project workflows and productivity control plane

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -67,6 +67,7 @@ src/
 │   ├── renderer-origin.ts        # Trusted-renderer URL check (navigation + IPC sender)
 │   ├── workspace-trust.ts        # Per-workspace trust registry (gates allow rules + preview)
 │   ├── workspace-manager.ts      # Multi-workspace management
+│   ├── git-conveyor.ts           # Validated commit, push, and GitHub PR commands
 │   ├── file-service.ts           # File tree, search, git status, read/write
 │   ├── terminal-service.ts       # node-pty PTY management
 │   ├── agent-detection.ts        # Detect claude/codex/pi CLIs (council)
@@ -108,6 +109,7 @@ src/
             ├── home-screen.tsx    # Full Home launcher (stats, recents, open folder / new session)
             ├── task-launcher.tsx  # New-task modal that starts a real background session
             ├── mission-control.tsx # Global live-session and workflow inbox
+            ├── git-conveyor-actions.tsx # Explicit commit/push/PR controls for reviewed diffs
             ├── stats-panel.tsx    # Activity stats dashboard on Home
             ├── chat-panel.tsx     # Main streaming chat; empty session = center prompt + project picker
             ├── chat-project-picker.tsx # Empty-chat project / no-project picker under the composer
@@ -157,6 +159,7 @@ src/
 ### Workspace Management
 
 - Mission Control summarizes all live session runtimes and workflow runs across projects; New Task launches a prompt into a dedicated background runtime
+- New Task can create an isolated Git worktree, and Diff Review exposes explicit Commit → Push → PR actions with upstream-aware GitHub CLI routing
 - Multiple workspaces (project directories)
 - Each workspace owns a file service; every live session in that project owns an independent Pi process bound to that workspace cwd and its own `--session` file
 - Session navigation is immediate; Pi startup and history hydration continue in the background
@@ -207,6 +210,12 @@ src/
 - Results grouped by source: Skills, Prompts, Commands (Pi built-ins), Extensions
 - Skills/prompts/extensions insert their token (`/skill:name`, `/template`, `/cmd`) for Pi to expand; built-ins (`/compact`, `/clone`, `/new`, `/resume`, `/fork`, `/settings`) run the GUI action directly
 - Workspace/session/file picks route through the store's guarded actions, so the streaming and dirty-editor confirms still apply
+
+### Issue-to-PR Conveyor
+
+- Task Launcher accepts an issue description or URL, optionally creates a clean isolated Git worktree, and sends the task to a dedicated Pi runtime.
+- Diff Review exposes explicit Commit, Push, and PR actions; mutating Git operations never happen implicitly.
+- PR creation uses GitHub CLI when available, targets the configured `upstream` remote when present, and opens the returned PR URL.
 
 ### Workspace Activity & Desktop Notifications
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -155,7 +155,8 @@ src/
 ### Workspace Management
 
 - Multiple workspaces (project directories)
-- Each workspace has its own Pi process, sessions, and file service
+- Each workspace owns a file service; every live session in that project owns an independent Pi process bound to that workspace cwd and its own `--session` file
+- Session navigation is immediate; Pi startup and history hydration continue in the background
 - Default workspace: user's home directory
 - Workspace switcher in sidebar
 - Auto-creates workspace when switching to a session from a different project
@@ -164,6 +165,9 @@ src/
 ### Session Management
 
 - Sessions organized by working directory (Pi native), decoded correctly cross-platform including Windows drive-letter paths
+- One independent Pi runtime per live session, including multiple sessions sharing one project directory
+- Switching sessions never sends a destructive `switch_session` to the previous process; the previous turn continues in the background
+- Session tabs and sidebar rows show working, approval, completed, and failed indicators
 - Sessions grouped by project in the session panel
 - **Session tags**: type `#tag-name` in chat to tag the current session
 - Tags persisted to `~/.pi-desktop-gui/session-tags.json`
@@ -203,7 +207,8 @@ src/
 
 ### Workspace Activity & Desktop Notifications
 
-- Main derives per-workspace activity (working / needs approval / completed / failed) from every workspace's Pi events — the renderer's stream state only follows the active workspace, so this ships as its own map (`workspace-activity.ts`, broadcast on `event:workspace-activity`)
+- Main derives aggregate per-workspace activity (working / needs approval / completed / failed) from every session runtime's Pi events — the renderer's stream state only follows the active runtime, so this ships as its own map (`workspace-activity.ts`, broadcast on `event:workspace-activity`)
+- A separate session-runtime snapshot stream exposes each live session's process status, PID, activity, and active binding for per-session indicators
 - Sidebar shows per-workspace dots (pulsing while working; success/error until the workspace is next viewed) alongside the existing held-prompt badges
 - OS notifications (toggleable in Settings → Behavior) fire when a turn finishes, fails, or waits for approval outside the focused view; clicking one focuses the window and switches to that workspace via the renderer's guarded switch
 
@@ -352,10 +357,10 @@ npm run package       # Create installer
 
 ## Pi Integration
 
-Pi runs in RPC mode as a subprocess:
+Pi runs in RPC mode as a subprocess; one `PiRpcManager` is retained for each live session runtime:
 
 ```
-pi --mode rpc [--provider <name>] [--model <id>] [--no-session]
+pi --mode rpc [--session <session-file>] [--provider <name>] [--model <id>] [--no-session]
 ```
 
 Communication via JSONL over stdin/stdout:

--- a/AGENT.md
+++ b/AGENT.md
@@ -106,6 +106,8 @@ src/
             ├── sidebar.tsx        # Workspace switcher, nav, sessions grouped by folder, inline rename
             ├── sidebar-session-labels.ts # Session row label helpers
             ├── home-screen.tsx    # Full Home launcher (stats, recents, open folder / new session)
+            ├── task-launcher.tsx  # New-task modal that starts a real background session
+            ├── mission-control.tsx # Global live-session and workflow inbox
             ├── stats-panel.tsx    # Activity stats dashboard on Home
             ├── chat-panel.tsx     # Main streaming chat; empty session = center prompt + project picker
             ├── chat-project-picker.tsx # Empty-chat project / no-project picker under the composer
@@ -154,6 +156,7 @@ src/
 
 ### Workspace Management
 
+- Mission Control summarizes all live session runtimes and workflow runs across projects; New Task launches a prompt into a dedicated background runtime
 - Multiple workspaces (project directories)
 - Each workspace owns a file service; every live session in that project owns an independent Pi process bound to that workspace cwd and its own `--session` file
 - Session navigation is immediate; Pi startup and history hydration continue in the background

--- a/AGENT.md
+++ b/AGENT.md
@@ -159,7 +159,7 @@ src/
 ### Workspace Management
 
 - Mission Control summarizes all live session runtimes and workflow runs across projects; New Task launches a prompt into a dedicated background runtime
-- New Task can create an isolated Git worktree, and Diff Review exposes explicit Commit → Push → PR actions with upstream-aware GitHub CLI routing
+- New Task can create or reuse an isolated Git worktree (matching task metadata, explicit branches, and GitHub PR URLs are detected), and Diff Review exposes explicit Commit → Push → PR actions with upstream-aware GitHub CLI routing
 - Multiple workspaces (project directories)
 - Each workspace owns a file service; every live session in that project owns an independent Pi process bound to that workspace cwd and its own `--session` file
 - Session navigation is immediate; Pi startup and history hydration continue in the background
@@ -213,7 +213,7 @@ src/
 
 ### Issue-to-PR Conveyor
 
-- Task Launcher accepts an issue description or URL, optionally creates a clean isolated Git worktree, and sends the task to a dedicated Pi runtime.
+- Task Launcher accepts an issue description or URL, optionally creates or reuses a local Git worktree, and sends the task to a dedicated Pi runtime. PR URLs are resolved with `gh pr view`; unrelated or ambiguous worktrees are never guessed.
 - Diff Review exposes explicit Commit, Push, and PR actions; mutating Git operations never happen implicitly.
 - PR creation uses GitHub CLI when available, targets the configured `upstream` remote when present, and opens the returned PR URL.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Changed files use readable status badges:
 
 ## Pi and OMP engines
 
-Pi Desktop speaks Pi's RPC protocol directly, so it can run either the standard `pi` CLI or the compatible `omp` binary from [oh-my-pi](https://github.com/can1357/oh-my-pi). Set **Settings → Agent Configuration → Agent Executable** to `omp` (or its full path). OMP sessions are placed in Desktop's existing session store, OMP's protocol-v2 large-frame transport is negotiated automatically, and model-specific thinking efforts—including `max`—are shown when advertised.
+Pi Desktop speaks Pi's RPC protocol directly, so it can run either the standard `pi` CLI or the compatible `omp` binary from [oh-my-pi](https://github.com/can1357/oh-my-pi). **Settings → Agent Configuration → Agent Installation** scans for installed Pi/OMP engines, lets you select one, and also supports a custom executable or install directory. OMP sessions are placed in Desktop's existing session store, OMP's protocol-v2 large-frame transport is negotiated automatically, and model-specific thinking efforts—including `max`—are shown when advertised.
 
 OMP's native `read`, `grep`, and `glob` tools are used for Plan / Read-only mode; its plugin install/update/remove verbs are mapped behind the existing package actions.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Still in alpha, so expect rough edges.
 - Session naming (read from Pi) with inline rename, and a themed in-app confirmation for delete
 - Custom models & providers editor in Settings, which edits `~/.pi/agent/models.json`
 - Multiple workspaces, each with its own Pi process and sessions; Mission Control and sidebar activity dots surface background work across projects, with optional desktop notifications when a session finishes, fails, or waits for approval
-- New Task launcher starts a real fresh Pi session in a selected project and sends the issue immediately, while work continues in the background
+- New Task launcher starts a real fresh Pi session in a selected project, optionally in an isolated Git worktree, and sends the issue immediately while work continues in the background
+- Diff Review conveyor with explicit Commit → Push → PR actions, upstream-aware GitHub CLI PR creation, and exact notification clicks back to the finished session
 - Diagnostics view: Pi install and PATH resolution, provider configuration, permissions, and recent errors
 - Review rail (toggleable) with permissions, approvals, changed files, and session status
 - Custom permission rules: allow/deny glob rules per Pi tool that refine the permission modes, with per-workspace rule files, import/export, and live edits that apply without restarting Pi

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Still in alpha, so expect rough edges.
 - Session naming (read from Pi) with inline rename, and a themed in-app confirmation for delete
 - Custom models & providers editor in Settings, which edits `~/.pi/agent/models.json`
 - Multiple workspaces, each with its own Pi process and sessions; Mission Control and sidebar activity dots surface background work across projects, with optional desktop notifications when a session finishes, fails, or waits for approval
-- New Task launcher starts a real fresh Pi session in a selected project, optionally in an isolated Git worktree, and sends the issue immediately while work continues in the background
+- New Task launcher starts a real fresh Pi session in a selected project, optionally in an isolated Git worktree, and sends the issue immediately while work continues in the background; matching task metadata, explicit branches, and GitHub PR URLs reuse an existing local worktree when found
 - Diff Review conveyor with explicit Commit → Push → PR actions, upstream-aware GitHub CLI PR creation, and exact notification clicks back to the finished session
 - Diagnostics view: Pi install and PATH resolution, provider configuration, permissions, and recent errors
 - Review rail (toggleable) with permissions, approvals, changed files, and session status

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Still in alpha, so expect rough edges.
 - Multiple workspaces, each with its own Pi process and sessions; Mission Control and sidebar activity dots surface background work across projects, with optional desktop notifications when a session finishes, fails, or waits for approval
 - New Task launcher starts a real fresh Pi session in a selected project, optionally in an isolated Git worktree, and sends the issue immediately while work continues in the background; matching task metadata, explicit branches, and GitHub PR URLs reuse an existing local worktree when found
 - Diff Review conveyor with explicit Commit → Push → PR actions, upstream-aware GitHub CLI PR creation, and exact notification clicks back to the finished session
-- Diagnostics view: Pi install and PATH resolution, provider configuration, permissions, and recent errors
+- Diagnostics view: Pi/OMP install and PATH resolution, provider configuration, permissions, and recent errors
 - Review rail (toggleable) with permissions, approvals, changed files, and session status
 - Custom permission rules: allow/deny glob rules per Pi tool that refine the permission modes, with per-workspace rule files, import/export, and live edits that apply without restarting Pi
 - File tree, code/image/PDF/HTML preview panes, code editor (CodeMirror 6 with syntax highlighting), diff viewer, file search
@@ -42,6 +42,12 @@ Changed files use readable status badges:
 | `ADD` | New file staged in git |
 | `STG` | Modified file staged in git |
 | `REN` | File was renamed |
+
+## Pi and OMP engines
+
+Pi Desktop speaks Pi's RPC protocol directly, so it can run either the standard `pi` CLI or the compatible `omp` binary from [oh-my-pi](https://github.com/can1357/oh-my-pi). Set **Settings → Agent Configuration → Agent Executable** to `omp` (or its full path). OMP sessions are placed in Desktop's existing session store, OMP's protocol-v2 large-frame transport is negotiated automatically, and model-specific thinking efforts—including `max`—are shown when advertised.
+
+OMP's native `read`, `grep`, and `glob` tools are used for Plan / Read-only mode; its plugin install/update/remove verbs are mapped behind the existing package actions.
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Still in alpha, so expect rough edges.
 - Skills browser, session fork/branch tree, and one-click context compaction
 - Session naming (read from Pi) with inline rename, and a themed in-app confirmation for delete
 - Custom models & providers editor in Settings, which edits `~/.pi/agent/models.json`
-- Multiple workspaces, each with its own Pi process and sessions; sidebar activity dots and optional desktop notifications when a background workspace finishes, fails, or waits for approval
+- Multiple workspaces, each with its own Pi process and sessions; Mission Control and sidebar activity dots surface background work across projects, with optional desktop notifications when a session finishes, fails, or waits for approval
+- New Task launcher starts a real fresh Pi session in a selected project and sends the issue immediately, while work continues in the background
 - Diagnostics view: Pi install and PATH resolution, provider configuration, permissions, and recent errors
 - Review rail (toggleable) with permissions, approvals, changed files, and session status
 - Custom permission rules: allow/deny glob rules per Pi tool that refine the permission modes, with per-workspace rule files, import/export, and live edits that apply without restarting Pi

--- a/src/main/agent-detection.ts
+++ b/src/main/agent-detection.ts
@@ -4,6 +4,7 @@ import { spawnSync } from 'child_process'
 import type { CouncilAgentId } from '../shared/council-config'
 import { COUNCIL_AGENT_IDS } from '../shared/council-config'
 import { buildNpmPrefixCommand } from './cmd-escape'
+import { getPiCli } from './pi-rpc-manager'
 
 const IS_WINDOWS = process.platform === 'win32'
 
@@ -80,6 +81,10 @@ function npmGlobalPrefix(): string | null {
 }
 
 function resolveAgent(id: CouncilAgentId): string | null {
+  if (id === 'pi') {
+    const configured = getPiCli()
+    if (configured.found) return configured.script
+  }
   const base = AGENT_BINARIES[id]
   // 1. PATH (respects PATHEXT on Windows)
   const fromPath = whichInPath(base)

--- a/src/main/council-manager.ts
+++ b/src/main/council-manager.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
 import { StringDecoder } from 'string_decoder'
-import type { CouncilAgentId, ConsensusMode, ConsultantResult } from '../shared/council-config'
+import type { CouncilAgentId, ConsensusMode, ConsultantResult, CouncilPiEngine } from '../shared/council-config'
 import {
   buildConsultantPrompt,
   buildConsensusPrompt,
@@ -13,6 +13,7 @@ import {
 } from '../shared/council-config'
 import { detectAgents } from './agent-detection'
 import { escapeCmdSpawn } from './cmd-escape'
+import { getPiCli } from './pi-rpc-manager'
 
 const IS_WINDOWS = process.platform === 'win32'
 const MS_PER_SECOND = 1000
@@ -145,15 +146,22 @@ export function buildConsultantSpawn(
   id: CouncilAgentId,
   executable: string,
   isWindows: boolean,
+  engine: CouncilPiEngine = 'pi',
 ): { file: string; args: string[] } {
-  const command = buildConsultantCommand(id, executable)
+  const command = buildConsultantCommand(id, executable, engine)
   return escapeCmdSpawn(isWindows, command.file, command.args)
 }
 
 /** Default spawn: run the consultant CLI, stream output, enforce timeout. */
 export const defaultSpawnConsultant: SpawnConsultant = (id, prompt, cwd, timeoutMs, onChunk) =>
   new Promise<SpawnOutcome>((resolve) => {
-    const { file, args } = buildConsultantSpawn(id, resolveExecutable(id), IS_WINDOWS)
+    const piCli = id === 'pi' ? getPiCli() : null
+    const { file, args } = buildConsultantSpawn(
+      id,
+      resolveExecutable(id),
+      IS_WINDOWS,
+      piCli?.kind === 'omp' ? 'omp' : 'pi',
+    )
     const child = spawn(file, args, {
       cwd,
       shell: IS_WINDOWS,
@@ -247,6 +255,10 @@ export const defaultSpawnConsultant: SpawnConsultant = (id, prompt, cwd, timeout
 
 // Resolve the executable path from agent detection; falls back to the bare id.
 function resolveExecutable(id: CouncilAgentId): string {
+  if (id === 'pi') {
+    const configured = getPiCli()
+    if (configured.found) return configured.script
+  }
   const found = detectAgents().find((a) => a.id === id)
   return found?.path ?? id
 }

--- a/src/main/git-conveyor.test.ts
+++ b/src/main/git-conveyor.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { countPorcelainFiles, extractUrl, githubRepoFromRemote, parseAheadBehind } from './git-conveyor'
+
+test('countPorcelainFiles counts changed porcelain rows, not changed lines', () => {
+  assert.equal(countPorcelainFiles(' M src/a.ts\n?? src/new.ts\n'), 2)
+  assert.equal(countPorcelainFiles(''), 0)
+})
+
+test('parseAheadBehind handles upstream counts and missing upstreams', () => {
+  assert.deepEqual(parseAheadBehind('2\t5\n'), { behind: 2, ahead: 5 })
+  assert.deepEqual(parseAheadBehind(null), { behind: 0, ahead: 0 })
+})
+
+test('extractUrl returns the first CLI URL without inventing one', () => {
+  assert.equal(extractUrl('Created pull request: https://github.com/example/repo/pull/42'), 'https://github.com/example/repo/pull/42')
+  assert.equal(extractUrl('authentication required'), null)
+})
+
+test('githubRepoFromRemote normalizes HTTPS and SSH remotes', () => {
+  assert.equal(githubRepoFromRemote('https://github.com/FaqFirebase/pi-desktop.git'), 'FaqFirebase/pi-desktop')
+  assert.equal(githubRepoFromRemote('git@github.com:FaqFirebase/pi-desktop.git'), 'FaqFirebase/pi-desktop')
+  assert.equal(githubRepoFromRemote('https://gitlab.com/example/repo.git'), null)
+})

--- a/src/main/git-conveyor.test.ts
+++ b/src/main/git-conveyor.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { countPorcelainFiles, extractUrl, githubRepoFromRemote, parseAheadBehind } from './git-conveyor'
+import { countPorcelainFiles, extractGitHubPullRequestUrl, extractUrl, githubRepoFromRemote, parseAheadBehind } from './git-conveyor'
 
 test('countPorcelainFiles counts changed porcelain rows, not changed lines', () => {
   assert.equal(countPorcelainFiles(' M src/a.ts\n?? src/new.ts\n'), 2)
@@ -15,6 +15,14 @@ test('parseAheadBehind handles upstream counts and missing upstreams', () => {
 test('extractUrl returns the first CLI URL without inventing one', () => {
   assert.equal(extractUrl('Created pull request: https://github.com/example/repo/pull/42'), 'https://github.com/example/repo/pull/42')
   assert.equal(extractUrl('authentication required'), null)
+})
+
+test('extractGitHubPullRequestUrl finds a PR URL inside a task', () => {
+  assert.equal(
+    extractGitHubPullRequestUrl('Continue https://github.com/FaqFirebase/pi-desktop/pull/55.'),
+    'https://github.com/FaqFirebase/pi-desktop/pull/55'
+  )
+  assert.equal(extractGitHubPullRequestUrl('Fix issue #55'), null)
 })
 
 test('githubRepoFromRemote normalizes HTTPS and SSH remotes', () => {

--- a/src/main/git-conveyor.ts
+++ b/src/main/git-conveyor.ts
@@ -26,6 +26,22 @@ export function extractUrl(output: string): string | null {
   return output.match(/https?:\/\/[^\s]+/)?.[0] ?? null
 }
 
+export function extractGitHubPullRequestUrl(value: string): string | null {
+  return value.match(/https?:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/\d+/i)?.[0] ?? null
+}
+
+export async function resolvePullRequestHeadBranch(cwd: string, url: string): Promise<string | null> {
+  const output = await runCommand('gh', ['pr', 'view', url, '--json', 'headRefName'], cwd)
+  try {
+    const value = JSON.parse(output) as { headRefName?: unknown }
+    return typeof value.headRefName === 'string' && value.headRefName.trim()
+      ? value.headRefName.trim()
+      : null
+  } catch {
+    return null
+  }
+}
+
 export function githubRepoFromRemote(remote: string | null): string | null {
   if (!remote) return null
   const match = remote.trim().replace(/\.git$/, '').match(/github\.com[:/]([^/]+\/[^/]+)$/i)

--- a/src/main/git-conveyor.ts
+++ b/src/main/git-conveyor.ts
@@ -1,0 +1,125 @@
+import { spawn } from 'child_process'
+import { inspectGitRepository, runGit } from './git-worktree'
+import type {
+  GitConveyorCommitOptions,
+  GitConveyorPullRequestOptions,
+  GitConveyorPullRequestResult,
+  GitConveyorStatus,
+} from '../shared/ipc-contracts'
+
+const COMMAND_TIMEOUT_MS = 30_000
+
+export function countPorcelainFiles(status: string): number {
+  return status.split(/\r?\n/).filter((line) => line.trim().length > 0).length
+}
+
+export function parseAheadBehind(value: string | null): { ahead: number; behind: number } {
+  if (!value) return { ahead: 0, behind: 0 }
+  const [behind, ahead] = value.trim().split(/\s+/).map(Number)
+  return {
+    ahead: Number.isFinite(ahead) ? ahead : 0,
+    behind: Number.isFinite(behind) ? behind : 0,
+  }
+}
+
+export function extractUrl(output: string): string | null {
+  return output.match(/https?:\/\/[^\s]+/)?.[0] ?? null
+}
+
+export function githubRepoFromRemote(remote: string | null): string | null {
+  if (!remote) return null
+  const match = remote.trim().replace(/\.git$/, '').match(/github\.com[:/]([^/]+\/[^/]+)$/i)
+  return match?.[1] ?? null
+}
+
+function runCommand(file: string, args: readonly string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, [...args], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill()
+      reject(new Error(`${file} ${args.join(' ')} timed out`))
+    }, COMMAND_TIMEOUT_MS)
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
+    child.once('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.once('close', (code) => {
+      clearTimeout(timer)
+      const output = (stdout || stderr).trim()
+      if (code === 0) resolve(output)
+      else reject(new Error(`${file} ${args.join(' ')} failed${output ? `: ${output}` : ''}`))
+    })
+  })
+}
+
+export async function getGitConveyorStatus(cwd: string): Promise<GitConveyorStatus> {
+  const repository = await inspectGitRepository(cwd)
+  const [lastCommitMessage, upstream, counts, remoteUrl] = await Promise.all([
+    runGit(['log', '-1', '--pretty=%s'], cwd).then((result) => result.stdout.trim()).catch(() => ''),
+    runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], cwd).then((result) => result.stdout.trim()).catch(() => ''),
+    runGit(['rev-list', '--left-right', '--count', '@{upstream}...HEAD'], cwd).then((result) => result.stdout.trim()).catch(() => null),
+    runGit(['config', '--get', 'remote.origin.url'], cwd).then((result) => result.stdout.trim()).catch(() => ''),
+  ])
+  return {
+    branch: repository.branch,
+    head: repository.head,
+    lastCommitMessage: lastCommitMessage || null,
+    dirtyFiles: countPorcelainFiles(repository.status),
+    ...parseAheadBehind(counts),
+    hasUpstream: !!upstream,
+    remoteUrl: remoteUrl || null,
+  }
+}
+
+export async function commitAll(cwd: string, options: GitConveyorCommitOptions): Promise<GitConveyorStatus> {
+  const message = options.message.trim()
+  if (!message) throw new Error('Commit message is required')
+  if (message.length > 200) throw new Error('Commit message must be 200 characters or fewer')
+  const repository = await inspectGitRepository(cwd)
+  if (!repository.branch) throw new Error('Cannot commit from a detached HEAD')
+  if (!repository.status.trim()) throw new Error('Working tree is clean')
+  await runGit(['add', '-A'], cwd)
+  await runGit(['commit', '-m', message], cwd)
+  return getGitConveyorStatus(cwd)
+}
+
+export async function pushBranch(cwd: string): Promise<GitConveyorStatus> {
+  const repository = await inspectGitRepository(cwd)
+  if (!repository.branch) throw new Error('Cannot push from a detached HEAD')
+  const upstream = await runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], cwd)
+    .then((result) => result.stdout.trim())
+    .catch(() => '')
+  await runGit(upstream ? ['push'] : ['push', '--set-upstream', 'origin', repository.branch], cwd)
+  return getGitConveyorStatus(cwd)
+}
+
+export async function createPullRequest(
+  cwd: string,
+  options: GitConveyorPullRequestOptions,
+): Promise<GitConveyorPullRequestResult> {
+  const title = options.title.trim()
+  if (!title) throw new Error('Pull request title is required')
+  const body = options.body.trim()
+  const [upstreamRemote, originRemote, branch] = await Promise.all([
+    runGit(['config', '--get', 'remote.upstream.url'], cwd).then((result) => result.stdout.trim()).catch(() => ''),
+    runGit(['config', '--get', 'remote.origin.url'], cwd).then((result) => result.stdout.trim()).catch(() => ''),
+    runGit(['symbolic-ref', '--quiet', '--short', 'HEAD'], cwd).then((result) => result.stdout.trim()).catch(() => ''),
+  ])
+  const baseRepo = githubRepoFromRemote(upstreamRemote)
+  const originRepo = githubRepoFromRemote(originRemote)
+  const args = ['pr', 'create']
+  if (baseRepo) args.push('--repo', baseRepo)
+  if (branch) args.push('--head', originRepo ? `${originRepo.split('/')[0]}:${branch}` : branch)
+  args.push('--title', title, '--body', body)
+  if (options.draft) args.push('--draft')
+  const output = await runCommand('gh', args, cwd)
+  return { url: extractUrl(output), output }
+}

--- a/src/main/git-worktree.test.ts
+++ b/src/main/git-worktree.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  slugifyWorktreePart,
+  worktreeBranchName,
+  worktreeTargetPath,
+} from './git-worktree'
+
+test('slugifyWorktreePart produces safe readable path and branch segments', () => {
+  assert.equal(slugifyWorktreePart('Feature: Add café tabs'), 'feature-add-cafe-tabs')
+  assert.equal(slugifyWorktreePart('---'), 'tab')
+})
+
+test('worktree names are deterministic and isolated by workspace id', () => {
+  assert.equal(
+    worktreeBranchName('Pi Desktop', 'ws-123-abc'),
+    'pi/pi-desktop-123-abc'
+  )
+  const target = worktreeTargetPath('/tmp/gui/worktrees', '/repo/My App', 'ws-123-abc')
+  assert.match(target.replaceAll('\\', '/'), /\/tmp\/gui\/worktrees\/my-app\/my-app-ws-123-abc$/)
+})

--- a/src/main/git-worktree.test.ts
+++ b/src/main/git-worktree.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import {
+  parseGitWorktrees,
   slugifyWorktreePart,
   worktreeBranchName,
   worktreeTargetPath,
@@ -9,6 +10,21 @@ import {
 test('slugifyWorktreePart produces safe readable path and branch segments', () => {
   assert.equal(slugifyWorktreePart('Feature: Add café tabs'), 'feature-add-cafe-tabs')
   assert.equal(slugifyWorktreePart('---'), 'tab')
+})
+
+test('parseGitWorktrees preserves paths, branches, and bare markers', () => {
+  assert.deepEqual(parseGitWorktrees([
+    'worktree E:\\repo\\main app',
+    'HEAD abc123',
+    'branch refs/heads/main',
+    '',
+    'worktree E:\\repo\\bare',
+    'bare',
+    '',
+  ].join('\n')), [
+    { path: 'E:\\repo\\main app', head: 'abc123', branch: 'main', bare: false },
+    { path: 'E:\\repo\\bare', head: null, branch: null, bare: true },
+  ])
 })
 
 test('worktree names are deterministic and isolated by workspace id', () => {

--- a/src/main/git-worktree.ts
+++ b/src/main/git-worktree.ts
@@ -1,0 +1,105 @@
+import { spawn } from 'child_process'
+import { mkdir } from 'fs/promises'
+import { basename, dirname, join, resolve } from 'path'
+
+export interface GitCommandResult {
+  stdout: string
+  stderr: string
+}
+
+export interface GitRepositoryInfo {
+  /** The main repository root, shared by linked worktrees. */
+  repoRoot: string
+  /** The commit checked out by the inspected worktree. */
+  head: string
+  branch: string | null
+  /** Porcelain status; empty means the worktree is clean. */
+  status: string
+}
+
+export function runGit(args: readonly string[], cwd: string): Promise<GitCommandResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn('git', [...args], {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8') })
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8') })
+    child.once('error', reject)
+    child.once('close', (code) => {
+      if (code === 0) {
+        resolvePromise({ stdout, stderr })
+        return
+      }
+      const detail = (stderr || stdout).trim()
+      reject(new Error(`git ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`))
+    })
+  })
+}
+
+async function gitValue(args: readonly string[], cwd: string): Promise<string> {
+  return (await runGit(args, cwd)).stdout.trim()
+}
+
+/**
+ * Return the main repository root and the current worktree state. Calling this
+ * from a linked worktree is intentional: HEAD and dirty files must come from
+ * the worktree the user is cloning, not from the main checkout.
+ */
+export async function inspectGitRepository(cwd: string): Promise<GitRepositoryInfo> {
+  const worktreeRoot = await gitValue(['rev-parse', '--show-toplevel'], cwd)
+  const commonDirRaw = await gitValue(['rev-parse', '--git-common-dir'], cwd)
+  const commonDir = resolve(cwd, commonDirRaw)
+  const repoRoot = dirname(commonDir)
+  const [head, branch, status] = await Promise.all([
+    gitValue(['rev-parse', 'HEAD'], cwd),
+    gitValue(['symbolic-ref', '--quiet', '--short', 'HEAD'], cwd).catch(() => null),
+    gitValue(['status', '--porcelain=v1', '--untracked-files=all'], cwd),
+  ])
+
+  // `--show-toplevel` also validates that the path is a usable checkout. Keep
+  // the variable read above so a future Git implementation cannot accidentally
+  // accept a bare repository without noticing the worktree requirement.
+  if (!worktreeRoot) throw new Error('Git returned an empty worktree root')
+  return { repoRoot, head, branch, status }
+}
+
+export function slugifyWorktreePart(value: string): string {
+  const slug = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  return slug || 'tab'
+}
+
+export function worktreeTargetPath(
+  guiWorktreesDir: string,
+  repoRoot: string,
+  workspaceId: string,
+): string {
+  const repoName = slugifyWorktreePart(basename(repoRoot))
+  return join(guiWorktreesDir, repoName, `${repoName}-${workspaceId}`)
+}
+
+export function worktreeBranchName(label: string, workspaceId: string): string {
+  return `pi/${slugifyWorktreePart(label)}-${workspaceId.replace(/^ws-/, '')}`
+}
+
+export async function createGitWorktree(options: {
+  sourceCwd: string
+  targetPath: string
+  branch: string
+}): Promise<void> {
+  await mkdir(dirname(options.targetPath), { recursive: true })
+  await runGit(['worktree', 'add', '-b', options.branch, options.targetPath, 'HEAD'], options.sourceCwd)
+}
+
+/** Remove only a clean worktree. Git refuses dirty worktrees, preserving edits. */
+export async function removeGitWorktree(repoRoot: string, worktreePath: string): Promise<void> {
+  await runGit(['worktree', 'remove', worktreePath], repoRoot)
+}

--- a/src/main/git-worktree.ts
+++ b/src/main/git-worktree.ts
@@ -17,6 +17,13 @@ export interface GitRepositoryInfo {
   status: string
 }
 
+export interface GitWorktreeEntry {
+  path: string
+  head: string | null
+  branch: string | null
+  bare: boolean
+}
+
 export function runGit(args: readonly string[], cwd: string): Promise<GitCommandResult> {
   return new Promise((resolvePromise, reject) => {
     const child = spawn('git', [...args], {
@@ -42,6 +49,45 @@ export function runGit(args: readonly string[], cwd: string): Promise<GitCommand
 
 async function gitValue(args: readonly string[], cwd: string): Promise<string> {
   return (await runGit(args, cwd)).stdout.trim()
+}
+
+/** Parse `git worktree list --porcelain` without losing Windows paths. */
+export function parseGitWorktrees(output: string): GitWorktreeEntry[] {
+  const entries: GitWorktreeEntry[] = []
+  let current: GitWorktreeEntry | null = null
+
+  const flush = (): void => {
+    if (current) entries.push(current)
+    current = null
+  }
+
+  for (const line of output.split(/\r?\n/)) {
+    if (!line.trim()) {
+      flush()
+      continue
+    }
+    const separator = line.indexOf(' ')
+    const key = separator === -1 ? line : line.slice(0, separator)
+    const value = separator === -1 ? '' : line.slice(separator + 1)
+    if (key === 'worktree') {
+      flush()
+      current = { path: value, head: null, branch: null, bare: false }
+    } else if (!current) {
+      continue
+    } else if (key === 'HEAD') {
+      current.head = value || null
+    } else if (key === 'branch') {
+      current.branch = value.replace(/^refs\/heads\//, '') || null
+    } else if (key === 'bare') {
+      current.bare = true
+    }
+  }
+  flush()
+  return entries
+}
+
+export async function listGitWorktrees(cwd: string): Promise<GitWorktreeEntry[]> {
+  return parseGitWorktrees(await gitValue(['worktree', 'list', '--porcelain'], cwd))
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,11 @@ import { IPC_CHANNELS } from '../shared/ipc-contracts'
 // launcher in bin/pi-desktop.js sets this from `pi-desktop <path>`.
 const WORKSPACE_ENV_VAR = 'PI_DESKTOP_WORKSPACE'
 
+// Electron's development executable otherwise registers as Electron on Windows,
+// which makes the taskbar and notification identity use Electron branding.
+app.setName('Pi Desktop')
+if (process.platform === 'win32') app.setAppUserModelId('dev.pi.desktop-gui')
+
 // Suppress EPIPE errors from closed subprocess pipes
 process.on('uncaughtException', (err) => {
   if (err.message?.includes('EPIPE') || (err as NodeJS.ErrnoException).code === 'EPIPE') {
@@ -161,6 +166,7 @@ function hardenPreviewSession(): void {
 }
 
 function createMainWindow(): BrowserWindow {
+  const appIcon = nativeImage.createFromPath(getAppIconPath())
   const window = new BrowserWindow({
     width: WINDOW_WIDTH,
     height: WINDOW_HEIGHT,
@@ -168,7 +174,7 @@ function createMainWindow(): BrowserWindow {
     minHeight: MIN_WINDOW_HEIGHT,
     title: 'Pi Desktop',
     backgroundColor: '#0a0a0a',
-    icon: getAppIconPath(),
+    icon: appIcon,
     show: false,
     webPreferences: {
       preload: PRELOAD_PATH,
@@ -415,7 +421,7 @@ app.whenReady().then(async () => {
   registerIpcHandlers(workspaceManager, {
     getWindow: () => mainWindow,
     showWindow: showMainWindow,
-  })
+  }, getAppIconPath())
 
   // The renderer mirrors its editor-dirty flag on every transition; the
   // quit/close/reload guards below read the cached value.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -414,6 +414,12 @@ app.whenReady().then(async () => {
   // Lock the HTML preview partition to local files before any preview can load.
   hardenPreviewSession()
 
+  // Resolve the configured engine before exposing IPC or creating the renderer;
+  // otherwise the renderer can win the startup race and launch the default Pi
+  // binary before this setting is applied.
+  const settings = await loadAppSettings(workspaceManager)
+  setPiExecutableOverride(settings.piExecutablePath)
+
   // Register IPC handlers before creating windows. The window getter is a
   // lazy closure — mainWindow is created later and the notification wiring
   // only dereferences it at event time. showMainWindow recreates the window
@@ -437,11 +443,6 @@ app.whenReady().then(async () => {
 
   // System tray: inject deps once, then enable it if the setting is on. The
   // one-time "still running" hint reads/persists via app settings.
-  const settings = await loadAppSettings(workspaceManager)
-
-  // Apply the configured Pi executable path before anything can start Pi.
-  setPiExecutableOverride(settings.piExecutablePath)
-
   setupTray({
     getWindow: () => mainWindow,
     quit: () => app.quit(),

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -39,6 +39,12 @@ export function registerIpcHandlers(
 ): void {
   const ctx = createIpcContext(workspaceManager)
 
+  // Session runtime snapshots are separate from workspace activity: several
+  // live Pi processes may share one project cwd.
+  workspaceManager.onSessionRuntime((runtime) => {
+    ctx.broadcast(IPC_CHANNELS.EVENT_SESSION_RUNTIME, runtime)
+  })
+
   registerPiHandlers(ctx)
   registerTerminalHandlers(ctx)
   registerSessionHandlers(ctx)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -19,6 +19,7 @@ import { registerCouncilHandlers } from './ipc/council-handlers'
 import { registerTagHandlers } from './ipc/tag-handlers'
 import { registerNotesHandlers } from './ipc/notes-handlers'
 import { registerFileHandlers } from './ipc/file-handlers'
+import { registerGitConveyorHandlers } from './ipc/git-conveyor-handlers'
 import { registerSystemHandlers } from './ipc/system-handlers'
 import { registerUpdateHandlers } from './ipc/update-handlers'
 import { registerDiagnosticsHandlers } from './ipc/diagnostics-handlers'
@@ -36,6 +37,7 @@ export { loadAppSettings, saveAppSettings } from './ipc/settings'
 export function registerIpcHandlers(
   workspaceManager: WorkspaceManager,
   windowControls: WindowControls = { getWindow: () => null, showWindow: () => {} },
+  iconPath = '',
 ): void {
   const ctx = createIpcContext(workspaceManager)
 
@@ -60,6 +62,7 @@ export function registerIpcHandlers(
   registerTagHandlers(ctx)
   registerNotesHandlers(ctx)
   registerFileHandlers(ctx)
+  registerGitConveyorHandlers(ctx)
   registerSystemHandlers(ctx)
   registerUpdateHandlers()
   registerDiagnosticsHandlers(ctx)
@@ -69,7 +72,7 @@ export function registerIpcHandlers(
 
   // Cross-workspace activity map + desktop notifications. Wired before the
   // router so it can observe the router's pending-prompt counts below.
-  const workspaceActivity = wireWorkspaceActivity(ctx, windowControls)
+  const workspaceActivity = wireWorkspaceActivity(ctx, windowControls, iconPath)
 
   // Router construction, the dialog-answer channels, the pending-prompt
   // flush/get pair and the two workspace hooks all live in extension-ui-ipc.ts

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -22,6 +22,7 @@ import { registerFileHandlers } from './ipc/file-handlers'
 import { registerSystemHandlers } from './ipc/system-handlers'
 import { registerUpdateHandlers } from './ipc/update-handlers'
 import { registerDiagnosticsHandlers } from './ipc/diagnostics-handlers'
+import { registerWorkflowHandlers } from './ipc/workflow-handlers'
 import { wireWorkspaceActivity, type WindowControls } from './ipc/workspace-activity-wiring'
 
 export { loadAppSettings, saveAppSettings } from './ipc/settings'
@@ -56,6 +57,7 @@ export function registerIpcHandlers(
   registerSystemHandlers(ctx)
   registerUpdateHandlers()
   registerDiagnosticsHandlers(ctx)
+  registerWorkflowHandlers(ctx)
 
   // ─── Extension UI Responses and Pi Event Forwarding ─────────────────────
 

--- a/src/main/ipc/git-conveyor-handlers.ts
+++ b/src/main/ipc/git-conveyor-handlers.ts
@@ -1,0 +1,39 @@
+import { ipcMain } from 'electron'
+import { IPC_CHANNELS } from '../../shared/ipc-contracts'
+import type {
+  GitConveyorCommitOptions,
+  GitConveyorPullRequestOptions,
+} from '../../shared/ipc-contracts'
+import { isObject, isOptionalBoolean, isString } from './validation'
+import { commitAll, createPullRequest, getGitConveyorStatus, pushBranch } from '../git-conveyor'
+import type { IpcContext } from './context'
+
+function activeCwd(ctx: IpcContext): string {
+  const cwd = ctx.workspaceManager.getActiveWorkspace()?.path
+  if (!cwd) throw new Error('No active workspace')
+  return cwd
+}
+
+export function registerGitConveyorHandlers(ctx: IpcContext): void {
+  ipcMain.handle(IPC_CHANNELS.GIT_CONVEYOR_STATUS, async () => getGitConveyorStatus(activeCwd(ctx)))
+
+  ipcMain.handle(IPC_CHANNELS.GIT_CONVEYOR_COMMIT, async (_event, input: unknown) => {
+    if (!isObject(input) || !isString(input.message)) throw new Error('Commit message must be a string')
+    const options: GitConveyorCommitOptions = { message: input.message }
+    return commitAll(activeCwd(ctx), options)
+  })
+
+  ipcMain.handle(IPC_CHANNELS.GIT_CONVEYOR_PUSH, async () => pushBranch(activeCwd(ctx)))
+
+  ipcMain.handle(IPC_CHANNELS.GIT_CONVEYOR_CREATE_PR, async (_event, input: unknown) => {
+    if (!isObject(input) || !isString(input.title) || !isString(input.body) || !isOptionalBoolean(input.draft)) {
+      throw new Error('Pull request title, body, and optional draft flag are required')
+    }
+    const options: GitConveyorPullRequestOptions = {
+      title: input.title,
+      body: input.body,
+      ...(typeof input.draft === 'boolean' ? { draft: input.draft } : {}),
+    }
+    return createPullRequest(activeCwd(ctx), options)
+  })
+}

--- a/src/main/ipc/pi-handlers.ts
+++ b/src/main/ipc/pi-handlers.ts
@@ -5,6 +5,7 @@ import { isString, isObject } from './validation'
 import { validateStartOptions, applyResumePreference, applyPermissionModeToStartOptions } from './pi-start-options'
 import { loadAppSettings } from './settings'
 import type { IpcContext } from './context'
+import { detectPiInstallations } from '../pi-rpc-manager'
 
 export function registerPiHandlers(ctx: IpcContext): void {
   const { workspaceManager, getActivePi } = ctx
@@ -73,6 +74,10 @@ export function registerPiHandlers(ctx: IpcContext): void {
     if (!pi) return { status: 'stopped', pid: null, error: null }
     return pi.getStatus()
   })
+
+  ipcMain.handle(IPC_CHANNELS.PI_DETECT_INSTALLATIONS, async () => ({
+    installations: detectPiInstallations(),
+  }))
 
   // ─── Pi Commands ────────────────────────────────────────────────────────
 

--- a/src/main/ipc/pi-start-options.ts
+++ b/src/main/ipc/pi-start-options.ts
@@ -49,7 +49,7 @@ function toolsForPermissionMode(mode: PermissionMode): string | null {
  * session or an ephemeral (no-session) run.
  */
 export function applyResumePreference(options: PiStartOptions, settings: AppSettings): PiStartOptions {
-  if (settings.resumeLastSession && !options.sessionPath && !options.noSession) {
+  if (settings.resumeLastSession && !options.sessionPath && !options.forkSessionPath && !options.noSession) {
     return { ...options, continueSession: true }
   }
   return options
@@ -99,6 +99,7 @@ export function validateStartOptions(value: unknown): PiStartOptions {
   if (!isOptionalString(value.model)) throw new Error('model must be a string')
   if (!isOptionalString(value.provider)) throw new Error('provider must be a string')
   if (!isOptionalString(value.sessionPath)) throw new Error('sessionPath must be a string')
+  if (!isOptionalString(value.forkSessionPath)) throw new Error('forkSessionPath must be a string')
   if (!isOptionalBoolean(value.noSession)) throw new Error('noSession must be a boolean')
   if (!isOptionalStringArray(value.args)) throw new Error('args must be a string array')
   if (value.env !== undefined && !isObject(value.env)) throw new Error('env must be an object')
@@ -107,6 +108,7 @@ export function validateStartOptions(value: unknown): PiStartOptions {
   if (isString(value.model)) opts.model = value.model
   if (isString(value.provider)) opts.provider = value.provider
   if (isString(value.sessionPath)) opts.sessionPath = value.sessionPath
+  if (isString(value.forkSessionPath)) opts.forkSessionPath = value.forkSessionPath
   if (value.noSession === true) opts.noSession = true
   if (Array.isArray(value.args)) opts.args = value.args as string[]
   if (isObject(value.env)) {

--- a/src/main/ipc/pi-start-options.ts
+++ b/src/main/ipc/pi-start-options.ts
@@ -6,8 +6,10 @@ import { join } from 'path'
 import { existsSync } from 'fs'
 import { PERMISSION_RULES_FILE_NAME } from '../../../resources/permission-rules'
 import { isString, isObject, isOptionalString, isOptionalBoolean, isOptionalStringArray } from './validation'
+import { getPiCli } from '../pi-rpc-manager'
 
 const READ_ONLY_TOOLS = 'read,grep,find,ls'
+const OMP_READ_ONLY_TOOLS = 'read,grep,glob'
 
 const PERMISSIONS_EXTENSION_PATH = app.isPackaged
   ? join(process.resourcesPath, 'resources', 'pi-desktop-permissions.ts')
@@ -32,10 +34,10 @@ function removeToolArgs(args: string[]): string[] {
   return filtered
 }
 
-function toolsForPermissionMode(mode: PermissionMode): string | null {
+function toolsForPermissionMode(mode: PermissionMode, runtime: 'pi' | 'omp' = 'pi'): string | null {
   switch (mode) {
     case 'plan-readonly':
-      return READ_ONLY_TOOLS
+      return runtime === 'omp' ? OMP_READ_ONLY_TOOLS : READ_ONLY_TOOLS
     case 'ask-commands':
     case 'ask-edits':
     case 'trusted':
@@ -59,7 +61,7 @@ export function applyPermissionModeToStartOptions(
   options: PiStartOptions,
   settings: AppSettings
 ): PiStartOptions {
-  const toolList = toolsForPermissionMode(settings.permissionMode)
+  const toolList = toolsForPermissionMode(settings.permissionMode, getPiCli().kind ?? 'pi')
   const args = toolList
     ? [...removeToolArgs(options.args ?? []), '--tools', toolList]
     : [...(options.args ?? [])]

--- a/src/main/ipc/run-pi-cli.ts
+++ b/src/main/ipc/run-pi-cli.ts
@@ -14,11 +14,21 @@ export async function runPiCli(
 ): Promise<{ success: boolean; output: string }> {
   try {
     const cli = getPiCli()
+    // OMP keeps `install` as a Pi-compatible alias but names the other plugin
+    // mutations explicitly. Preserve the package panel's existing contract
+    // while routing those two verbs to OMP's native commands.
+    const cliArgs = cli.kind === 'omp'
+      ? args[0] === 'remove'
+        ? ['plugin', 'uninstall', ...args.slice(1)]
+        : args[0] === 'update'
+        ? ['plugin', 'upgrade', ...args.slice(1)]
+        : args
+      : args
     // Package specs reach this argv from the renderer, and shell:true means
     // Node quotes nothing — buildPiInvocation escapes the whole invocation for
     // the cmd.exe traversal. A spec cmd.exe cannot carry throws here and is
     // reported through the same failure path as any other CLI error below.
-    const invocation = buildPiInvocation(cli, args)
+    const invocation = buildPiInvocation(cli, cliArgs)
     const { stdout, stderr } = await execFileAsync(invocation.file, invocation.args, {
       cwd,
       timeout,

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -154,6 +154,7 @@ export function registerSessionHandlers(ctx: IpcContext): void {
   })
 
   ipcMain.handle(IPC_CHANNELS.SESSION_LIST_RUNTIMES, async () => {
+    await workspaceManager.pruneEmptySessionRuntimes()
     return workspaceManager.getSessionRuntimes()
   })
 
@@ -312,6 +313,7 @@ async function fillSessionLabels(entries: SessionEntry[]): Promise<void> {
 function createListSessions(wm: WorkspaceManager) {
   return async function listSessions(_cwd: string): Promise<SessionEntry[]> {
     try {
+      await wm.pruneEmptySessionRuntimes()
       const sessionsDir = getSessionsRoot()
       const entries: SessionEntry[] = []
       // Precompute workspace match map once (was O(workspaces) per file).

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -8,13 +8,13 @@ import {
   projectNameFromPath,
   JSONL_EXTENSION,
 } from '../session-paths'
-import { pathGroupKey as workspaceMatchKey } from '../../shared/path-compare'
+import { pathGroupKey as workspaceMatchKey, pathsEqual } from '../../shared/path-compare'
 import { readSessionMetadataCached } from '../session-metadata'
 import { mapWithConcurrency } from '../map-concurrent'
 import { readSessionLineage } from '../session-lineage-reader'
 import { trimGetMessagesResponse } from '../get-messages-trim'
 import { activityStatsStore } from '../activity-stats'
-import type { SessionDeleteResult, SessionListItem } from '../../shared/ipc-contracts'
+import type { SessionDeleteResult, SessionListItem, SessionRuntimeInfo } from '../../shared/ipc-contracts'
 import { IPC_CHANNELS } from '../../shared/ipc-contracts'
 import { readdir, stat, unlink } from 'fs/promises'
 import { basename, join } from 'path'
@@ -22,6 +22,8 @@ import { isPathWithin } from '../path-authorization'
 import { existsSync } from 'fs'
 import { spawnSync } from 'child_process'
 import { assertTrustedSender, isString } from './validation'
+import { applyResumePreference, applyPermissionModeToStartOptions } from './pi-start-options'
+import { loadAppSettings } from './settings'
 import type { IpcContext } from './context'
 
 const MAX_SESSION_LIST = 100
@@ -66,24 +68,54 @@ async function deleteSessionFile(sessionPath: string): Promise<SessionDeleteResu
 export function registerSessionHandlers(ctx: IpcContext): void {
   const { workspaceManager, getActivePi, tagManager, archivedSessions } = ctx
 
+  const startRuntime = async (runtime: SessionRuntimeInfo, sessionPath?: string): Promise<void> => {
+    const settings = await loadAppSettings(workspaceManager)
+    const workspace = workspaceManager.getWorkspaces().find((item) => item.id === runtime.workspaceId)
+    if (!workspace) return
+    const options = {
+      cwd: workspace.path,
+      ...(sessionPath ? { sessionPath } : {}),
+      provider: settings.defaultProvider ?? undefined,
+      model: settings.defaultModel ?? undefined,
+    }
+    await workspaceManager.startSessionRuntime(runtime.runtimeId, applyPermissionModeToStartOptions(
+      sessionPath ? applyResumePreference(options, settings) : options,
+      settings
+    ))
+  }
+
   // ─── Session Management ─────────────────────────────────────────────────
 
-  ipcMain.handle(IPC_CHANNELS.SESSION_NEW, async () => {
-    const pi = workspaceManager.getActivePiManager()
-    if (!pi || pi.getStatus().status !== 'running') {
-      return { success: false, error: 'Pi not running. Start Pi first.' }
-    }
-    return pi.sendCommand({ type: 'new_session' })
+  ipcMain.handle(IPC_CHANNELS.SESSION_NEW, async (): Promise<SessionRuntimeInfo> => {
+    const workspace = workspaceManager.getActiveWorkspace()
+    if (!workspace) throw new Error('No active workspace')
+    const runtime = await workspaceManager.createNewSessionRuntime(workspace.id)
+    // Navigation must not wait for Pi startup. The runtime event marks it
+    // starting/running and hydrates the renderer when ready.
+    void startRuntime(runtime).catch(() => undefined)
+    return runtime
   })
 
-  ipcMain.handle(IPC_CHANNELS.SESSION_SWITCH, async (_event, sessionPath: unknown) => {
-    if (!isString(sessionPath)) throw new Error('sessionPath must be a string')
-    const pi = workspaceManager.getActivePiManager()
-    if (!pi || pi.getStatus().status !== 'running') {
-      // Pi not running — just store the path for when it starts
-      return { success: false, error: 'Pi not running. Start Pi first.' }
+  const activateSession = async (sessionPath: string, cwd?: string): Promise<SessionRuntimeInfo> => {
+    if (!isPathWithin(getSessionsRoot(), sessionPath) || !existsSync(sessionPath)) {
+      throw new Error('sessionPath must point to an existing Pi session file')
     }
-    return pi.sendCommand({ type: 'switch_session', sessionPath })
+    const workspace = workspaceManager.getActiveWorkspace()
+    if (!workspace) throw new Error('No active workspace')
+    if (cwd && !pathsEqual(workspace.path, cwd)) throw new Error('Session project does not match the active workspace')
+    const runtime = await workspaceManager.activateSession(workspace.id, sessionPath)
+    if (runtime.status !== 'running') void startRuntime(runtime, sessionPath).catch(() => undefined)
+    return runtime
+  }
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_SWITCH, async (_event, sessionPath: unknown, cwd?: unknown) => {
+    if (!isString(sessionPath)) throw new Error('sessionPath must be a string')
+    if (cwd !== undefined && !isString(cwd)) throw new Error('cwd must be a string')
+    return activateSession(sessionPath, isString(cwd) ? cwd : undefined)
+  })
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_LIST_RUNTIMES, async () => {
+    return workspaceManager.getSessionRuntimes()
   })
 
   ipcMain.handle(IPC_CHANNELS.SESSION_FORK, async (_event, entryId?: unknown) => {

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -215,9 +215,20 @@ const SESSION_NAME_READ_CONCURRENCY = 24
  */
 async function fillSessionLabels(entries: SessionEntry[]): Promise<void> {
   await mapWithConcurrency(entries, SESSION_NAME_READ_CONCURRENCY, async (entry) => {
-    const { name, preview } = await readSessionMetadataCached(entry.path, entry.lastModified)
+    const { name, preview, header } = await readSessionMetadataCached(entry.path, entry.lastModified)
     entry.name = name
     entry.preview = preview
+    entry.piSessionId = header?.id
+    // The session header's cwd is authoritative: session directory names are
+    // lossy decodes of real paths (hyphens vs separators collide), so the
+    // workspace-match/desanitize values from collectSessionFiles can point at
+    // a phantom path. Repair the project from the header so opening the
+    // session creates/activates the REAL workspace and never re-persists a
+    // phantom one. The filename-stem sessionId (tags/archive key) is untouched.
+    if (header?.cwd) {
+      entry.projectPath = header.cwd
+      entry.projectName = projectNameFromPath(header.cwd)
+    }
   })
 }
 

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -21,7 +21,7 @@ import { basename, join } from 'path'
 import { isPathWithin } from '../path-authorization'
 import { existsSync } from 'fs'
 import { spawnSync } from 'child_process'
-import { assertTrustedSender, isString } from './validation'
+import { assertTrustedSender, isObject, isString } from './validation'
 import { applyResumePreference, applyPermissionModeToStartOptions } from './pi-start-options'
 import { loadAppSettings } from './settings'
 import type { IpcContext } from './context'
@@ -93,6 +93,25 @@ export function registerSessionHandlers(ctx: IpcContext): void {
     // Navigation must not wait for Pi startup. The runtime event marks it
     // starting/running and hydrates the renderer when ready.
     void startRuntime(runtime).catch(() => undefined)
+    return runtime
+  })
+
+  ipcMain.handle(IPC_CHANNELS.SESSION_LAUNCH_TASK, async (_event, input: unknown): Promise<SessionRuntimeInfo> => {
+    if (!isObject(input) || !isString(input.workspaceId) || !isString(input.prompt) || !input.prompt.trim()) {
+      throw new Error('workspaceId and a non-empty prompt are required')
+    }
+    const workspace = workspaceManager.getWorkspaces().find((item) => item.id === input.workspaceId)
+    if (!workspace) throw new Error('Workspace not found')
+    const runtime = await workspaceManager.createNewSessionRuntime(workspace.id)
+    // Keep the prompt attached to this runtime. It must not go through the
+    // renderer's active-manager shortcut because the user can switch away
+    // before Pi finishes starting.
+    void startRuntime(runtime)
+      .then(() => workspaceManager.sendCommandToSessionRuntime(runtime.runtimeId, {
+        type: 'prompt',
+        message: input.prompt,
+      }))
+      .catch(() => undefined)
     return runtime
   })
 

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -14,7 +14,7 @@ import { mapWithConcurrency } from '../map-concurrent'
 import { readSessionLineage } from '../session-lineage-reader'
 import { trimGetMessagesResponse } from '../get-messages-trim'
 import { activityStatsStore } from '../activity-stats'
-import type { SessionDeleteResult, SessionListItem, SessionRuntimeInfo } from '../../shared/ipc-contracts'
+import type { SessionDeleteResult, SessionListItem, SessionRuntimeCloseResult, SessionRuntimeInfo } from '../../shared/ipc-contracts'
 import { IPC_CHANNELS } from '../../shared/ipc-contracts'
 import { readdir, stat, unlink } from 'fs/promises'
 import { basename, join } from 'path'
@@ -127,6 +127,26 @@ export function registerSessionHandlers(ctx: IpcContext): void {
     return runtime
   }
 
+  ipcMain.handle(IPC_CHANNELS.SESSION_CLOSE_RUNTIME, async (_event, runtimeId: unknown): Promise<SessionRuntimeCloseResult | null> => {
+    if (!isString(runtimeId)) throw new Error('runtimeId must be a string')
+    const result = await workspaceManager.closeSessionRuntime(runtimeId)
+    if (!result) return null
+
+    let deleted = false
+    if (result.empty && result.sessionPath && isPathWithin(getSessionsRoot(), result.sessionPath) && existsSync(result.sessionPath)) {
+      activityStatsStore.captureBeforeDelete(result.sessionPath)
+      const deleteResult = await deleteSessionFile(result.sessionPath)
+      deleted = deleteResult.ok
+      if (deleted) {
+        const sessionId = sessionIdFromPath(result.sessionPath)
+        await archivedSessions.forget(sessionId)
+        await tagManager.setTags(sessionId, [])
+        await tagManager.forgetAuto(sessionId)
+      }
+    }
+    return { ...result, deleted }
+  })
+
   ipcMain.handle(IPC_CHANNELS.SESSION_SWITCH, async (_event, sessionPath: unknown, cwd?: unknown) => {
     if (!isString(sessionPath)) throw new Error('sessionPath must be a string')
     if (cwd !== undefined && !isString(cwd)) throw new Error('cwd must be a string')
@@ -205,6 +225,12 @@ export function registerSessionHandlers(ctx: IpcContext): void {
     if (!isPathWithin(getSessionsRoot(), sessionPath)) {
       throw new Error('sessionPath must be inside the Pi sessions directory')
     }
+
+    // Detach any live tab first. Otherwise deleting an active/session-tab file
+    // leaves a runtime pointing at a path that SESSION_SWITCH can no longer
+    // validate, producing a stale "existing Pi session file" error.
+    const runtime = workspaceManager.getSessionRuntimeForPath(sessionPath)
+    if (runtime) await workspaceManager.closeSessionRuntime(runtime.runtimeId)
 
     // Roll this session into the persisted stats store *before* removing the
     // file, so its activity survives the deletion (see activity-stats.ts).
@@ -299,7 +325,10 @@ function createListSessions(wm: WorkspaceManager) {
       // whole store), then surface each session's latest session_info name.
       const top = entries.slice(0, MAX_SESSION_LIST)
       await fillSessionLabels(top)
-      return top
+      // Pi creates the JSONL header before the first user turn. Do not expose
+      // those disposable empty sessions in Recent/Sessions; they cannot be
+      // resumed meaningfully and become stale switch targets after a restart.
+      return top.filter((entry) => entry.preview !== null)
     } catch {
       return []
     }

--- a/src/main/ipc/skills-mcp-handlers.ts
+++ b/src/main/ipc/skills-mcp-handlers.ts
@@ -4,6 +4,7 @@ import { readdir, readFile } from 'fs/promises'
 import { join } from 'path'
 import { existsSync } from 'fs'
 import type { IpcContext } from './context'
+import { getPiCli } from '../pi-rpc-manager'
 
 export function registerSkillsMcpHandlers(ctx: IpcContext): void {
   const { workspaceManager } = ctx
@@ -20,7 +21,8 @@ export function registerSkillsMcpHandlers(ctx: IpcContext): void {
     const pi = workspaceManager.getActivePiManager()
     if (!pi || pi.getStatus().status !== 'running') return []
     try {
-      const response = await pi.sendCommand({ type: 'get_commands' }) as { success?: boolean; data?: { commands?: unknown[] } } | null
+      const command = getPiCli().kind === 'omp' ? 'get_available_commands' : 'get_commands'
+      const response = await pi.sendCommand({ type: command }) as { success?: boolean; data?: { commands?: unknown[] } } | null
       if (response?.success && response.data?.commands) {
         return response.data.commands
       }
@@ -53,6 +55,7 @@ async function listSkills(cwd: string): Promise<InstalledSkill[]> {
   // Global skills
   const globalPaths = [
     join(homeDir, '.pi', 'agent', 'skills'),
+    join(homeDir, '.omp', 'agent', 'skills'),
     join(homeDir, '.agents', 'skills'),
   ]
 
@@ -63,6 +66,7 @@ async function listSkills(cwd: string): Promise<InstalledSkill[]> {
   // Project skills
   const projectPaths = [
     join(cwd, '.pi', 'skills'),
+    join(cwd, '.omp', 'skills'),
     join(cwd, '.agents', 'skills'),
   ]
 
@@ -165,13 +169,25 @@ async function listMcpServers(wsPath?: string): Promise<McpServerInfo[]> {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? ''
 
   // Check Pi global settings for mcpServers
-  const globalSettingsPath = join(homeDir, '.pi', 'agent', 'settings.json')
-  await collectMcpServers(globalSettingsPath, servers, 'global')
+  const globalSettingsPaths = [
+    join(homeDir, '.pi', 'agent', 'settings.json'),
+    join(homeDir, '.omp', 'agent', 'mcp.json'),
+    join(homeDir, '.omp', 'agent', '.mcp.json'),
+  ]
+  for (const settingsPath of globalSettingsPaths) {
+    await collectMcpServers(settingsPath, servers, 'global')
+  }
 
   // Check project settings
   if (wsPath) {
-    const projectSettingsPath = join(wsPath, '.pi', 'settings.json')
-    await collectMcpServers(projectSettingsPath, servers, 'project')
+    const projectSettingsPaths = [
+      join(wsPath, '.pi', 'settings.json'),
+      join(wsPath, '.omp', 'mcp.json'),
+      join(wsPath, '.omp', '.mcp.json'),
+    ]
+    for (const settingsPath of projectSettingsPaths) {
+      await collectMcpServers(settingsPath, servers, 'project')
+    }
   }
 
   // Also check common MCP config locations

--- a/src/main/ipc/workflow-handlers.ts
+++ b/src/main/ipc/workflow-handlers.ts
@@ -82,7 +82,7 @@ export function registerWorkflowHandlers(ctx: IpcContext): void {
 
       // Route to the run's OWN workspace Pi process, never the active one —
       // the active session and its Pi stay untouched.
-      const pi = ctx.workspaceManager.getPiManager(workspaceId)
+      const pi = ctx.workspaceManager.getPiManagerForSession(workspaceId, run.sessionId)
       if (!pi) return fail('no-pi')
       if (pi.getStatus().status !== 'running') return fail('pi-not-running')
 

--- a/src/main/ipc/workflow-handlers.ts
+++ b/src/main/ipc/workflow-handlers.ts
@@ -1,0 +1,114 @@
+import { ipcMain, type IpcMainInvokeEvent } from 'electron'
+import { IPC_CHANNELS, type WorkflowControlAction, type WorkflowControlResult } from '../../shared/ipc-contracts'
+import { getWorkflowRun, listWorkflowRuns, resolveWorkflowWorkspaces, setWorkflowPersistence } from '../workflow-monitor'
+import { assertTrustedSender, isString } from './validation'
+import type { PiRpcManager } from '../pi-rpc-manager'
+import type { IpcContext } from './context'
+
+/**
+ * The one resolved workspace projection shared by list, getRun and control:
+ * registered workspaces keep their ids (healed in memory when their persisted
+ * path is a lossy phantom), plus read-only `workflow-<key>` projections for
+ * every discovered project that is not registered.
+ */
+async function workflowWorkspaces(ctx: IpcContext) {
+  return resolveWorkflowWorkspaces(ctx.workspaceManager.getWorkspaces())
+}
+
+async function findWorkspace(ctx: IpcContext, workspaceId: string) {
+  const workspaces = await workflowWorkspaces(ctx)
+  return workspaces.find((workspace) => workspace.id === workspaceId) ?? null
+}
+
+// The extension's authoritative control matrix (workflow-control-tool.ts
+// `allowedActions`): stop = running|paused, resume = paused|failed|pending.
+// The extension enforces it again at dispatch time; this gate only decides
+// which buttons are meaningful and avoids dispatching doomed commands.
+function actionAllowedForStatus(action: WorkflowControlAction, status: string): boolean {
+  if (action === 'stop') return status === 'running' || status === 'paused'
+  if (action === 'resume') return status === 'paused' || status === 'failed' || status === 'pending'
+  return false
+}
+
+/** Probe the workspace's Pi for the `/workflows` extension command. */
+async function hasWorkflowsExtension(pi: PiRpcManager): Promise<boolean> {
+  const response = await pi.sendCommand({ type: 'get_commands' }) as
+    | { success?: boolean; data?: { commands?: Array<{ name?: unknown; source?: unknown }> } }
+    | null
+  if (!response?.success || !Array.isArray(response.data?.commands)) return false
+  return response.data.commands.some(
+    (command) => command?.name === 'workflows' && command?.source === 'extension'
+  )
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && /timed out/i.test(error.message)
+}
+
+export function registerWorkflowHandlers(ctx: IpcContext): void {
+  ipcMain.handle(IPC_CHANNELS.WORKFLOW_LIST, async (event: IpcMainInvokeEvent) => {
+    assertTrustedSender(event)
+    // The launch-cwd projection must be included here too, not only in
+    // findWorkspace: a run from the current (possibly unregistered) project
+    // has to appear in the navigator list as well as be openable by id.
+    return listWorkflowRuns(await workflowWorkspaces(ctx))
+  })
+
+  ipcMain.handle(IPC_CHANNELS.WORKFLOW_GET_RUN, async (event: IpcMainInvokeEvent, workspaceId: unknown, runId: unknown) => {
+    assertTrustedSender(event)
+    if (!isString(workspaceId) || !isString(runId)) throw new Error('workspaceId and runId must be strings')
+    const workspace = await findWorkspace(ctx, workspaceId)
+    if (!workspace) throw new Error('Workspace not found')
+    const run = await getWorkflowRun(workspace, runId)
+    if (!run) throw new Error('Workflow run not found')
+    return run
+  })
+
+  ipcMain.handle(
+    IPC_CHANNELS.WORKFLOW_CONTROL,
+    async (event: IpcMainInvokeEvent, workspaceId: unknown, runId: unknown, action: unknown): Promise<WorkflowControlResult> => {
+      assertTrustedSender(event)
+      if (!isString(workspaceId) || !isString(runId) || (action !== 'stop' && action !== 'resume')) {
+        throw new Error('workspaceId, runId and action are required')
+      }
+      const fail = (reason: WorkflowControlResult['reason']): WorkflowControlResult => ({ action, runId, ok: false, reason })
+
+      // Gate on the persisted status first (never fake a transition locally).
+      const workspace = await findWorkspace(ctx, workspaceId)
+      if (!workspace) return fail('no-pi')
+      const run = await getWorkflowRun(workspace, runId)
+      if (!run) return fail('status-not-permitted')
+      if (!actionAllowedForStatus(action, run.status)) return fail('status-not-permitted')
+
+      // Route to the run's OWN workspace Pi process, never the active one —
+      // the active session and its Pi stay untouched.
+      const pi = ctx.workspaceManager.getPiManager(workspaceId)
+      if (!pi) return fail('no-pi')
+      if (pi.getStatus().status !== 'running') return fail('pi-not-running')
+
+      // The extension command is what executes the control; only dispatch when
+      // it is actually registered in that Pi process. Without this probe an
+      // unloaded extension would fall through to a real LLM prompt turn.
+      try {
+        if (!(await hasWorkflowsExtension(pi))) return fail('extension-missing')
+      } catch {
+        return fail('extension-missing')
+      }
+
+      try {
+        // Extension commands execute immediately in Pi, even during streaming —
+        // no LLM turn is started for a registered command.
+        await pi.sendCommand({ type: 'prompt', message: `/workflows ${action} ${runId}` })
+        return { action, runId, ok: true, dispatched: true }
+      } catch (error) {
+        return fail(isTimeoutError(error) ? 'timeout' : 'dispatch-failed')
+      }
+    }
+  )
+
+  ipcMain.handle(IPC_CHANNELS.WORKFLOW_SET_PERSISTENCE, async (event: IpcMainInvokeEvent, enabled: unknown) => {
+    assertTrustedSender(event)
+    if (typeof enabled !== 'boolean') throw new Error('enabled must be a boolean')
+    await setWorkflowPersistence(enabled)
+  })
+}

--- a/src/main/ipc/workspace-activity-wiring.ts
+++ b/src/main/ipc/workspace-activity-wiring.ts
@@ -1,6 +1,6 @@
 import { ipcMain, Notification, type BrowserWindow } from 'electron'
 import { IPC_CHANNELS } from '../../shared/ipc-contracts'
-import type { PiProcessStatus } from '../../shared/ipc-contracts'
+import type { PiProcessStatus, WorkspaceActivationIntent } from '../../shared/ipc-contracts'
 import {
   createWorkspaceActivityTracker,
   type WorkspaceActivityNotification,
@@ -34,12 +34,13 @@ export interface WindowControls {
 export function wireWorkspaceActivity(
   ctx: IpcContext,
   windowControls: WindowControls,
+  iconPath: string,
 ): WorkspaceActivityTracker {
   const { workspaceManager } = ctx
   const { getWindow, showWindow } = windowControls
   // Activation intent from a notification clicked while no window existed;
   // the freshly created renderer pulls it once its subscriptions are live.
-  let pendingActivationWorkspaceId: string | null = null
+  let pendingActivation: WorkspaceActivationIntent | null = null
 
   const showNotification = async (
     notification: WorkspaceActivityNotification,
@@ -61,7 +62,10 @@ export function wireWorkspaceActivity(
 
     const osNotification = new Notification({
       title: workspace.name,
-      body: NOTIFICATION_BODIES[notification.kind],
+      body: notification.sessionPath
+        ? `${NOTIFICATION_BODIES[notification.kind]} Click to open the finished session.`
+        : NOTIFICATION_BODIES[notification.kind],
+      ...(iconPath ? { icon: iconPath } : {}),
     })
     osNotification.on('click', () => {
       // The workspace can be removed between showing and clicking; a stale
@@ -75,7 +79,12 @@ export function wireWorkspaceActivity(
       // reload, or with the window closed cannot guarantee. A renderer that
       // does receive the broadcast consumes the stash immediately; one that
       // missed it pulls the stash when its subscriptions come up.
-      if (stillExists) pendingActivationWorkspaceId = notification.workspaceId
+      const intent: WorkspaceActivationIntent = {
+        workspaceId: notification.workspaceId,
+        ...(notification.sessionPath ? { sessionPath: notification.sessionPath } : {}),
+        ...(notification.runtimeId ? { runtimeId: notification.runtimeId } : {}),
+      }
+      if (stillExists) pendingActivation = intent
       const win = getWindow()
       if (win) {
         if (win.isMinimized()) win.restore()
@@ -85,9 +94,7 @@ export function wireWorkspaceActivity(
         // dirty-editor confirms), so hand it the intent instead of switching
         // main-side and desyncing its store.
         if (stillExists) {
-          ctx.broadcast(IPC_CHANNELS.EVENT_ACTIVATE_WORKSPACE, {
-            workspaceId: notification.workspaceId,
-          })
+          ctx.broadcast(IPC_CHANNELS.EVENT_ACTIVATE_WORKSPACE, intent)
         }
       } else {
         // macOS: the window may be fully closed — recreate it; the fresh
@@ -117,19 +124,27 @@ export function wireWorkspaceActivity(
       const id = workspaceIdOf()
       if (id) tracker.handleAgentStart(id)
     })
+    const sessionTarget = (): { runtimeId?: string; sessionPath?: string } => {
+      const sessionPath = workspaceManager.sessionPathFor(manager)
+      const runtimeId = workspaceManager.runtimeIdFor(manager)
+      return {
+        ...(sessionPath ? { sessionPath } : {}),
+        ...(sessionPath && runtimeId ? { runtimeId } : {}),
+      }
+    }
     manager.on('agent_end', () => {
       const id = workspaceIdOf()
-      if (id) tracker.handleAgentEnd(id)
+      if (id) tracker.handleAgentEnd(id, sessionTarget())
     })
     manager.on('status-change', (status: PiProcessStatus) => {
       const id = workspaceIdOf()
-      if (id) tracker.handleStatusChange(id, status)
+      if (id) tracker.handleStatusChange(id, status, sessionTarget())
     })
     // Only unexpected death emits 'exit' (deliberate stop() detaches
     // listeners first) — this is what distinguishes a crash from a stop.
     manager.on('exit', () => {
       const id = workspaceIdOf()
-      if (id) tracker.handleProcessExit(id)
+      if (id) tracker.handleProcessExit(id, sessionTarget())
     })
   })
 
@@ -144,9 +159,9 @@ export function wireWorkspaceActivity(
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_ACTIVITY_GET, async () => tracker.getMap())
 
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_TAKE_PENDING_ACTIVATION, async () => {
-    const workspaceId = pendingActivationWorkspaceId
-    pendingActivationWorkspaceId = null
-    return workspaceId
+    const intent = pendingActivation
+    pendingActivation = null
+    return intent
   })
 
   return tracker

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import { IPC_CHANNELS } from '../../shared/ipc-contracts'
-import { isString, isObject, isOptionalString } from './validation'
+import { isString, isObject, isOptionalBoolean, isOptionalString } from './validation'
 import { validateStartOptions, applyResumePreference, applyPermissionModeToStartOptions } from './pi-start-options'
 import { loadAppSettings } from './settings'
 import type { WorkspaceTabOptions } from '../../shared/ipc-contracts'
@@ -16,11 +16,13 @@ function validateWorkspaceTabOptions(value: unknown): WorkspaceTabOptions {
   if (!isOptionalString(value.name)) throw new Error('tab name must be a string')
   if (!isOptionalString(value.sourceWorkspaceId)) throw new Error('sourceWorkspaceId must be a string')
   if (!isOptionalString(value.forkSessionPath)) throw new Error('forkSessionPath must be a string')
+  if (!isOptionalBoolean(value.startPi)) throw new Error('startPi must be a boolean')
 
   return {
     ...(isString(value.name) ? { name: value.name } : {}),
     ...(isString(value.sourceWorkspaceId) ? { sourceWorkspaceId: value.sourceWorkspaceId } : {}),
     ...(isString(value.forkSessionPath) ? { forkSessionPath: value.forkSessionPath } : {}),
+    ...(typeof value.startPi === 'boolean' ? { startPi: value.startPi } : {}),
   }
 }
 
@@ -106,8 +108,10 @@ export function registerWorkspaceHandlers(ctx: IpcContext): void {
     const settings = await loadAppSettings(workspaceManager)
     const workspace = await workspaceManager.createWorktreeWorkspace(options)
     // Return the new project tab immediately. Its session runtime starts in the
-    // background so the tab/file contents are usable before Pi is ready.
-    void workspaceManager.startPiForWorkspace(
+    // background so the tab/file contents are usable before Pi is ready. A task
+    // launch may explicitly skip this default runtime to avoid two Pi processes
+    // in the freshly-created worktree.
+    if (options.startPi !== false) void workspaceManager.startPiForWorkspace(
       workspace.id,
       applyPermissionModeToStartOptions(
         applyResumePreference(

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -1,9 +1,27 @@
 import { ipcMain } from 'electron'
 import { IPC_CHANNELS } from '../../shared/ipc-contracts'
-import { isString } from './validation'
-import { validateStartOptions, applyPermissionModeToStartOptions } from './pi-start-options'
+import { isString, isObject, isOptionalString } from './validation'
+import { validateStartOptions, applyResumePreference, applyPermissionModeToStartOptions } from './pi-start-options'
 import { loadAppSettings } from './settings'
+import type { WorkspaceTabOptions } from '../../shared/ipc-contracts'
+import { getSessionsRoot } from '../pi-paths'
+import { isPathWithin } from '../path-authorization'
+import { existsSync } from 'fs'
 import type { IpcContext } from './context'
+
+function validateWorkspaceTabOptions(value: unknown): WorkspaceTabOptions {
+  if (value === undefined || value === null) return {}
+  if (!isObject(value)) throw new Error('Tab options must be an object')
+  if (!isOptionalString(value.name)) throw new Error('tab name must be a string')
+  if (!isOptionalString(value.sourceWorkspaceId)) throw new Error('sourceWorkspaceId must be a string')
+  if (!isOptionalString(value.forkSessionPath)) throw new Error('forkSessionPath must be a string')
+
+  return {
+    ...(isString(value.name) ? { name: value.name } : {}),
+    ...(isString(value.sourceWorkspaceId) ? { sourceWorkspaceId: value.sourceWorkspaceId } : {}),
+    ...(isString(value.forkSessionPath) ? { forkSessionPath: value.forkSessionPath } : {}),
+  }
+}
 
 export function registerWorkspaceHandlers(ctx: IpcContext): void {
   const { workspaceManager, notesManager } = ctx
@@ -22,9 +40,10 @@ export function registerWorkspaceHandlers(ctx: IpcContext): void {
 
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_REMOVE, async (_event, workspaceId: unknown) => {
     if (!isString(workspaceId)) throw new Error('workspaceId must be a string')
-    await workspaceManager.removeWorkspace(workspaceId)
+    const result = await workspaceManager.removeWorkspace(workspaceId)
     // Notes scoped to the removed workspace fall back to global so they survive.
     await notesManager.reassignToGlobal(workspaceId)
+    return result
   })
 
   ipcMain.handle(IPC_CHANNELS.WORKSPACE_RENAME, async (_event, workspaceId: unknown, name: unknown) => {
@@ -60,7 +79,10 @@ export function registerWorkspaceHandlers(ctx: IpcContext): void {
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`)
     await workspaceManager.startPiForWorkspace(
       workspaceId,
-      applyPermissionModeToStartOptions({ cwd: workspace.path, ...opts }, settings)
+      applyPermissionModeToStartOptions(
+        applyResumePreference({ cwd: workspace.path, ...opts }, settings),
+        settings
+      )
     )
     const pi = workspaceManager.getPiManager(workspaceId)
     return pi?.getStatus() ?? { status: 'stopped', pid: null, error: null }
@@ -70,5 +92,33 @@ export function registerWorkspaceHandlers(ctx: IpcContext): void {
     if (!isString(workspaceId)) throw new Error('workspaceId must be a string')
     workspaceManager.stopPiForWorkspace(workspaceId)
     return { status: 'stopped', pid: null, error: null }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.WORKSPACE_CREATE_TAB, async (_event, value: unknown) => {
+    const options = validateWorkspaceTabOptions(value)
+    if (options.forkSessionPath) {
+      if (!isPathWithin(getSessionsRoot(), options.forkSessionPath) || !existsSync(options.forkSessionPath)) {
+        throw new Error('forkSessionPath must point to an existing Pi session file')
+      }
+    }
+
+    const settings = await loadAppSettings(workspaceManager)
+    const workspace = await workspaceManager.createWorktreeWorkspace(options)
+    await workspaceManager.startPiForWorkspace(
+      workspace.id,
+      applyPermissionModeToStartOptions(
+        applyResumePreference(
+          {
+            cwd: workspace.path,
+            provider: settings.defaultProvider ?? undefined,
+            model: settings.defaultModel ?? undefined,
+            forkSessionPath: options.forkSessionPath,
+          },
+          settings
+        ),
+        settings
+      )
+    )
+    return workspace
   })
 }

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -8,6 +8,7 @@ import { getSessionsRoot } from '../pi-paths'
 import { isPathWithin } from '../path-authorization'
 import { existsSync } from 'fs'
 import type { IpcContext } from './context'
+import { appLog } from '../app-log'
 
 function validateWorkspaceTabOptions(value: unknown): WorkspaceTabOptions {
   if (value === undefined || value === null) return {}
@@ -104,7 +105,9 @@ export function registerWorkspaceHandlers(ctx: IpcContext): void {
 
     const settings = await loadAppSettings(workspaceManager)
     const workspace = await workspaceManager.createWorktreeWorkspace(options)
-    await workspaceManager.startPiForWorkspace(
+    // Return the new project tab immediately. Its session runtime starts in the
+    // background so the tab/file contents are usable before Pi is ready.
+    void workspaceManager.startPiForWorkspace(
       workspace.id,
       applyPermissionModeToStartOptions(
         applyResumePreference(
@@ -118,7 +121,7 @@ export function registerWorkspaceHandlers(ctx: IpcContext): void {
         ),
         settings
       )
-    )
+    ).catch((error) => appLog.warn('workspaces', 'Background worktree Pi start failed', error))
     return workspace
   })
 }

--- a/src/main/ipc/workspace-handlers.ts
+++ b/src/main/ipc/workspace-handlers.ts
@@ -16,12 +16,14 @@ function validateWorkspaceTabOptions(value: unknown): WorkspaceTabOptions {
   if (!isOptionalString(value.name)) throw new Error('tab name must be a string')
   if (!isOptionalString(value.sourceWorkspaceId)) throw new Error('sourceWorkspaceId must be a string')
   if (!isOptionalString(value.forkSessionPath)) throw new Error('forkSessionPath must be a string')
+  if (!isOptionalString(value.taskPrompt)) throw new Error('taskPrompt must be a string')
   if (!isOptionalBoolean(value.startPi)) throw new Error('startPi must be a boolean')
 
   return {
     ...(isString(value.name) ? { name: value.name } : {}),
     ...(isString(value.sourceWorkspaceId) ? { sourceWorkspaceId: value.sourceWorkspaceId } : {}),
     ...(isString(value.forkSessionPath) ? { forkSessionPath: value.forkSessionPath } : {}),
+    ...(isString(value.taskPrompt) ? { taskPrompt: value.taskPrompt } : {}),
     ...(typeof value.startPi === 'boolean' ? { startPi: value.startPi } : {}),
   }
 }

--- a/src/main/pi-binary-resolution.test.ts
+++ b/src/main/pi-binary-resolution.test.ts
@@ -88,6 +88,11 @@ test('normalizeOverride treats the bare binary name as auto-detect', () => {
   assert.equal(normalizeOverride('PI.CMD', POSIX_HOME), null)
 })
 
+test('normalizeOverride keeps omp as an explicit engine selector', () => {
+  assert.equal(normalizeOverride('omp', POSIX_HOME), 'omp')
+  assert.equal(normalizeOverride('OMP.EXE', POSIX_HOME), 'OMP.EXE')
+})
+
 test('normalizeOverride strips surrounding quotes pasted from a file manager', () => {
   assert.equal(normalizeOverride('"/opt/pi/cli.js"', POSIX_HOME), '/opt/pi/cli.js')
   assert.equal(normalizeOverride("'/opt/pi/cli.js'", POSIX_HOME), '/opt/pi/cli.js')
@@ -259,6 +264,27 @@ test('versionManagerPrefixes returns nothing when no manager is installed', () =
 })
 
 // ─── resolvePiBinary: configured override ────────────────────────────────────
+
+test('resolvePiBinary resolves the omp engine selector from PATH', () => {
+  const deps = fakeDeps({ env: { HOME: POSIX_HOME, PATH: '/opt/omp' }, files: ['/opt/omp/omp'] })
+  const resolution = resolvePiBinary(deps, 'omp')
+  assert.deepEqual(resolution, {
+    script: '/opt/omp/omp',
+    useNode: false,
+    needsShell: false,
+    source: 'override',
+    found: true,
+    rejectedOverride: null,
+    pathEnv: '/opt/omp',
+  })
+})
+
+test('resolvePiBinary auto-detects OMP when Pi is not installed', () => {
+  const deps = fakeDeps({ env: { HOME: POSIX_HOME, PATH: '/opt/omp' }, files: ['/opt/omp/omp'] })
+  const resolution = resolvePiBinary(deps, null)
+  assert.equal(resolution.script, '/opt/omp/omp')
+  assert.equal(resolution.source, 'omp')
+})
 
 test('resolvePiBinary uses a configured cli.js override ahead of auto-detection', () => {
   const override = join(POSIX_HOME, '.nvm/versions/node', NVM_VERSION_NEW, 'lib', PI_CLI_REL)

--- a/src/main/pi-binary-resolution.test.ts
+++ b/src/main/pi-binary-resolution.test.ts
@@ -286,6 +286,27 @@ test('resolvePiBinary auto-detects OMP when Pi is not installed', () => {
   assert.equal(resolution.source, 'omp')
 })
 
+test('resolvePiBinary can resolve each engine independently for the chooser', () => {
+  const deps = fakeDeps({
+    env: { HOME: POSIX_HOME, PATH: '/opt/pi:/opt/omp' },
+    files: ['/opt/pi/pi', '/opt/omp/omp'],
+  })
+  assert.equal(resolvePiBinary(deps, null, 'pi').script, '/opt/pi/pi')
+  assert.equal(resolvePiBinary(deps, null, 'omp').script, '/opt/omp/omp')
+})
+
+test('resolvePiBinary finds an npm-global OMP shim outside PATH', () => {
+  const prefix = '/opt/npm'
+  const omp = join(prefix, 'bin', 'omp')
+  const deps = fakeDeps({
+    env: { HOME: POSIX_HOME, PATH: '/nowhere' },
+    files: [omp],
+    dirs: [prefix],
+    captures: { 'npm prefix -g': `${prefix}\n` },
+  })
+  assert.equal(resolvePiBinary(deps, null, 'omp').script, omp)
+})
+
 test('resolvePiBinary uses a configured cli.js override ahead of auto-detection', () => {
   const override = join(POSIX_HOME, '.nvm/versions/node', NVM_VERSION_NEW, 'lib', PI_CLI_REL)
   const deps = fakeDeps({ files: [override, '/usr/local/bin/pi'] })

--- a/src/main/pi-binary-resolution.ts
+++ b/src/main/pi-binary-resolution.ts
@@ -63,6 +63,8 @@ export interface ResolutionDeps {
   capture(command: string, args: string[], options: CaptureOptions): string | null
 }
 
+export type PiEngine = 'auto' | 'pi' | 'omp'
+
 export interface PiResolution {
   /** Path to spawn: either a cli.js (with node) or an executable/shim. */
   script: string
@@ -333,13 +335,22 @@ function npmGlobalPrefix(deps: ResolutionDeps, pathEnv: string): string | null {
 }
 
 /** Hardcoded install locations, used only after every dynamic probe fails. */
+function ompShimCandidates(deps: ResolutionDeps, prefix: string): string[] {
+  return deps.isWindows
+    ? [join(prefix, 'omp.cmd'), join(prefix, 'omp.ps1'), join(prefix, 'omp.exe')]
+    : [join(prefix, 'bin', 'omp'), join(prefix, 'omp')]
+}
+
 function ompLocations(deps: ResolutionDeps): string[] {
   const { env } = deps
   const home = homeDir(env)
   if (deps.isWindows) {
+    const appData = env.APPDATA ?? ''
     const localAppData = env.LOCALAPPDATA ?? ''
     const userProfile = env.USERPROFILE ?? home
     return [
+      appData ? join(appData, 'npm', OMP_FALLBACK_BINARY_WINDOWS) : '',
+      localAppData ? join(localAppData, 'npm', OMP_FALLBACK_BINARY_WINDOWS) : '',
       localAppData ? join(localAppData, 'omp', OMP_FALLBACK_BINARY_WINDOWS) : '',
       join(userProfile, '.bun', 'bin', OMP_FALLBACK_BINARY_WINDOWS),
     ].filter(Boolean)
@@ -347,6 +358,8 @@ function ompLocations(deps: ResolutionDeps): string[] {
   return [
     join(home, '.local', 'bin', OMP_FALLBACK_BINARY_POSIX),
     join(home, '.bun', 'bin', OMP_FALLBACK_BINARY_POSIX),
+    join(home, '.npm-global', 'bin', OMP_FALLBACK_BINARY_POSIX),
+    join(home, '.npm-packages', 'bin', OMP_FALLBACK_BINARY_POSIX),
     '/opt/homebrew/bin/omp',
     '/usr/local/bin/omp',
     '/usr/bin/omp',
@@ -358,6 +371,12 @@ function resolveOmpBinary(deps: ResolutionDeps, pathEnv: string): string | null 
   if (onPath) return onPath
   for (const candidate of ompLocations(deps)) {
     if (deps.exists(candidate)) return candidate
+  }
+  const prefix = npmGlobalPrefix(deps, pathEnv)
+  if (prefix) {
+    for (const candidate of ompShimCandidates(deps, prefix)) {
+      if (deps.exists(candidate)) return candidate
+    }
   }
   return null
 }
@@ -432,13 +451,27 @@ function finalize(
  */
 export function resolvePiBinary(
   deps: ResolutionDeps,
-  overridePath: string | null
+  overridePath: string | null,
+  engine: PiEngine = 'auto'
 ): PiResolution {
   const basePath = deps.env.PATH ?? ''
   const shellPath = loginShellPath(deps)
   const pathEnv = shellPath ? mergePathEntries(basePath, shellPath, deps.isWindows) : basePath
 
   let rejectedOverride: string | null = null
+  if (engine === 'omp') {
+    const omp = resolveOmpBinary(deps, pathEnv)
+    return omp
+      ? finalize(deps, omp, 'omp', true, null, pathEnv)
+      : finalize(
+          deps,
+          deps.isWindows ? OMP_FALLBACK_BINARY_WINDOWS : OMP_FALLBACK_BINARY_POSIX,
+          'fallback',
+          false,
+          null,
+          pathEnv
+        )
+  }
   if (overridePath && (overridePath.toLowerCase() === OMP_FALLBACK_BINARY_POSIX || overridePath.toLowerCase() === OMP_FALLBACK_BINARY_WINDOWS)) {
     const omp = resolveOmpBinary(deps, pathEnv)
     if (omp) return finalize(deps, omp, 'override', true, null, pathEnv)
@@ -495,16 +528,18 @@ export function resolvePiBinary(
 
   // Keep the historical Pi-first preference, but make an OMP-only machine
   // work without forcing the user to discover the Agent Executable field.
-  const omp = resolveOmpBinary(deps, pathEnv)
-  if (omp) return finalize(deps, omp, 'omp', true, rejectedOverride, pathEnv)
+  if (engine === 'auto') {
+    const omp = resolveOmpBinary(deps, pathEnv)
+    if (omp) return finalize(deps, omp, 'omp', true, rejectedOverride, pathEnv)
+  }
 
   const fallback = deps.isWindows ? PI_FALLBACK_BINARY_WINDOWS : PI_FALLBACK_BINARY_POSIX
   return finalize(deps, fallback, 'fallback', false, rejectedOverride, pathEnv)
 }
 
-const SETTINGS_HINT = 'Settings > Pi Configuration > Pi Executable'
+const SETTINGS_HINT = 'Settings > Agent Configuration > Agent Installation'
 const INSTALL_HINT =
-  'Install Pi with:\n  npm install -g @earendil-works/pi-coding-agent\nor on Windows:\n  irm https://pi.dev/install.ps1 | iex'
+  'Install Pi with:\n  npm install -g @earendil-works/pi-coding-agent\nor install OMP with:\n  bun install -g @oh-my-pi/pi-coding-agent'
 
 /**
  * Explain a failed resolution. A stale configured path is the headline when

--- a/src/main/pi-binary-resolution.ts
+++ b/src/main/pi-binary-resolution.ts
@@ -1,4 +1,4 @@
-import { basename, join } from 'path'
+import { basename, join, posix as posixPath } from 'path'
 import { buildNpmPrefixCommand } from './cmd-escape'
 
 /**
@@ -16,6 +16,8 @@ export const PI_PACKAGE = '@earendil-works/pi-coding-agent'
 export const PI_CLI_REL = join('node_modules', PI_PACKAGE, 'dist', 'cli.js')
 export const PI_FALLBACK_BINARY_POSIX = 'pi'
 export const PI_FALLBACK_BINARY_WINDOWS = 'pi.cmd'
+export const OMP_FALLBACK_BINARY_POSIX = 'omp'
+export const OMP_FALLBACK_BINARY_WINDOWS = 'omp.exe'
 export const DEFAULT_LOGIN_SHELL = '/bin/bash'
 export const FISH_SHELL_NAME = 'fish'
 /** Sentinels bracket the PATH so rc-file chatter can be discarded. */
@@ -30,6 +32,7 @@ const DEFAULT_WINDOWS_PATHEXT = '.COM;.EXE;.BAT;.CMD'
 const JS_EXTENSION = '.js'
 const SHELL_SCRIPT_PATTERN = /\.(cmd|bat|ps1)$/i
 const VERSION_NUMBER_PATTERN = /\d+/g
+const OMP_BINARY_PATTERN = /(?:^|[\\/])omp(?:\.(?:cmd|exe|bat|ps1))?$/i
 
 /** Where a resolved path came from, for logging and error messaging. */
 export type PiResolutionSource =
@@ -38,6 +41,7 @@ export type PiResolutionSource =
   | 'path'
   | 'version-manager'
   | 'common-location'
+  | 'omp'
   | 'fallback'
 
 export interface CaptureOptions {
@@ -100,6 +104,10 @@ export function normalizeOverride(raw: string | undefined | null, home: string):
 
   const lower = value.toLowerCase()
   if (lower === PI_FALLBACK_BINARY_POSIX || lower === PI_FALLBACK_BINARY_WINDOWS) return null
+  // `omp` is an intentional engine selector, not a filesystem path. Keep it
+  // for resolvePiBinary() so the Settings field can switch runtimes without
+  // requiring the user to find the installed executable.
+  if (lower === OMP_FALLBACK_BINARY_POSIX || lower === OMP_FALLBACK_BINARY_WINDOWS) return value
 
   if (value === '~') return home
   if (value.startsWith('~/') || value.startsWith('~\\')) {
@@ -290,13 +298,21 @@ function resolveFromPrefix(deps: ResolutionDeps, prefix: string): string | null 
 /** Search PATH for an executable, honoring PATHEXT on Windows. */
 export function whichInPath(deps: ResolutionDeps, name: string, pathEnv: string): string | null {
   const dirs = pathEnv.split(pathDelimiterFor(deps.isWindows)).filter(Boolean)
+  const pathJoin = deps.isWindows ? join : posixPath.join
   const extensions = deps.isWindows
     ? (deps.env.PATHEXT ?? DEFAULT_WINDOWS_PATHEXT).split(';').map((e) => e.toLowerCase())
     : ['']
   for (const dir of dirs) {
     for (const extension of extensions) {
-      const candidate = join(dir, name + extension)
+      const candidate = pathJoin(dir, name + extension)
       if (deps.exists(candidate)) return candidate
+      // Tests inject a platform independent `isWindows` flag while running on
+      // the host OS. Accept the host join spelling as a fallback in that seam;
+      // real processes always take the first branch for their native platform.
+      if (!deps.isWindows) {
+        const hostCandidate = join(dir, name + extension)
+        if (hostCandidate !== candidate && deps.exists(hostCandidate)) return hostCandidate
+      }
     }
   }
   return null
@@ -317,6 +333,39 @@ function npmGlobalPrefix(deps: ResolutionDeps, pathEnv: string): string | null {
 }
 
 /** Hardcoded install locations, used only after every dynamic probe fails. */
+function ompLocations(deps: ResolutionDeps): string[] {
+  const { env } = deps
+  const home = homeDir(env)
+  if (deps.isWindows) {
+    const localAppData = env.LOCALAPPDATA ?? ''
+    const userProfile = env.USERPROFILE ?? home
+    return [
+      localAppData ? join(localAppData, 'omp', OMP_FALLBACK_BINARY_WINDOWS) : '',
+      join(userProfile, '.bun', 'bin', OMP_FALLBACK_BINARY_WINDOWS),
+    ].filter(Boolean)
+  }
+  return [
+    join(home, '.local', 'bin', OMP_FALLBACK_BINARY_POSIX),
+    join(home, '.bun', 'bin', OMP_FALLBACK_BINARY_POSIX),
+    '/opt/homebrew/bin/omp',
+    '/usr/local/bin/omp',
+    '/usr/bin/omp',
+  ]
+}
+
+function resolveOmpBinary(deps: ResolutionDeps, pathEnv: string): string | null {
+  const onPath = whichInPath(deps, OMP_FALLBACK_BINARY_POSIX, pathEnv)
+  if (onPath) return onPath
+  for (const candidate of ompLocations(deps)) {
+    if (deps.exists(candidate)) return candidate
+  }
+  return null
+}
+
+export function isOmpExecutable(script: string): boolean {
+  return OMP_BINARY_PATTERN.test(script)
+}
+
 function commonLocations(deps: ResolutionDeps): string[] {
   const { env } = deps
   const home = homeDir(env)
@@ -378,7 +427,8 @@ function finalize(
  *   3. A PATH search.
  *   4. Per-version prefixes created by node version managers.
  *   5. Hardcoded common install locations.
- *   6. The bare binary name, flagged as not found.
+ *   6. OMP fallback when Pi is not installed.
+ *   7. The bare binary name, flagged as not found.
  */
 export function resolvePiBinary(
   deps: ResolutionDeps,
@@ -389,6 +439,18 @@ export function resolvePiBinary(
   const pathEnv = shellPath ? mergePathEntries(basePath, shellPath, deps.isWindows) : basePath
 
   let rejectedOverride: string | null = null
+  if (overridePath && (overridePath.toLowerCase() === OMP_FALLBACK_BINARY_POSIX || overridePath.toLowerCase() === OMP_FALLBACK_BINARY_WINDOWS)) {
+    const omp = resolveOmpBinary(deps, pathEnv)
+    if (omp) return finalize(deps, omp, 'override', true, null, pathEnv)
+    return finalize(
+      deps,
+      deps.isWindows ? OMP_FALLBACK_BINARY_WINDOWS : OMP_FALLBACK_BINARY_POSIX,
+      'fallback',
+      false,
+      overridePath,
+      pathEnv
+    )
+  }
   if (overridePath) {
     if (deps.isDirectory(overridePath)) {
       const fromDir = resolveFromPrefix(deps, overridePath)
@@ -430,6 +492,11 @@ export function resolvePiBinary(
       return finalize(deps, candidate, 'common-location', true, rejectedOverride, pathEnv)
     }
   }
+
+  // Keep the historical Pi-first preference, but make an OMP-only machine
+  // work without forcing the user to discover the Agent Executable field.
+  const omp = resolveOmpBinary(deps, pathEnv)
+  if (omp) return finalize(deps, omp, 'omp', true, rejectedOverride, pathEnv)
 
   const fallback = deps.isWindows ? PI_FALLBACK_BINARY_WINDOWS : PI_FALLBACK_BINARY_POSIX
   return finalize(deps, fallback, 'fallback', false, rejectedOverride, pathEnv)

--- a/src/main/pi-event-router.ts
+++ b/src/main/pi-event-router.ts
@@ -64,11 +64,13 @@ export interface PiEventRouter {
 }
 
 export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
-  // Blocking dialogs not yet shown, per workspace, in arrival order.
-  const queues = new Map<string, QueuedPrompt[]>()
-  // The one dialog currently owned by the renderer slot per workspace. The
+  // Blocking dialogs are owned by a Pi process, not a project. Multiple live
+  // session runtimes may share one workspace cwd, so workspace-keyed queues
+  // would deliver one session's prompt to another.
+  const queues = new Map<PiRpcManager, QueuedPrompt[]>()
+  // The one dialog currently owned by the renderer slot per Pi process. The
   // full payload is retained until answered or evicted so flush can replay it.
-  const delivered = new Map<string, QueuedPrompt>()
+  const delivered = new Map<PiRpcManager, QueuedPrompt>()
   // Every blocking dialog's asking manager, until answered or evicted.
   const origins = new Map<string, PiRpcManager>()
   const attached = new WeakSet<PiRpcManager>()
@@ -102,20 +104,22 @@ export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
   }
 
   /** An empty queue is deleted rather than stored, so counts omit zero entries. */
-  const storeQueue = (workspaceId: string, entries: QueuedPrompt[]): void => {
-    if (entries.length === 0) queues.delete(workspaceId)
-    else queues.set(workspaceId, entries)
+  const storeQueue = (manager: PiRpcManager, entries: QueuedPrompt[]): void => {
+    if (entries.length === 0) queues.delete(manager)
+    else queues.set(manager, entries)
   }
 
   const getPendingCounts = (): PendingPromptCounts => {
     const counts: PendingPromptCounts = {}
-    for (const [workspaceId, entries] of queues) {
+    for (const [manager, entries] of queues) {
       const live = reapExpired(entries)
-      if (live.length !== entries.length) storeQueue(workspaceId, live)
-      if (live.length > 0) counts[workspaceId] = live.length
+      if (live.length !== entries.length) storeQueue(manager, live)
+      const workspaceId = deps.workspaceIdFor(manager)
+      if (workspaceId && live.length > 0) counts[workspaceId] = (counts[workspaceId] ?? 0) + live.length
     }
-    for (const workspaceId of delivered.keys()) {
-      counts[workspaceId] = (counts[workspaceId] ?? 0) + 1
+    for (const manager of delivered.keys()) {
+      const workspaceId = deps.workspaceIdFor(manager)
+      if (workspaceId) counts[workspaceId] = (counts[workspaceId] ?? 0) + 1
     }
     return counts
   }
@@ -128,25 +132,25 @@ export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
    * Pop the workspace's queue into its empty delivered slot and broadcast,
    * reaping expired entries on the way. Returns whether state changed.
    */
-  const deliverNext = (workspaceId: string): boolean => {
-    if (delivered.has(workspaceId)) return false
-    const entries = queues.get(workspaceId)
+  const deliverNext = (manager: PiRpcManager): boolean => {
+    if (delivered.has(manager)) return false
+    const entries = queues.get(manager)
     if (entries === undefined) return false
     const live = reapExpired(entries)
     const next = live.shift()
     if (next !== undefined) {
-      delivered.set(workspaceId, next)
+      delivered.set(manager, next)
       deps.broadcastEvent(next.event)
     }
-    storeQueue(workspaceId, live)
+    storeQueue(manager, live)
     return live.length !== entries.length
   }
 
-  const enqueue = (workspaceId: string, event: PiExtensionUiRequest): void => {
+  const enqueue = (manager: PiRpcManager, event: PiExtensionUiRequest): void => {
     const entry = track(event)
-    const queue = queues.get(workspaceId)
+    const queue = queues.get(manager)
     if (queue) queue.push(entry)
-    else queues.set(workspaceId, [entry])
+    else queues.set(manager, [entry])
   }
 
   const handleBlockingDialog = (manager: PiRpcManager, event: PiExtensionUiRequest): void => {
@@ -159,12 +163,12 @@ export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
       if (manager === deps.getActiveManager()) deps.broadcastEvent(event)
       return
     }
-    if (manager === deps.getActiveManager() && !delivered.has(workspaceId)) {
-      delivered.set(workspaceId, track(event))
+    if (manager === deps.getActiveManager() && !delivered.has(manager)) {
+      delivered.set(manager, track(event))
       deps.broadcastEvent(event)
     } else {
-      // Inactive workspace, or a dialog already on screen: hold for later.
-      enqueue(workspaceId, event)
+      // Inactive session runtime, or a dialog already on screen: hold for later.
+      enqueue(manager, event)
     }
     emitCounts()
   }
@@ -191,12 +195,12 @@ export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
     }
     if (ownedIds.size === 0) return
     for (const id of ownedIds) origins.delete(id)
-    for (const [workspaceId, entries] of queues) {
+    for (const [manager, entries] of queues) {
       const kept = entries.filter((entry) => !ownedIds.has(entry.event.id))
-      if (kept.length !== entries.length) storeQueue(workspaceId, kept)
+      if (kept.length !== entries.length) storeQueue(manager, kept)
     }
-    for (const [workspaceId, entry] of delivered) {
-      if (ownedIds.has(entry.event.id)) delivered.delete(workspaceId)
+    for (const [manager, entry] of delivered) {
+      if (ownedIds.has(entry.event.id)) delivered.delete(manager)
     }
     emitCounts()
   }
@@ -221,33 +225,35 @@ export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
     origins.delete(id)
     // Purge the id everywhere FIRST — regardless of a routing hit — so an
     // answered request can never linger as a queued or delivered ghost.
-    let purgedWorkspaceId: string | null = null
-    for (const [workspaceId, entries] of queues) {
+    let purgedManager: PiRpcManager | null = null
+    for (const [manager, entries] of queues) {
       const kept = entries.filter((entry) => entry.event.id !== id)
       if (kept.length === entries.length) continue
-      purgedWorkspaceId = workspaceId
-      storeQueue(workspaceId, kept)
+      purgedManager = manager
+      storeQueue(manager, kept)
     }
-    for (const [workspaceId, entry] of delivered) {
+    for (const [manager, entry] of delivered) {
       if (entry.event.id !== id) continue
-      delivered.delete(workspaceId)
-      purgedWorkspaceId = workspaceId
+      delivered.delete(manager)
+      purgedManager = manager
     }
     // Origin miss (notify dismissal, evicted prompt): fall back to the active
     // manager — Pi ignores unknown ids — or drop when no workspace is active.
     const target = origin ?? deps.getActiveManager()
     target?.sendExtensionUiResponse(id, response)
-    if (purgedWorkspaceId !== null && purgedWorkspaceId === activeWorkspaceId()) {
-      deliverNext(purgedWorkspaceId)
+    if (purgedManager !== null && purgedManager === deps.getActiveManager()) {
+      deliverNext(purgedManager)
     }
     emitCounts()
   }
 
   const flush = (workspaceId: string): void => {
-    // Only the workspace on screen may be flushed: a stale flush must not
-    // resurface a dialog the user just switched away from.
+    // Only the active workspace and its active session runtime may be flushed:
+    // a stale flush must not resurface another session's dialog.
     if (workspaceId !== activeWorkspaceId()) return
-    const held = delivered.get(workspaceId)
+    const manager = deps.getActiveManager()
+    if (!manager) return
+    const held = delivered.get(manager)
     if (held !== undefined && !isExpired(held)) {
       // Self-healing re-broadcast: rebuilds the renderer slot after a reload,
       // a switch-back, or a same-workspace re-activation. The renderer's
@@ -259,10 +265,10 @@ export function createPiEventRouter(deps: PiEventRouterDeps): PiEventRouter {
       // The slot's dialog timed out while the workspace was away: releasing it
       // lets the next queued dialog take the slot instead of waiting on an
       // answer Pi would discard.
-      delivered.delete(workspaceId)
+      delivered.delete(manager)
       origins.delete(held.event.id)
     }
-    const promoted = deliverNext(workspaceId)
+    const promoted = deliverNext(manager)
     if (held !== undefined || promoted) emitCounts()
   }
 

--- a/src/main/pi-rpc-manager.test.ts
+++ b/src/main/pi-rpc-manager.test.ts
@@ -64,6 +64,14 @@ test('buildPiInvocation leaves a direct POSIX spawn byte-identical', () => {
   })
 })
 
+test('buildPiInvocation preserves fork startup arguments', () => {
+  const cli = piCli()
+  assert.deepEqual(buildPiInvocation(cli, ['--mode', 'rpc', '--fork', '/sessions/source.jsonl']), {
+    file: '/usr/local/bin/pi',
+    args: ['--mode', 'rpc', '--fork', '/sessions/source.jsonl'],
+  })
+})
+
 test('buildPiInvocation rejects arguments cmd.exe cannot carry', () => {
   const cli = piCli({ script: String.raw`C:\npm\pi.cmd`, needsShell: true })
   assert.throws(

--- a/src/main/pi-rpc-manager.test.ts
+++ b/src/main/pi-rpc-manager.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { buildPiInvocation, type PiCli } from './pi-rpc-manager'
+import { buildPiInvocation, RpcFrameDecoder, type PiCli } from './pi-rpc-manager'
 
 /**
  * A resolution fixture. `needsShell` is only ever true on Windows for a
@@ -19,6 +19,30 @@ function piCli(overrides: Partial<PiCli> = {}): PiCli {
     ...overrides,
   }
 }
+
+test('RpcFrameDecoder reassembles a lossless OMP protocol-v2 frame', () => {
+  const payload = JSON.stringify({ type: 'response', command: 'get_messages', success: true, data: 'x'.repeat(1_100_000) })
+  const bytes = Buffer.from(payload, 'utf8')
+  const chunkSize = 256 * 1024
+  const count = Math.ceil(bytes.length / chunkSize)
+  const decoder = new RpcFrameDecoder()
+  let decoded: object | undefined
+
+  for (let index = 0; index < count; index++) {
+    const frame = {
+      type: 'rpc_chunk',
+      chunkId: 'rpc-test',
+      index,
+      count,
+      byteLength: bytes.length,
+      data: bytes.subarray(index * chunkSize, (index + 1) * chunkSize).toString('base64'),
+    }
+    const result = decoder.push(frame)
+    if (result) decoded = result
+  }
+
+  assert.equal((decoded as { data?: string }).data?.length, 1_100_000)
+})
 
 test('buildPiInvocation escapes the shim path and args for the Windows cmd.exe hop', () => {
   const cli = piCli({ script: String.raw`C:\Program Files\nodejs\pi.cmd`, needsShell: true })

--- a/src/main/pi-rpc-manager.ts
+++ b/src/main/pi-rpc-manager.ts
@@ -13,6 +13,7 @@ import type {
 import type { CaptureOptions, PiResolution, ResolutionDeps } from './pi-binary-resolution'
 import {
   describePiResolutionFailure,
+  isOmpExecutable,
   normalizeOverride,
   resolvePiBinary,
   whichInPath,
@@ -20,6 +21,7 @@ import {
 import { escapeCmdSpawn } from './cmd-escape'
 import { appLog } from './app-log'
 import { getGuiDataPath } from './app-data-paths'
+import { getSessionsRoot } from './pi-paths'
 
 /**
  * Manages a Pi RPC child process.
@@ -63,6 +65,80 @@ const STARTUP_PROBE_ID = '__startup_probe__'
 const STARTUP_PROBE_COMMAND = 'get_state'
 const STARTUP_PROBE_INTERVAL_MS = 750
 const FORCE_KILL_TIMEOUT_MS = 3_000
+const RPC_MAX_FRAME_BYTES = 1024 * 1024
+const RPC_MAX_REASSEMBLED_BYTES = 64 * 1024 * 1024
+const RPC_CHUNK_PAYLOAD_BYTES = 256 * 1024
+
+interface PendingRpcChunks {
+  chunkId: string
+  count: number
+  byteLength: number
+  nextIndex: number
+  chunks: Buffer[]
+  receivedBytes: number
+}
+
+function isRpcChunkFrame(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && (value as { type?: unknown }).type === 'rpc_chunk'
+}
+
+/** Minimal lossless decoder for OMP RPC protocol v2 physical frames. */
+export class RpcFrameDecoder {
+  private pending: PendingRpcChunks | null = null
+
+  hasPending(): boolean {
+    return this.pending !== null
+  }
+
+  push(value: Record<string, unknown>): object | undefined {
+    const chunkId = value.chunkId
+    const index = typeof value.index === 'number' ? value.index : Number.NaN
+    const count = typeof value.count === 'number' ? value.count : Number.NaN
+    const byteLength = typeof value.byteLength === 'number' ? value.byteLength : Number.NaN
+    const data = value.data
+    if (
+      typeof chunkId !== 'string' || chunkId.length === 0 || chunkId.length > 128 ||
+      !Number.isSafeInteger(index) || !Number.isSafeInteger(count) || !Number.isSafeInteger(byteLength) ||
+      index < 0 || count < 2 || count > Math.ceil(RPC_MAX_REASSEMBLED_BYTES / RPC_CHUNK_PAYLOAD_BYTES) || index >= count ||
+      byteLength < RPC_MAX_FRAME_BYTES ||
+      byteLength > RPC_MAX_REASSEMBLED_BYTES || typeof data !== 'string' || data.length === 0 ||
+      !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(data)
+    ) {
+      throw new Error('invalid rpc chunk metadata')
+    }
+    const chunkIndex = index as number
+    const chunkCount = count as number
+    const declaredByteLength = byteLength as number
+    const bytes = Buffer.from(data, 'base64')
+    if (bytes.toString('base64') !== data || bytes.byteLength > RPC_CHUNK_PAYLOAD_BYTES) {
+      throw new Error('invalid rpc chunk data')
+    }
+
+    if (!this.pending) {
+      if (chunkIndex !== 0) throw new Error('rpc chunk sequence must start at index 0')
+      this.pending = { chunkId, count: chunkCount, byteLength: declaredByteLength, nextIndex: 0, chunks: [], receivedBytes: 0 }
+    }
+    const pending = this.pending!
+    if (
+      pending.chunkId !== chunkId || pending.count !== chunkCount || pending.byteLength !== declaredByteLength ||
+      pending.nextIndex !== chunkIndex
+    ) {
+      throw new Error('rpc chunk sequence mismatch')
+    }
+    pending.chunks.push(bytes)
+    pending.receivedBytes += bytes.byteLength
+    pending.nextIndex++
+    if (pending.receivedBytes > pending.byteLength) throw new Error('rpc chunk sequence exceeds declared length')
+    if (pending.nextIndex < pending.count) return undefined
+    if (pending.receivedBytes !== pending.byteLength) throw new Error('rpc chunk sequence length mismatch')
+
+    this.pending = null
+    const decoded = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(pending.chunks))
+    const frame = JSON.parse(decoded) as unknown
+    if (typeof frame !== 'object' || frame === null || Array.isArray(frame)) throw new Error('rpc frame must be an object')
+    return frame as object
+  }
+}
 
 // Real filesystem/process access for the resolver in pi-binary-resolution.ts.
 // Kept in one object so the search order stays testable against a fake.
@@ -164,6 +240,8 @@ function findNodeBinary(): string {
  * `script` is only a hopeful fallback; `failureReason` then explains why.
  */
 export interface PiCli {
+  /** The selected engine. OMP deliberately keeps the Pi-compatible RPC path. */
+  kind?: 'pi' | 'omp'
   script: string
   node: string
   useNode: boolean
@@ -257,6 +335,7 @@ export function getPiCli(): PiCli {
       'or set the NODE env var to your Node binary path.'
   }
   return {
+    kind: isOmpExecutable(resolution.script) ? 'omp' : 'pi',
     script: resolution.script,
     node,
     useNode: resolution.useNode,
@@ -360,6 +439,7 @@ export class PiRpcManager extends EventEmitter {
   private pendingResponses = new Map<string, PendingResponse>()
   private nextRequestId = 1
   private decoder = new StringDecoder('utf8')
+  private rpcFrameDecoder = new RpcFrameDecoder()
   private startInFlight: Promise<PiStatus> | null = null
   // Set while a spawn attempt awaits readiness; handleLine invokes it when the
   // startup probe's correlated response arrives. Cleared once the attempt settles.
@@ -657,6 +737,14 @@ export class PiRpcManager extends EventEmitter {
 
   private buildArgs(options: PiStartOptions): string[] {
     const args: string[] = [MODE_FLAG, RPC_MODE]
+    const cli = getPiCli()
+
+    // OMP stores sessions under ~/.omp by default. Keep Desktop's single
+    // session index authoritative by pointing OMP at the same JSONL root.
+    // Explicit caller args win so advanced users can intentionally separate it.
+    if (cli.kind === 'omp' && !options.args?.some((arg) => arg === '--session-dir' || arg.startsWith('--session-dir='))) {
+      args.push('--session-dir', getSessionsRoot())
+    }
 
     if (options.noSession) {
       args.push(NO_SESSION_FLAG)
@@ -732,11 +820,29 @@ export class PiRpcManager extends EventEmitter {
   }
 
   private handleLine(line: string): void {
-    let event: PiRpcEvent
+    let parsed: unknown
     try {
-      event = JSON.parse(line) as PiRpcEvent
+      parsed = JSON.parse(line)
+      if (isRpcChunkFrame(parsed)) {
+        parsed = this.rpcFrameDecoder.push(parsed)
+        if (parsed === undefined) return
+      } else if (this.rpcFrameDecoder.hasPending()) {
+        throw new Error('rpc chunk sequence interrupted')
+      }
     } catch {
       this.emit('parse-error', line)
+      return
+    }
+    const event = parsed as PiRpcEvent
+
+    // OMP advertises readiness explicitly. Keep the probe fallback for the
+    // original Pi RPC implementation, which has no ready frame.
+    if ((event as { type?: unknown }).type === 'ready') {
+      this.markReady?.()
+      const ready = event as { supportedProtocolVersions?: unknown }
+      if (Array.isArray(ready.supportedProtocolVersions) && ready.supportedProtocolVersions.includes(2)) {
+        void this.sendCommand({ type: 'negotiate_protocol', protocolVersion: 2 }).catch(() => {})
+      }
       return
     }
 
@@ -816,6 +922,7 @@ export class PiRpcManager extends EventEmitter {
 
     this.stdoutBuffer = ''
     this.decoder = new StringDecoder('utf8')
+    this.rpcFrameDecoder = new RpcFrameDecoder()
   }
 
   private rejectAllPending(reason: string): void {

--- a/src/main/pi-rpc-manager.ts
+++ b/src/main/pi-rpc-manager.ts
@@ -510,6 +510,13 @@ export class PiRpcManager extends EventEmitter {
       appLog.error('pi', 'Pre-flight failed', this.stderrBuffer)
       return this.getStatus()
     }
+    if (options.cwd && (!existsSync(options.cwd) || !statSync(options.cwd).isDirectory())) {
+      this.stderrBuffer = `Pi working directory does not exist or is not a directory:\n  ${options.cwd}`
+      this.setStatus('error')
+      console.error('[Pi] Pre-flight failed:', this.stderrBuffer)
+      appLog.error('pi', 'Pre-flight failed', this.stderrBuffer)
+      return this.getStatus()
+    }
 
     // Spawn, with one retry reserved for a crash before readiness. See
     // STARTUP_MAX_ATTEMPTS: a crash is often transient; a timeout is not.

--- a/src/main/pi-rpc-manager.ts
+++ b/src/main/pi-rpc-manager.ts
@@ -9,6 +9,7 @@ import type {
   PiProcessStatus,
   PiStatus,
   PiResponseEvent,
+  AgentInstallation,
 } from '../shared/ipc-contracts'
 import type { CaptureOptions, PiResolution, ResolutionDeps } from './pi-binary-resolution'
 import {
@@ -291,6 +292,22 @@ function getResolution(): PiResolution {
  */
 export function getPiResolution(): PiResolution {
   return getResolution()
+}
+
+/** Detect the first usable installation for each supported engine. */
+export function detectPiInstallations(): AgentInstallation[] {
+  const candidates: Array<{ kind: AgentInstallation['kind']; resolution: PiResolution }> = [
+    { kind: 'pi', resolution: resolvePiBinary(RESOLUTION_DEPS, null, 'pi') },
+    { kind: 'omp', resolution: resolvePiBinary(RESOLUTION_DEPS, null, 'omp') },
+  ]
+  const seen = new Set<string>()
+  return candidates.flatMap(({ kind, resolution }) => {
+    if (!resolution.found) return []
+    const key = resolution.script.toLowerCase()
+    if (seen.has(key)) return []
+    seen.add(key)
+    return [{ kind, path: resolution.script, source: resolution.source }]
+  })
 }
 
 function logResolution(resolution: PiResolution): void {

--- a/src/main/pi-rpc-manager.ts
+++ b/src/main/pi-rpc-manager.ts
@@ -39,6 +39,7 @@ const MODE_FLAG = '--mode'
 const PROVIDER_FLAG = '--provider'
 const MODEL_FLAG = '--model'
 const SESSION_FLAG = '--session'
+const FORK_FLAG = '--fork'
 const CONTINUE_FLAG = '--continue'
 const IS_WINDOWS = process.platform === 'win32'
 const SPAWN_STARTUP_TIMEOUT_MS = 15_000
@@ -669,7 +670,9 @@ export class PiRpcManager extends EventEmitter {
       args.push(MODEL_FLAG, options.model)
     }
 
-    if (options.sessionPath) {
+    if (options.forkSessionPath) {
+      args.push(FORK_FLAG, options.forkSessionPath)
+    } else if (options.sessionPath) {
       args.push(SESSION_FLAG, options.sessionPath)
     } else if (options.continueSession && !options.noSession) {
       // Resume the most recent session for the cwd. Pi falls back to a fresh

--- a/src/main/session-metadata.test.ts
+++ b/src/main/session-metadata.test.ts
@@ -133,18 +133,26 @@ test('userMessageText returns null for non-record input', () => {
 
 // ─── sessionHeaderFromLine ───────────────────────────────────────────────────
 
-test('sessionHeaderFromLine parses the id and parentSession', () => {
+test('sessionHeaderFromLine parses the id, parentSession and cwd', () => {
   const header = sessionHeaderFromLine(
     headerLine({ parentSession: '/home/u/.pi/agent/sessions/proj/parent.jsonl' })
   )
   assert.deepEqual(header, {
     id: SESSION_ID,
     parentSession: '/home/u/.pi/agent/sessions/proj/parent.jsonl',
+    cwd: '/home/u/proj',
   })
 })
 
 test('sessionHeaderFromLine reports a missing parentSession as null', () => {
   assert.equal(sessionHeaderFromLine(headerLine())?.parentSession, null)
+})
+
+test('sessionHeaderFromLine reports a missing cwd as null (legacy headers)', () => {
+  const header = JSON.parse(headerLine()) as Record<string, unknown>
+  delete header.cwd
+  assert.equal(sessionHeaderFromLine(JSON.stringify(header))?.cwd, null)
+  assert.equal(sessionHeaderFromLine(headerLine({ cwd: '' }))?.cwd, null)
 })
 
 test('sessionHeaderFromLine rejects a line that is not a session header', () => {

--- a/src/main/session-metadata.ts
+++ b/src/main/session-metadata.ts
@@ -45,6 +45,13 @@ export interface SessionHeader {
   id: string
   /** Absolute path to the session this one was forked from, or null. */
   parentSession: string | null
+  /**
+   * Working directory the session actually ran in, or null when the header
+   * omits it (legacy sessions). Authoritative where it exists: session dir
+   * names are lossy decodes of paths, so this is the only reliable anchor
+   * back to the real project.
+   */
+  cwd: string | null
 }
 
 export interface SessionMetadata {
@@ -69,12 +76,13 @@ export function sessionHeaderFromLine(line: string): SessionHeader | null {
   }
   if (typeof record !== 'object' || record === null) return null
 
-  const rec = record as { type?: unknown; id?: unknown; parentSession?: unknown }
+  const rec = record as { type?: unknown; id?: unknown; parentSession?: unknown; cwd?: unknown }
   if (rec.type !== 'session' || typeof rec.id !== 'string') return null
 
   return {
     id: rec.id,
     parentSession: typeof rec.parentSession === 'string' ? rec.parentSession : null,
+    cwd: typeof rec.cwd === 'string' && rec.cwd.length > 0 ? rec.cwd : null,
   }
 }
 

--- a/src/main/tray-manager.ts
+++ b/src/main/tray-manager.ts
@@ -134,6 +134,7 @@ function warnNoTrayOnce(): void {
     new Notification({
       title: 'System tray unavailable',
       body: 'This desktop has no system tray, so Pi Desktop will close normally instead of minimizing to the tray.',
+      ...(deps?.iconPath ? { icon: deps.iconPath } : {}),
     }).show()
   }
 }
@@ -203,6 +204,7 @@ export function notifyFirstHide(): void {
     new Notification({
       title: 'Pi Desktop is still running',
       body: 'The window was hidden to the system tray. Click the tray icon to reopen it, or use Quit to exit.',
+      ...(deps?.iconPath ? { icon: deps.iconPath } : {}),
     }).show()
   }
 }

--- a/src/main/workflow-discovery.test.ts
+++ b/src/main/workflow-discovery.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { test } from 'node:test'
+import {
+  clearWorkflowProjectDiscoveryCache,
+  discoverWorkflowProjects,
+  getWorkflowRun,
+  listWorkflowRuns,
+  resolveWorkflowWorkspaces,
+} from './workflow-monitor'
+import { desanitizeSessionDir, sanitizePath } from './session-paths'
+import { pathGroupKey, pathsEqual } from '../shared/path-compare'
+import type { Workspace } from '../shared/ipc-contracts'
+
+function projectKey(cwd: string): string {
+  const projectPath = resolve(cwd)
+  const name = (basename(projectPath) || 'project')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'project'
+  return `${name}-${createHash('sha256').update(projectPath).digest('hex').slice(0, 12)}`
+}
+
+const SESSION_UUID = '01a01a28-f010-7b29-8312-21ba523d9edf'
+const RUN_ID = 'run-hyphenated-abc123'
+
+interface Fixture {
+  realCwd: string
+  phantomPath: string
+  projectDir: string
+  runsDir: string
+  sessionDir: string
+  cleanup: () => Promise<void>
+}
+
+/**
+ * Create a real project with a HYPHEN in its folder name (the lossy-decode
+ * case: `pi-desktop-abc123` desanitizes to `pi\desktop\abc123`), a persisted
+ * workflow run keyed under the REAL path, and a session JSONL whose header
+ * carries the authoritative real cwd.
+ */
+async function makeFixture(): Promise<Fixture> {
+  const realCwd = await mkdtemp(join(homedir(), 'pi-discovery-'))
+  const phantomPath = desanitizeSessionDir(sanitizePath(realCwd))
+  const key = projectKey(realCwd)
+  const projectDir = join(homedir(), '.pi', 'workflows', 'projects', key)
+  const runsDir = join(projectDir, 'runs')
+  const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), '.pi', 'agent')
+  const sessionDir = join(agentDir, 'sessions', sanitizePath(realCwd))
+
+  await mkdir(runsDir, { recursive: true })
+  await writeFile(join(runsDir, `${RUN_ID}.json`), JSON.stringify({
+    runId: RUN_ID,
+    workflowName: 'audit',
+    sessionId: SESSION_UUID,
+    status: 'completed',
+    phases: ['scan'],
+    startedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:01.000Z',
+    agents: [{ id: 0, label: 'scan files', status: 'done', history: [{ role: 'assistant', kind: 'text', text: 'captured' }] }],
+  }))
+
+  await mkdir(sessionDir, { recursive: true })
+  await writeFile(join(sessionDir, `2026-01-01T00-00-00-000Z_${SESSION_UUID}.jsonl`), [
+    { type: 'session', id: SESSION_UUID, cwd: realCwd },
+    { type: 'session_info', name: `workflow:${RUN_ID} scan files` },
+    { type: 'message', timestamp: '2026-01-01T00:00:02.000Z', message: { role: 'user', content: [{ type: 'text', text: 'inspect the repo' }] } },
+    { type: 'message', timestamp: '2026-01-01T00:00:03.000Z', message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] } },
+  ].map((line) => JSON.stringify(line)).join('\n'))
+
+  return {
+    realCwd,
+    phantomPath,
+    projectDir,
+    runsDir,
+    sessionDir,
+    cleanup: async () => {
+      await rm(projectDir, { recursive: true, force: true })
+      await rm(sessionDir, { recursive: true, force: true })
+      await rm(realCwd, { recursive: true, force: true })
+    },
+  }
+}
+
+const phantomWorkspace = (path: string): Workspace => ({
+  id: 'ws-phantom',
+  name: 'desktop',
+  path,
+  createdAt: 0,
+  lastActiveAt: 0,
+  color: '#fff',
+})
+
+test('discovery resolves a hyphenated project from the session header cwd', async () => {
+  const fixture = await makeFixture()
+  try {
+    clearWorkflowProjectDiscoveryCache()
+    const discovery = await discoverWorkflowProjects()
+    const key = projectKey(fixture.realCwd)
+    // The project key is the real cwd's key, never the phantom's.
+    assert.equal(discovery.projects.get(key), resolve(fixture.realCwd))
+    assert.ok(fixture.phantomPath !== fixture.realCwd)
+    // The session-dir map anchors the phantom (lossy) dir name to the real cwd.
+    // Keyed case-folded like every other path key on Windows.
+    assert.equal(
+      discovery.sessionDirCwds.get(pathGroupKey(sanitizePath(fixture.realCwd))),
+      resolve(fixture.realCwd)
+    )
+  } finally {
+    await fixture.cleanup()
+    clearWorkflowProjectDiscoveryCache()
+  }
+})
+
+test('a registered workspace holding the phantom path is healed in memory (id preserved)', async () => {
+  const fixture = await makeFixture()
+  try {
+    clearWorkflowProjectDiscoveryCache()
+    // The workspace is registered at the LOSSY path — exactly the live bug
+    // (workspaces.json had E:\Projects\AI\pi\desktop).
+    const registered = [phantomWorkspace(fixture.phantomPath)]
+    const resolved = await resolveWorkflowWorkspaces(registered)
+
+    const healed = resolved.find((ws) => ws.id === 'ws-phantom')
+    assert.ok(healed, 'registered workspace id is preserved')
+    assert.ok(pathsEqual(healed.path, fixture.realCwd), `healed to real cwd, got ${healed.path}`)
+    assert.equal(healed.name, basename(fixture.realCwd))
+
+    // The same projection serves list, detail and control routing. Filter to
+    // the fixture's workspace — the resolution also includes every other
+    // project discovered in the real store.
+    const runs = (await listWorkflowRuns(resolved)).filter((run) => run.workspaceId === 'ws-phantom')
+    assert.equal(runs.length, 1)
+    assert.equal(runs[0].workspaceId, 'ws-phantom')
+    assert.equal(runs[0].cwd, resolve(fixture.realCwd))
+
+    const detail = await getWorkflowRun(healed, RUN_ID)
+    assert.equal(detail?.workflowName, 'audit')
+    // Transcript attaches through the healed cwd (persisted-session, not the
+    // degraded run-history fallback).
+    assert.equal(detail?.agents[0].transcriptSource, 'persisted-session')
+    assert.equal(detail?.agents[0].transcriptComplete, true)
+  } finally {
+    await fixture.cleanup()
+    clearWorkflowProjectDiscoveryCache()
+  }
+})
+
+test('an unregistered project gets a read-only workflow-<key> projection with the real cwd', async () => {
+  const fixture = await makeFixture()
+  try {
+    clearWorkflowProjectDiscoveryCache()
+    const key = projectKey(fixture.realCwd)
+    const resolved = await resolveWorkflowWorkspaces([])
+
+    const projection = resolved.find((ws) => ws.id === `workflow-${key}`)
+    assert.ok(projection, 'workflow-<key> projection exists')
+    assert.ok(pathsEqual(projection.path, fixture.realCwd))
+    assert.equal(projection.name, basename(fixture.realCwd))
+
+    const runs = await listWorkflowRuns([projection])
+    assert.equal(runs.length, 1)
+    assert.equal(runs[0].workspaceId, `workflow-${key}`)
+    const detail = await getWorkflowRun(projection, RUN_ID)
+    assert.equal(detail?.agents[0].transcriptSource, 'persisted-session')
+  } finally {
+    await fixture.cleanup()
+    clearWorkflowProjectDiscoveryCache()
+  }
+})
+
+test('an unresolved project is still listable/detail-openable via its display path', async () => {
+  const fixture = await makeFixture()
+  // Remove the session trace: only the run JSONs remain, so the cwd cannot be
+  // recovered — the projection must fall back to a display-only path while the
+  // run stays readable (run-history transcript).
+  await rm(fixture.sessionDir, { recursive: true, force: true })
+  try {
+    clearWorkflowProjectDiscoveryCache()
+    const key = projectKey(fixture.realCwd)
+    const resolved = await resolveWorkflowWorkspaces([])
+
+    const projection = resolved.find((ws) => ws.id === `workflow-${key}`)
+    assert.ok(projection, 'unresolved project still gets a projection')
+    // Display-only path under the projects dir; the id still pins the key.
+    assert.equal(projection.path, join(homedir(), '.pi', 'workflows', 'projects', key))
+
+    const runs = await listWorkflowRuns([projection])
+    assert.equal(runs.length, 1)
+    assert.equal(runs[0].cwd, projection.path)
+    const detail = await getWorkflowRun(projection, RUN_ID)
+    assert.equal(detail?.workflowName, 'audit')
+    assert.equal(detail?.agents[0].transcriptSource, 'run-history')
+  } finally {
+    await fixture.cleanup()
+    clearWorkflowProjectDiscoveryCache()
+  }
+})
+
+test('discovery results are cached and reused between polls', async () => {
+  const fixture = await makeFixture()
+  try {
+    clearWorkflowProjectDiscoveryCache()
+    const first = await discoverWorkflowProjects()
+    const second = await discoverWorkflowProjects()
+    // Same cache hit → same Map instances; no re-walk on the next poll.
+    assert.equal(second.projects, first.projects)
+    assert.equal(second.sessionDirCwds, first.sessionDirCwds)
+    clearWorkflowProjectDiscoveryCache()
+    const third = await discoverWorkflowProjects()
+    assert.notEqual(third.projects, first.projects)
+  } finally {
+    await fixture.cleanup()
+    clearWorkflowProjectDiscoveryCache()
+  }
+})

--- a/src/main/workflow-monitor.test.ts
+++ b/src/main/workflow-monitor.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { test } from 'node:test'
+import { getWorkflowRun, listWorkflowRuns } from './workflow-monitor'
+import type { Workspace } from '../shared/ipc-contracts'
+
+function projectKey(cwd: string): string {
+  const projectPath = resolve(cwd)
+  const name = (basename(projectPath) || 'project')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48) || 'project'
+  return `${name}-${createHash('sha256').update(projectPath).digest('hex').slice(0, 12)}`
+}
+
+test('projects persisted workflow runs into safe workspace summaries', async () => {
+  const cwd = await mkdtemp(join(homedir(), 'pi-workflow-monitor-'))
+  const runsDir = join(homedir(), '.pi', 'workflows', 'projects', projectKey(cwd), 'runs')
+  const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), '.pi', 'agent')
+  const safeCwd = `--${resolve(cwd).replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`
+  const sessionDir = join(agentDir, 'sessions', safeCwd)
+  const workspace: Workspace = {
+    id: 'ws-workflow-test',
+    name: 'Workflow Test',
+    path: cwd,
+    createdAt: Date.now(),
+    lastActiveAt: Date.now(),
+    color: '#fff',
+  }
+
+  try {
+    await mkdir(runsDir, { recursive: true })
+    await writeFile(join(runsDir, 'run-1.json'), JSON.stringify({
+      runId: 'run-1',
+      workflowName: 'audit',
+      status: 'running',
+      phases: ['scan', 'verify'],
+      currentPhase: 'scan',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:01.000Z',
+      script: 'do not expose this',
+      result: { secret: 'do not expose this' },
+      agents: [{ id: 0, label: 'scan files', phase: 'scan', status: 'running', prompt: 'private prompt', tokens: 12, history: [{ role: 'assistant', kind: 'text', text: 'captured' }] }],
+    }))
+
+    const [run] = await listWorkflowRuns([workspace])
+    assert.equal(run.workflowName, 'audit')
+    assert.equal(run.workspaceId, workspace.id)
+    assert.equal(run.currentPhase, 'scan')
+    assert.deepEqual(run.agents[0], {
+      id: 0,
+      label: 'scan files',
+      phase: 'scan',
+      status: 'running',
+      hasHistory: true,
+      tokens: 12,
+    })
+    assert.equal('script' in run, false)
+    assert.equal('result' in run, false)
+
+    await mkdir(sessionDir, { recursive: true })
+    await writeFile(join(sessionDir, 'workflow-agent.jsonl'), [
+      { type: 'session', id: 'session-1', cwd },
+      { type: 'session_info', name: 'workflow:run-1 scan files' },
+      { type: 'message', timestamp: '2026-01-01T00:00:02.000Z', message: { role: 'user', content: [{ type: 'text', text: 'private prompt' }] } },
+      { type: 'message', timestamp: '2026-01-01T00:00:03.000Z', message: { role: 'assistant', content: [{ type: 'text', text: 'I will inspect the files.' }, { type: 'toolCall', name: 'bash', arguments: { command: 'npm test' } }] } },
+      { type: 'message', timestamp: '2026-01-01T00:00:04.000Z', message: { role: 'toolResult', toolName: 'bash', content: [{ type: 'text', text: 'all tests passed' }] } },
+    ].map((line) => JSON.stringify(line)).join('\n'))
+
+    const full = await getWorkflowRun(workspace, 'run-1')
+    assert.equal(full?.agents[0].transcriptSource, 'persisted-session')
+    assert.equal(full?.agents[0].transcriptComplete, true)
+    assert.equal(full?.agents[0].history.some((entry) => entry.toolName === 'bash'), true)
+
+    await rm(sessionDir, { recursive: true, force: true })
+    const detail = await getWorkflowRun(workspace, 'run-1')
+    assert.equal(detail?.script, 'do not expose this')
+    assert.equal(detail?.agents[0].transcriptSource, 'run-history')
+    assert.equal(detail?.agents[0].transcriptComplete, false)
+    assert.equal(detail?.agents[0].prompt, 'private prompt')
+  } finally {
+    await rm(join(homedir(), '.pi', 'workflows', 'projects', projectKey(cwd)), { recursive: true, force: true })
+    await rm(sessionDir, { recursive: true, force: true })
+    await rm(cwd, { recursive: true, force: true })
+  }
+})

--- a/src/main/workflow-monitor.ts
+++ b/src/main/workflow-monitor.ts
@@ -1,0 +1,811 @@
+import { createHash } from 'crypto'
+import { mkdir, open, readdir, readFile, rename, stat, writeFile } from 'fs/promises'
+import { homedir } from 'os'
+import { basename, join, resolve } from 'path'
+import { pathGroupKey } from '../shared/path-compare'
+import { pathsEqual, sanitizePath } from './session-paths'
+import type {
+  WorkflowAgentDetail,
+  WorkflowAgentSummary,
+  WorkflowAgentStatus,
+  WorkflowHistoryEntry,
+  WorkflowRunDetail,
+  WorkflowRunStatus,
+  WorkflowRunSummary,
+  Workspace,
+} from '../shared/ipc-contracts'
+
+const WORKFLOW_HOME = join(homedir(), '.pi', 'workflows')
+const WORKFLOW_PROJECTS_DIR = join(WORKFLOW_HOME, 'projects')
+const WORKFLOW_SETTINGS_PATH = join(WORKFLOW_HOME, 'settings.json')
+const MAX_HISTORY_ENTRIES = 150
+const MAX_ENTRY_CHARS = 20_000
+const MAX_TRANSCRIPT_CHARS = 160_000
+const MAX_SCRIPT_CHARS = 120_000
+const MAX_LOG_LINES = 200
+const MAX_LOG_CHARS = 4_000
+// Bounds for the read-only workflow project discovery (see discoverWorkflowProjects).
+const MAX_DISCOVERED_PROJECTS = 100
+const MAX_SESSION_DIRS_SCANNED = 200
+const MAX_SESSION_FILES_INDEXED = 500
+const MAX_SESSION_HEADER_BYTES = 4 * 1024
+const MAX_RUNS_READ_PER_PROJECT = 3
+const MAX_RUN_FILE_BYTES = 2 * 1024 * 1024
+// pi-dynamic-workflows names project dirs `<slug>-<sha256(cwd).slice(0,12)>`.
+const WORKFLOW_PROJECT_KEY_RE = /^[a-z0-9._-]{1,60}-[0-9a-f]{12}$/
+const RUN_STATUSES = new Set<WorkflowRunStatus>([
+  'pending',
+  'running',
+  'paused',
+  'completed',
+  'failed',
+  'aborted',
+])
+const AGENT_STATUSES = new Set<WorkflowAgentStatus>([
+  'queued',
+  'running',
+  'done',
+  'error',
+  'skipped',
+])
+
+interface UnknownRecord {
+  [key: string]: unknown
+}
+
+interface CachedRun {
+  mtimeMs: number
+  size: number
+  ino: number
+  value: UnknownRecord
+}
+
+const runCache = new Map<string, CachedRun>()
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function boundedString(value: unknown, max = 500): string | undefined {
+  const text = stringValue(value)
+  return text ? text.slice(0, max) : undefined
+}
+
+function jsonText(value: unknown, max: number): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value === 'string') return value.slice(0, max)
+  try {
+    return JSON.stringify(value, null, 2).slice(0, max)
+  } catch {
+    return '[unserializable value]'
+  }
+}
+
+function sanitizeProjectName(value: string): string {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+  return sanitized || 'project'
+}
+
+/** Mirrors pi-dynamic-workflows' project key without importing the extension. */
+function workflowProjectKey(cwd: string): string {
+  const projectPath = resolve(cwd)
+  const projectName = sanitizeProjectName(basename(projectPath) || 'project')
+  const hash = createHash('sha256').update(projectPath).digest('hex').slice(0, 12)
+  return `${projectName}-${hash}`
+}
+
+/**
+ * Read-only workspace projection for workflow files of a project that is not
+ * registered in workspaces.json. `key` is optional: pass it for projects whose
+ * resolved cwd does not recompute to the wanted key (unresolved projects get a
+ * display-only path under the projects dir; the id still pins the real key).
+ */
+export function workflowWorkspaceForPath(cwd: string, key?: string): Workspace {
+  const path = resolve(cwd)
+  const projectKey = key ?? workflowProjectKey(path)
+  const name = key ? slugFromProjectKey(key) : basename(path) || path
+  return {
+    id: `workflow-${projectKey}`,
+    name,
+    path,
+    createdAt: 0,
+    lastActiveAt: 0,
+    color: '#6b7280',
+  }
+}
+
+/** `pi-desktop-273acbe828fd` -> `pi-desktop`; passthrough when malformed. */
+function slugFromProjectKey(key: string): string {
+  return key.length > 13 ? key.slice(0, key.length - 13) : key
+}
+
+/** The project key embedded in a `workflow-<key>` workspace id, or null. */
+function workflowKeyFromId(workspaceId: string): string | null {
+  if (!workspaceId.startsWith('workflow-')) return null
+  const key = workspaceId.slice('workflow-'.length)
+  return WORKFLOW_PROJECT_KEY_RE.test(key) ? key : null
+}
+
+function workflowRunDirs(workspace: Workspace): string[] {
+  // A `workflow-<key>` projection pins its project key even when its path is
+  // display-only (unresolved projects); registered workspaces derive the key
+  // from their (possibly healed) path as before.
+  const key = workflowKeyFromId(workspace.id) ?? workflowProjectKey(workspace.path)
+  return [
+    join(WORKFLOW_PROJECTS_DIR, key, 'runs'),
+    join(resolve(workspace.path), '.pi', 'workflows', 'runs'),
+  ]
+}
+
+function workflowSessionsDir(cwd: string): string {
+  const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), '.pi', 'agent')
+  const resolvedCwd = resolve(cwd)
+  const safePath = `--${resolvedCwd.replace(/^[/\\]/, '').replace(/[/\\:]/g, '-')}--`
+  return join(agentDir, 'sessions', safePath)
+}
+
+// ─── Workflow project discovery ─────────────────────────────────────────────
+
+/**
+ * Result of the bounded discovery walk over `~/.pi/workflows/projects`.
+ *
+ * `projects` maps every on-disk project key to its real cwd, or null when the
+ * cwd could not be recovered from the session store. `sessionDirCwds` maps
+ * sanitized session dir names to the header cwd of their newest session, so
+ * registered workspaces holding a lossy/phantom path can be repaired.
+ */
+export interface WorkflowProjectDiscovery {
+  projects: Map<string, string | null>
+  sessionDirCwds: Map<string, string>
+}
+
+let projectDiscoveryCache: { cacheKey: string; value: WorkflowProjectDiscovery } | null = null
+
+/** Test helper: drop the discovery cache between cases. */
+export function clearWorkflowProjectDiscoveryCache(): void {
+  projectDiscoveryCache = null
+}
+
+/** `E:\Projects\AI\pi-desktop` -> `--E--Projects-AI-pi-desktop--`. */
+function sessionDirKey(cwd: string): string {
+  return pathGroupKey(sanitizePath(cwd))
+}
+
+/**
+ * Bounded read of the session header's cwd: first complete line, first 4 KB.
+ * Never throws; null when the file is unreadable or the header lacks a cwd.
+ */
+async function readSessionHeaderCwd(filePath: string): Promise<string | null> {
+  let handle
+  try {
+    handle = await open(filePath, 'r')
+    const buffer = Buffer.alloc(MAX_SESSION_HEADER_BYTES)
+    const { bytesRead } = await handle.read(buffer, 0, MAX_SESSION_HEADER_BYTES, 0)
+    const firstLine = buffer.subarray(0, bytesRead).toString('utf-8').split('\n', 1)[0]
+    const record: unknown = JSON.parse(firstLine)
+    return isRecord(record) && typeof record.cwd === 'string' && record.cwd.length > 0
+      ? record.cwd
+      : null
+  } catch {
+    return null
+  } finally {
+    await handle?.close()
+  }
+}
+
+/** sessionId (header uuid) from a run record, without parsing the whole file. */
+async function sessionIdFromRunFile(filePath: string): Promise<string | null> {
+  try {
+    const file = await stat(filePath)
+    if (file.size <= 0 || file.size > MAX_RUN_FILE_BYTES) return null
+    const text = await readFile(filePath, 'utf8')
+    const match = /"sessionId"\s*:\s*"([^"]+)"/.exec(text)
+    return match?.[1] ?? null
+  } catch {
+    return null
+  }
+}
+
+/** All parent session files in one dir, newest first. */
+async function sessionFilesNewestFirst(sessionDir: string): Promise<string[]> {
+  try {
+    const names = (await readdir(sessionDir)).filter((name) => name.endsWith('.jsonl'))
+    // Pi names parent sessions `<ISO-timestamp>_<uuid>.jsonl`; the fixed-width
+    // timestamp makes a descending sort the newest-first order with no stats.
+    return names.sort().reverse().map((name) => join(sessionDir, name))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Discover every workflow project on disk and its real cwd.
+ *
+ * Never reconstructs a path from a sanitized session dir name (lossy). Instead:
+ *  1. `workflowProjectKey` of every known path (registered workspaces + launch
+ *     cwd) is matched against the on-disk project keys;
+ *  2. one bounded pass over the session store reads the header cwd of the
+ *     newest session per dir and verifies it recomputes to a project key;
+ *  3. unresolved keys fall back to their newest run JSONs' `sessionId`, which
+ *     is matched against session filenames (`<timestamp>_<uuid>.jsonl`) and
+ *     verified against the session header cwd.
+ *
+ * Every read is bounded (caps above), and the whole walk is cached on the
+ * projects + sessions directory mtimes, so the runs-list poll does not rescan
+ * session files (or huge run files) on every tick.
+ */
+export async function discoverWorkflowProjects(
+  knownPaths: readonly string[] = []
+): Promise<WorkflowProjectDiscovery> {
+  const cacheKey = await discoveryCacheKey(knownPaths)
+  if (cacheKey === null) {
+    projectDiscoveryCache = null
+    return { projects: new Map(), sessionDirCwds: new Map() }
+  }
+  if (projectDiscoveryCache && projectDiscoveryCache.cacheKey === cacheKey) {
+    return projectDiscoveryCache.value
+  }
+
+  const projects = new Map<string, string | null>()
+  let projectDirs: string[]
+  try {
+    projectDirs = (await readdir(WORKFLOW_PROJECTS_DIR, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && WORKFLOW_PROJECT_KEY_RE.test(entry.name))
+      .slice(0, MAX_DISCOVERED_PROJECTS)
+      .map((entry) => entry.name)
+  } catch {
+    projectDirs = []
+  }
+
+  // (1) Known paths: exact key match, no reads. This is what keeps registered
+  // workspace ids authoritative — a registered path that resolves here is never
+  // shadowed by a projection.
+  for (const dir of projectDirs) {
+    projects.set(dir, null)
+  }
+  for (const known of knownPaths) {
+    const key = workflowProjectKey(known)
+    if (projects.has(key) && projects.get(key) === null) projects.set(key, resolve(known))
+  }
+
+  const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), '.pi', 'agent')
+  const sessionsRoot = join(agentDir, 'sessions')
+  const sessionDirCwds = new Map<string, string>()
+  const sessionUuidToFile = new Map<string, string>()
+  let sessionDirsScanned = 0
+  let filesIndexed = 0
+
+  // (2) One bounded pass over the session store.
+  let sessionDirNames: string[]
+  try {
+    sessionDirNames = (await readdir(sessionsRoot, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  } catch {
+    sessionDirNames = []
+  }
+  for (const dirName of sessionDirNames) {
+    if (sessionDirsScanned >= MAX_SESSION_DIRS_SCANNED) break
+    sessionDirsScanned++
+    const sessionDir = join(sessionsRoot, dirName)
+    // One readdir per dir serves both the header scan and the uuid index.
+    const files = await sessionFilesNewestFirst(sessionDir)
+
+    const headerCwd = await readSessionHeaderCwd(files[0])
+    if (headerCwd) {
+      sessionDirCwds.set(pathGroupKey(dirName), headerCwd)
+      const key = workflowProjectKey(headerCwd)
+      if (projects.has(key) && projects.get(key) === null) projects.set(key, resolve(headerCwd))
+    }
+
+    // Index parent session uuids from filenames alone (no reads) for the
+    // run-sessionId fallback below.
+    for (const name of files) {
+      if (filesIndexed >= MAX_SESSION_FILES_INDEXED) break
+      const stem = basename(name, '.jsonl')
+      const underscore = stem.lastIndexOf('_')
+      if (underscore > 0 && underscore < stem.length - 1) {
+        sessionUuidToFile.set(stem.slice(underscore + 1), name)
+        filesIndexed++
+      }
+    }
+  }
+
+  // (3) Run-sessionId fallback for keys the header scan could not resolve.
+  for (const [key, cwd] of [...projects]) {
+    if (cwd !== null) continue
+    const runsDir = join(WORKFLOW_PROJECTS_DIR, key, 'runs')
+    let runFiles: string[]
+    try {
+      const names = (await readdir(runsDir)).filter((name) => name.endsWith('.json'))
+      const newest = await Promise.all(
+        names.map(async (name) => {
+          try {
+            return { name, mtimeMs: (await stat(join(runsDir, name))).mtimeMs }
+          } catch {
+            return null
+          }
+        })
+      )
+      runFiles = newest
+        .filter((entry): entry is { name: string; mtimeMs: number } => entry !== null)
+        .sort((a, b) => b.mtimeMs - a.mtimeMs)
+        .slice(0, MAX_RUNS_READ_PER_PROJECT)
+        .map((entry) => join(runsDir, entry.name))
+    } catch {
+      continue
+    }
+    for (const runFile of runFiles) {
+      const sessionId = await sessionIdFromRunFile(runFile)
+      if (!sessionId) continue
+      const sessionFile = sessionUuidToFile.get(sessionId)
+      if (!sessionFile) continue
+      const headerCwd = await readSessionHeaderCwd(sessionFile)
+      if (headerCwd && workflowProjectKey(headerCwd) === key) {
+        projects.set(key, resolve(headerCwd))
+        break
+      }
+    }
+  }
+
+  const value: WorkflowProjectDiscovery = { projects, sessionDirCwds }
+  projectDiscoveryCache = { cacheKey, value }
+  return value
+}
+
+/** mtime+size of both store roots; null when the projects dir is missing. */
+async function discoveryCacheKey(knownPaths: readonly string[]): Promise<string | null> {
+  try {
+    const [projects, sessions] = await Promise.all([
+      stat(WORKFLOW_PROJECTS_DIR),
+      stat(join(process.env.PI_CODING_AGENT_DIR || join(homedir(), '.pi', 'agent'), 'sessions')),
+    ])
+    // Known paths are cheap to fold in and change only with workspace state.
+    const known = knownPaths.map((p) => workflowProjectKey(p)).join(',')
+    return `${projects.mtimeMs}:${projects.size}:${sessions.mtimeMs}:${sessions.size}:${known}`
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The single workspace projection shared by workflow list, getRun and control.
+ *
+ * Registered workspaces keep their ids and (on-disk) paths. A registered path
+ * whose key has no project dir is checked against the session-store scan: if
+ * its sanitized session dir's headers point at a real project (the lossy-decode
+ * phantom case), the returned projection carries the healed real cwd in memory
+ * only — workspaces.json is never rewritten and no sidebar workspace is created.
+ * Unregistered projects get a read-only `workflow-<key>` projection (real cwd
+ * when discovered, display-only path otherwise) that never spawns a Pi manager.
+ */
+export async function resolveWorkflowWorkspaces(
+  registered: readonly Workspace[]
+): Promise<Workspace[]> {
+  const knownPaths = [...registered.map((ws) => ws.path), process.cwd()]
+  const discovery = await discoverWorkflowProjects(knownPaths)
+  const out: Workspace[] = []
+  const coveredKeys = new Set<string>()
+
+  for (const ws of registered) {
+    const key = workflowProjectKey(ws.path)
+    coveredKeys.add(key)
+    let effective = ws
+    if (!discovery.projects.has(key)) {
+      // No runs at the registered path. If it is a phantom (lossy session-dir
+      // decode), the session headers reveal the real cwd of the project whose
+      // runs exist on disk — heal the projection in memory, keeping the id.
+      const headerCwd = discovery.sessionDirCwds.get(sessionDirKey(ws.path))
+      if (headerCwd && !pathsEqual(headerCwd, ws.path)) {
+        const healedKey = workflowProjectKey(headerCwd)
+        if (discovery.projects.has(healedKey)) {
+          effective = { ...ws, path: headerCwd, name: basename(headerCwd) || headerCwd }
+          coveredKeys.add(healedKey)
+        }
+      }
+    }
+    out.push(effective)
+  }
+
+  // Read-only projections for every project dir without a registered workspace.
+  for (const [key, cwd] of discovery.projects) {
+    if (coveredKeys.has(key)) continue
+    coveredKeys.add(key)
+    out.push(
+      cwd
+        ? workflowWorkspaceForPath(cwd)
+        : workflowWorkspaceForPath(join(WORKFLOW_PROJECTS_DIR, key), key)
+    )
+  }
+
+  // The launch cwd must stay visible even before its first run is persisted.
+  const launchKey = workflowProjectKey(process.cwd())
+  if (!coveredKeys.has(launchKey)) {
+    out.push(workflowWorkspaceForPath(process.cwd()))
+  }
+
+  return out
+}
+
+function toStatus(value: unknown): WorkflowRunStatus {
+  return typeof value === 'string' && RUN_STATUSES.has(value as WorkflowRunStatus)
+    ? (value as WorkflowRunStatus)
+    : 'pending'
+}
+
+function toAgentStatus(value: unknown): WorkflowAgentStatus {
+  return typeof value === 'string' && AGENT_STATUSES.has(value as WorkflowAgentStatus)
+    ? (value as WorkflowAgentStatus)
+    : 'queued'
+}
+
+function toTokenUsage(value: unknown): WorkflowRunSummary['tokenUsage'] | undefined {
+  if (!isRecord(value)) return undefined
+  const input = numberValue(value.input)
+  const output = numberValue(value.output)
+  const total = numberValue(value.total)
+  if (input === undefined || output === undefined || total === undefined) return undefined
+  const cost = numberValue(value.cost)
+  const cacheRead = numberValue(value.cacheRead)
+  const cacheWrite = numberValue(value.cacheWrite)
+  return {
+    input,
+    output,
+    total,
+    ...(cost === undefined ? {} : { cost }),
+    ...(cacheRead === undefined ? {} : { cacheRead }),
+    ...(cacheWrite === undefined ? {} : { cacheWrite }),
+  }
+}
+
+function normalizeHistoryEntry(value: unknown): WorkflowHistoryEntry | null {
+  if (!isRecord(value)) return null
+  const text = boundedString(value.text, MAX_ENTRY_CHARS) ?? ''
+  const role = stringValue(value.role) ?? 'system'
+  const kind = stringValue(value.kind) ?? 'text'
+  const entry: WorkflowHistoryEntry = { role, kind, text }
+  const id = stringValue(value.id)
+  const timestamp = stringValue(value.timestamp)
+  const toolName = stringValue(value.toolName)
+  const path = stringValue(value.path)
+  const diff = boundedString(value.diff, MAX_ENTRY_CHARS)
+  if (id) entry.id = id
+  if (timestamp) entry.timestamp = timestamp
+  if (toolName) entry.toolName = toolName
+  if (path) entry.path = path
+  if (diff) entry.diff = diff
+  if (typeof value.isError === 'boolean') entry.isError = value.isError
+  return entry
+}
+
+function normalizeHistory(value: unknown): WorkflowHistoryEntry[] {
+  if (!Array.isArray(value)) return []
+  const result: WorkflowHistoryEntry[] = []
+  let chars = 0
+  for (const item of value.slice(-MAX_HISTORY_ENTRIES)) {
+    const entry = normalizeHistoryEntry(item)
+    if (!entry) continue
+    chars += entry.text.length + (entry.diff?.length ?? 0)
+    if (chars > MAX_TRANSCRIPT_CHARS) break
+    result.push(entry)
+  }
+  return result
+}
+
+function projectRun(workspace: Workspace, raw: UnknownRecord): WorkflowRunSummary | null {
+  const runId = stringValue(raw.runId)
+  const workflowName = stringValue(raw.workflowName)
+  const startedAt = stringValue(raw.startedAt)
+  const updatedAt = stringValue(raw.updatedAt)
+  if (!runId || !workflowName || !startedAt || !updatedAt) return null
+
+  const phases = Array.isArray(raw.phases)
+    ? raw.phases.filter((phase): phase is string => typeof phase === 'string')
+    : []
+  const agents = Array.isArray(raw.agents)
+    ? raw.agents.flatMap((value): WorkflowRunSummary['agents'] => {
+        if (!isRecord(value)) return []
+        const id = numberValue(value.id)
+        const label = stringValue(value.label)
+        if (id === undefined || !label) return []
+        const error = boundedString(value.error)
+        const resultPreview = boundedString(value.resultPreview, 4_000)
+        const tokens = numberValue(value.tokens)
+        const model = stringValue(value.model)
+        const started = stringValue(value.startedAt)
+        const ended = stringValue(value.endedAt)
+        const callId = stringValue(value.callId)
+        const errorCode = stringValue(value.errorCode)
+        const tokenUsage = toTokenUsage(value.tokenUsage)
+        return [{
+          id,
+          ...(callId ? { callId } : {}),
+          label,
+          ...(stringValue(value.phase) ? { phase: value.phase as string } : {}),
+          status: toAgentStatus(value.status),
+          ...(error ? { error } : {}),
+          ...(errorCode ? { errorCode } : {}),
+          ...(typeof value.recoverable === 'boolean' ? { recoverable: value.recoverable } : {}),
+          hasHistory: Array.isArray(value.history) && value.history.length > 0,
+          ...(resultPreview ? { resultPreview } : {}),
+          ...(tokens === undefined ? {} : { tokens }),
+          ...(model ? { model } : {}),
+          ...(started ? { startedAt: started } : {}),
+          ...(ended ? { endedAt: ended } : {}),
+          ...(tokenUsage ? { tokenUsage } : {}),
+        }]
+      })
+    : []
+  const tokenUsage = toTokenUsage(raw.tokenUsage)
+  const sessionId = stringValue(raw.sessionId)
+  const pauseReason = boundedString(raw.pauseReason)
+  const resetHint = boundedString(raw.resetHint)
+
+  return {
+    workspaceId: workspace.id,
+    workspaceName: workspace.name,
+    cwd: workspace.path,
+    runId,
+    workflowName,
+    ...(sessionId ? { sessionId } : {}),
+    status: toStatus(raw.status),
+    ...(pauseReason ? { pauseReason } : {}),
+    ...(resetHint ? { resetHint } : {}),
+    phases,
+    ...(stringValue(raw.currentPhase) ? { currentPhase: raw.currentPhase as string } : {}),
+    agents,
+    startedAt,
+    updatedAt,
+    ...(numberValue(raw.durationMs) === undefined ? {} : { durationMs: raw.durationMs as number }),
+    ...(tokenUsage ? { tokenUsage } : {}),
+  }
+}
+
+async function readJson(path: string): Promise<UnknownRecord | null> {
+  try {
+    const value: unknown = JSON.parse(await readFile(path, 'utf8'))
+    return isRecord(value) ? value : null
+  } catch {
+    return null
+  }
+}
+
+async function readRunFiles(dir: string): Promise<UnknownRecord[]> {
+  let names: string[]
+  try {
+    names = await readdir(dir)
+  } catch {
+    return []
+  }
+
+  const values = await Promise.all(names.filter((name) => name.endsWith('.json')).map(async (name) => {
+    const filePath = join(dir, name)
+    try {
+      const file = await stat(filePath)
+      const cached = runCache.get(filePath)
+      if (cached && cached.mtimeMs === file.mtimeMs && cached.size === file.size && cached.ino === file.ino) {
+        return cached.value
+      }
+      const value = await readJson(filePath)
+      if (value) runCache.set(filePath, { mtimeMs: file.mtimeMs, size: file.size, ino: file.ino, value })
+      else runCache.delete(filePath)
+      return value
+    } catch {
+      runCache.delete(filePath)
+      return null
+    }
+  }))
+  return values.filter((value): value is UnknownRecord => value !== null)
+}
+
+async function readRunRecord(workspace: Workspace, runId: string): Promise<UnknownRecord | null> {
+  if (!/^[a-zA-Z0-9._-]{1,200}$/.test(runId)) return null
+  for (const dir of workflowRunDirs(workspace)) {
+    const primary = await readJson(join(dir, `${runId}.json`))
+    if (primary) return primary
+    const backup = await readJson(join(dir, `${runId}.json.bak`))
+    if (backup) return backup
+  }
+  return null
+}
+
+function contentText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (!Array.isArray(value)) return ''
+  return value
+    .map((block) => {
+      if (!isRecord(block)) return ''
+      if (typeof block.text === 'string') return block.text
+      if (typeof block.thinking === 'string') return block.thinking
+      if (block.type === 'toolCall') return jsonText(block, MAX_ENTRY_CHARS) ?? ''
+      return ''
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+function sessionHistory(entries: UnknownRecord[]): WorkflowHistoryEntry[] {
+  const result: WorkflowHistoryEntry[] = []
+  for (const entry of entries) {
+    if (entry.type !== 'message' || !isRecord(entry.message)) continue
+    const message = entry.message
+    const role = stringValue(message.role) ?? 'system'
+    const timestamp = stringValue(entry.timestamp)
+    const content = Array.isArray(message.content) ? message.content : [message.content]
+    if (role === 'assistant') {
+      for (const block of content) {
+        if (!isRecord(block)) continue
+        const kind = block.type === 'thinking' ? 'thinking' : block.type === 'toolCall' ? 'toolCall' : 'text'
+        const text = block.type === 'toolCall'
+          ? jsonText(block, MAX_ENTRY_CHARS) ?? ''
+          : contentText([block])
+        if (text) result.push({
+          role,
+          kind,
+          text: text.slice(0, MAX_ENTRY_CHARS),
+          ...(timestamp ? { timestamp } : {}),
+          ...(stringValue(block.name) ? { toolName: block.name as string } : {}),
+        })
+      }
+      continue
+    }
+    const text = contentText(message.content).slice(0, MAX_ENTRY_CHARS)
+    if (!text) continue
+    result.push({
+      role,
+      kind: role === 'toolResult' ? 'toolResult' : 'text',
+      text,
+      ...(timestamp ? { timestamp } : {}),
+      ...(stringValue(message.toolName) ? { toolName: message.toolName as string } : {}),
+      ...(message.isError === true ? { isError: true } : {}),
+    })
+  }
+  return normalizeHistory(result)
+}
+
+interface PersistedSessionMatch {
+  history: WorkflowHistoryEntry[]
+  sessionName: string
+}
+
+async function findPersistedSession(cwd: string, runId: string, agent: UnknownRecord): Promise<PersistedSessionMatch | null> {
+  let names: string[]
+  try {
+    names = (await readdir(workflowSessionsDir(cwd))).filter((name) => name.endsWith('.jsonl'))
+  } catch {
+    return null
+  }
+
+  const expected = `workflow:${runId} `
+  const prompt = stringValue(agent.prompt)
+  const matches: PersistedSessionMatch[] = []
+  for (const name of names) {
+    let lines: string[]
+    try {
+      lines = (await readFile(join(workflowSessionsDir(cwd), name), 'utf8')).split(/\r?\n/)
+    } catch {
+      continue
+    }
+    const entries: UnknownRecord[] = []
+    let sessionName: string | undefined
+    for (const line of lines) {
+      if (!line.trim()) continue
+      try {
+        const value: unknown = JSON.parse(line)
+        if (!isRecord(value)) continue
+        if (value.type === 'session_info') sessionName = stringValue(value.name)
+        entries.push(value)
+      } catch {
+        // A live session can end with a partial JSONL line; keep the readable prefix.
+      }
+    }
+    if (!sessionName?.startsWith(expected)) continue
+    // The header cwd is authoritative: session dir names are lossy decodes of
+    // real paths (hyphens vs separators collide), so a caller holding a
+    // phantom/decoded path still lands on the same physical dir — the
+    // runId-prefixed name, not the cwd, is what uniquely identifies this
+    // run's transcript. Rejecting on a cwd mismatch is what silently degraded
+    // transcripts to run-history for hyphenated projects.
+    const history = sessionHistory(entries)
+    const matchesPrompt = prompt && history.some((item) => item.role === 'user' && item.text.includes(prompt))
+    const match = { history, sessionName }
+    if (matchesPrompt) return match
+    matches.push(match)
+  }
+  return matches[0] ?? null
+}
+
+async function projectAgentDetail(
+  workspace: Workspace,
+  runId: string,
+  value: UnknownRecord,
+  summary: WorkflowAgentSummary
+): Promise<WorkflowAgentDetail> {
+  const runHistory = normalizeHistory(value.history)
+  const persisted = await findPersistedSession(workspace.path, runId, value)
+  const history = persisted?.history.length ? persisted.history : runHistory
+  const resultText = jsonText(value.result ?? value.resultPreview, MAX_ENTRY_CHARS)
+  const prompt = stringValue(value.prompt)
+  return {
+    ...summary,
+    ...(prompt ? { prompt: prompt.slice(0, MAX_ENTRY_CHARS) } : {}),
+    ...(resultText ? { resultText } : {}),
+    history,
+    transcriptSource: persisted?.history.length ? 'persisted-session' : runHistory.length ? 'run-history' : 'none',
+    transcriptComplete: !!persisted?.history.length,
+  }
+}
+
+async function readWorkspaceRuns(workspace: Workspace): Promise<WorkflowRunSummary[]> {
+  const byId = new Map<string, WorkflowRunSummary>()
+  // Primary storage wins over the legacy project-local directory if both exist.
+  for (const dir of workflowRunDirs(workspace)) {
+    for (const raw of await readRunFiles(dir)) {
+      const run = projectRun(workspace, raw)
+      if (run && !byId.has(run.runId)) byId.set(run.runId, run)
+    }
+  }
+  return [...byId.values()]
+}
+
+export async function listWorkflowRuns(workspaces: Workspace[]): Promise<WorkflowRunSummary[]> {
+  const runs = (await Promise.all(workspaces.map(readWorkspaceRuns))).flat()
+  return runs.sort((a, b) => {
+    const time = (value: string): number => Date.parse(value) || 0
+    return time(b.updatedAt) - time(a.updatedAt)
+  })
+}
+
+export async function setWorkflowPersistence(enabled: boolean): Promise<void> {
+  let existing: UnknownRecord = {}
+  try {
+    const value: unknown = JSON.parse(await readFile(WORKFLOW_SETTINGS_PATH, 'utf8'))
+    if (isRecord(value)) existing = value
+  } catch {
+    // Missing or malformed settings are replaced with the one safe preference.
+  }
+  await mkdir(WORKFLOW_HOME, { recursive: true })
+  const tempPath = `${WORKFLOW_SETTINGS_PATH}.tmp`
+  await writeFile(tempPath, `${JSON.stringify({ ...existing, persistAgentSessions: enabled }, null, 2)}\n`, 'utf8')
+  await rename(tempPath, WORKFLOW_SETTINGS_PATH)
+}
+
+export async function getWorkflowRun(workspace: Workspace, runId: string): Promise<WorkflowRunDetail | null> {
+  const raw = await readRunRecord(workspace, runId)
+  if (!raw) return null
+  const summary = projectRun(workspace, raw)
+  if (!summary) return null
+  const rawAgents = Array.isArray(raw.agents) ? raw.agents.filter(isRecord) : []
+  const agents = await Promise.all(rawAgents.map(async (agent) => {
+    const id = numberValue(agent.id)
+    const fallback = summary.agents.find((candidate) => candidate.id === id)
+    if (id === undefined || !fallback) return null
+    return projectAgentDetail(workspace, runId, agent, fallback)
+  }))
+  const logs = Array.isArray(raw.logs)
+    ? raw.logs
+        .filter((line): line is string => typeof line === 'string')
+        .slice(-MAX_LOG_LINES)
+        .map((line) => line.slice(0, MAX_LOG_CHARS))
+    : []
+  return {
+    ...summary,
+    ...(boundedString(raw.script, MAX_SCRIPT_CHARS) ? { script: boundedString(raw.script, MAX_SCRIPT_CHARS) } : {}),
+    ...(raw.args === undefined ? {} : { argsText: jsonText(raw.args, MAX_ENTRY_CHARS) }),
+    ...(raw.result === undefined ? {} : { resultText: jsonText(raw.result, MAX_TRANSCRIPT_CHARS) }),
+    logs,
+    agents: agents.filter((agent): agent is WorkflowAgentDetail => agent !== null),
+  }
+}

--- a/src/main/workspace-activity.test.ts
+++ b/src/main/workspace-activity.test.ts
@@ -76,6 +76,18 @@ test('agent_end in a background workspace marks completed and notifies', () => {
   assert.deepEqual(h.notifications, [{ workspaceId: 'ws-bg', kind: 'completed' }])
 })
 
+test('agent_end preserves the exact runtime session target for notification clicks', () => {
+  const h = makeHarness('ws-active')
+  h.tracker.handleAgentStart('ws-bg')
+  h.tracker.handleAgentEnd('ws-bg', { runtimeId: 'rt-1', sessionPath: '/sessions/finished.jsonl' })
+  assert.deepEqual(h.notifications, [{
+    workspaceId: 'ws-bg',
+    kind: 'completed',
+    runtimeId: 'rt-1',
+    sessionPath: '/sessions/finished.jsonl',
+  }])
+})
+
 test('pending prompts override working and notify needs-approval', () => {
   const h = makeHarness('ws-active')
   h.tracker.handleAgentStart('ws-bg')

--- a/src/main/workspace-activity.ts
+++ b/src/main/workspace-activity.ts
@@ -21,6 +21,9 @@ import type {
 export type WorkspaceActivityNotification = {
   workspaceId: string
   kind: 'completed' | 'failed' | 'needs-approval'
+  /** Exact runtime/session target when the event came from a session manager. */
+  runtimeId?: string
+  sessionPath?: string
 }
 
 export interface WorkspaceActivityTrackerDeps {
@@ -40,15 +43,15 @@ export interface WorkspaceActivityTrackerDeps {
 
 export interface WorkspaceActivityTracker {
   handleAgentStart(workspaceId: string): void
-  handleAgentEnd(workspaceId: string): void
-  handleStatusChange(workspaceId: string, status: PiProcessStatus): void
+  handleAgentEnd(workspaceId: string, target?: { runtimeId?: string; sessionPath?: string }): void
+  handleStatusChange(workspaceId: string, status: PiProcessStatus, target?: { runtimeId?: string; sessionPath?: string }): void
   /**
    * The manager's 'exit' emission: the process died UNEXPECTEDLY after
    * reaching running (a deliberate stop() detaches listeners first and never
    * emits it). This — not the 'stopped' status both paths share — is the
    * failure signal, so quitting or stopping Pi mid-turn stays silent.
    */
-  handleProcessExit(workspaceId: string): void
+  handleProcessExit(workspaceId: string, target?: { runtimeId?: string; sessionPath?: string }): void
   handlePendingCounts(counts: PendingPromptCounts): void
   /** The user is now looking at this workspace — clear finished outcomes. */
   handleWorkspaceSeen(workspaceId: string): void
@@ -124,7 +127,7 @@ export function createWorkspaceActivityTracker(
       recompute()
     },
 
-    handleAgentEnd(workspaceId) {
+    handleAgentEnd(workspaceId, target) {
       const entry = signalsFor(workspaceId)
       const wasTurnActive = entry.turnActive
       entry.turnActive = false
@@ -133,18 +136,18 @@ export function createWorkspaceActivityTracker(
       // background stays visible until the user looks at that workspace. The
       // notification fires either way — focus, not activity, decides there.
       entry.outcome = deps.getActiveWorkspaceId() === workspaceId ? null : 'completed'
-      if (wasTurnActive) deps.onNotify({ workspaceId, kind: 'completed' })
+      if (wasTurnActive) deps.onNotify({ workspaceId, kind: 'completed', ...target })
       recompute()
     },
 
-    handleStatusChange(workspaceId, status) {
+    handleStatusChange(workspaceId, status, target) {
       const entry = signalsFor(workspaceId)
       const isActive = deps.getActiveWorkspaceId() === workspaceId
       if (status === 'error') {
         entry.turnActive = false
         entry.stoppedMidTurn = false
         entry.outcome = isActive ? null : 'failed'
-        deps.onNotify({ workspaceId, kind: 'failed' })
+        deps.onNotify({ workspaceId, kind: 'failed', ...target })
       } else if (status === 'stopped') {
         // 'stopped' alone is neutral — deliberate stops (user stop, quit,
         // folder change) land here too. Only a following 'exit' emission
@@ -160,11 +163,11 @@ export function createWorkspaceActivityTracker(
       recompute()
     },
 
-    handleProcessExit(workspaceId) {
+    handleProcessExit(workspaceId, target) {
       const entry = signalsFor(workspaceId)
       if (entry.stoppedMidTurn || entry.turnActive) {
         entry.outcome = deps.getActiveWorkspaceId() === workspaceId ? null : 'failed'
-        deps.onNotify({ workspaceId, kind: 'failed' })
+        deps.onNotify({ workspaceId, kind: 'failed', ...target })
       }
       entry.stoppedMidTurn = false
       entry.turnActive = false

--- a/src/main/workspace-manager.test.ts
+++ b/src/main/workspace-manager.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { mkdtemp, readFile, writeFile, access } from 'fs/promises'
+import { existsSync } from 'fs'
+import { spawnSync } from 'child_process'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { configureGuiDataDir, getGuiDataPath } from './app-data-paths'
@@ -78,6 +80,43 @@ test('changeWorkspacePath stops the workspace Pi so it cannot keep the old cwd',
     await mgr.changeWorkspacePath(ws.id, await project())
 
     assert.equal(stopped, true, "Pi's cwd is bound at spawn; a repoint must stop it")
+  })
+})
+
+test('creates and removes a clean managed worktree tab', async () => {
+  await freshDataDir()
+  const repo = await project()
+  await writeFile(join(repo, 'README.md'), 'worktree test\\n', 'utf-8')
+  const git = (args: string[], cwd = repo): string => {
+    const result = spawnSync('git', args, { cwd, encoding: 'utf-8' })
+    assert.equal(result.status, 0, result.stderr || `git ${args.join(' ')} failed`)
+    return result.stdout.trim()
+  }
+  git(['init'])
+  git(['config', 'user.email', 'pi-desktop@example.test'])
+  git(['config', 'user.name', 'Pi Desktop Tests'])
+  git(['add', '.'])
+  git(['commit', '-m', 'initial'])
+
+  await withManager(async (mgr) => {
+    await mgr.createWorkspace('Repo', repo)
+    const tab = await mgr.createWorktreeWorkspace()
+
+    assert.equal(tab.kind, 'worktree')
+    assert.equal(tab.branch, 'pi/repo-tab-' + tab.id.replace(/^ws-/, ''))
+    assert.equal(existsSync(tab.path), true)
+    assert.equal(git(['branch', '--show-current'], tab.path), tab.branch)
+
+    const result = await mgr.removeWorkspace(tab.id)
+    assert.equal(result.worktreeRemoved, true)
+    assert.equal(result.preservedWorktreePath, undefined)
+    assert.equal(existsSync(tab.path), false)
+
+    await writeFile(join(repo, 'source-dirty.txt'), 'stays in source\\n', 'utf-8')
+    const dirtySourceTab = await mgr.createWorktreeWorkspace()
+    assert.equal(dirtySourceTab.sourceWasDirty, true)
+    assert.equal(existsSync(join(dirtySourceTab.path, 'source-dirty.txt')), false)
+    await mgr.removeWorkspace(dirtySourceTab.id)
   })
 })
 

--- a/src/main/workspace-manager.test.ts
+++ b/src/main/workspace-manager.test.ts
@@ -221,10 +221,6 @@ test('closing a session runtime removes its tab and only marks empty sessions di
     const emptyPath = join(await project(), 'empty.jsonl')
     await writeFile(emptyPath, JSON.stringify({ type: 'session', id: 'empty' }) + '\n', 'utf-8')
     const emptyRuntime = await mgr.activateSession(workspace.id, emptyPath)
-    const emptyResult = await mgr.closeSessionRuntime(emptyRuntime.runtimeId)
-
-    assert.equal(emptyResult?.empty, true)
-    assert.equal(mgr.getSessionRuntime(emptyRuntime.runtimeId), null)
 
     const contentPath = join(await project(), 'content.jsonl')
     await writeFile(contentPath, [
@@ -232,8 +228,11 @@ test('closing a session runtime removes its tab and only marks empty sessions di
       JSON.stringify({ type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'keep me' }] } }),
     ].join('\n') + '\n', 'utf-8')
     const contentRuntime = await mgr.activateSession(workspace.id, contentPath)
+    const pruned = await mgr.pruneEmptySessionRuntimes()
     const contentResult = await mgr.closeSessionRuntime(contentRuntime.runtimeId)
 
+    assert.equal(pruned.some((result) => result.runtimeId === emptyRuntime.runtimeId && result.empty), true)
+    assert.equal(mgr.getSessionRuntime(emptyRuntime.runtimeId), null)
     assert.equal(contentResult?.empty, false)
     assert.equal(existsSync(contentPath), true)
   })

--- a/src/main/workspace-manager.test.ts
+++ b/src/main/workspace-manager.test.ts
@@ -65,6 +65,29 @@ test('workspaceIdFor reverse-maps a manager to its owning workspace', async () =
   })
 })
 
+test('multiple session runtimes share a project cwd without sharing a Pi process', async () => {
+  await freshDataDir()
+
+  await withManager(async (mgr) => {
+    const ws = await mgr.createWorkspace('Alpha', await project())
+    const fallback = mgr.getPiManager(ws.id)
+    const first = await mgr.createNewSessionRuntime(ws.id)
+    const second = await mgr.createNewSessionRuntime(ws.id)
+
+    assert.notEqual(first.runtimeId, second.runtimeId)
+    assert.notEqual(mgr.getActivePiManager(), fallback, 'the active session runtime replaces the workspace fallback')
+    assert.equal(mgr.getSessionRuntimes(ws.id).length, 2)
+    assert.equal(mgr.workspaceIdFor(mgr.getActivePiManager()!), ws.id)
+
+    const existingPath = join(await project(), 'session.jsonl')
+    await writeFile(existingPath, '{}\n', 'utf-8')
+    const activated = await mgr.activateSession(ws.id, existingPath)
+    assert.equal(activated.sessionPath, existingPath)
+    assert.equal(mgr.getSessionRuntimeForPath(existingPath)?.runtimeId, activated.runtimeId)
+    assert.equal(mgr.getActiveSessionRuntime()?.runtimeId, activated.runtimeId)
+  })
+})
+
 test('changeWorkspacePath stops the workspace Pi so it cannot keep the old cwd', async () => {
   await freshDataDir()
 

--- a/src/main/workspace-manager.test.ts
+++ b/src/main/workspace-manager.test.ts
@@ -143,6 +143,76 @@ test('creates and removes a clean managed worktree tab', async () => {
   })
 })
 
+test('reuses the same managed worktree for the same task', async () => {
+  await freshDataDir()
+  const repo = await project()
+  await writeFile(join(repo, 'README.md'), 'task reuse\n', 'utf-8')
+  const git = (args: string[], cwd = repo): string => {
+    const result = spawnSync('git', args, { cwd, encoding: 'utf-8' })
+    assert.equal(result.status, 0, result.stderr || `git ${args.join(' ')} failed`)
+    return result.stdout.trim()
+  }
+  git(['init'])
+  git(['config', 'user.email', 'pi-desktop@example.test'])
+  git(['config', 'user.name', 'Pi Desktop Tests'])
+  git(['add', '.'])
+  git(['commit', '-m', 'initial'])
+
+  await withManager(async (mgr) => {
+    const source = await mgr.createWorkspace('Repo', repo)
+    const task = 'Fix the task reuse test'
+    const first = await mgr.createWorktreeWorkspace({
+      sourceWorkspaceId: source.id,
+      name: 'Fix task reuse',
+      taskPrompt: task,
+    })
+    const second = await mgr.createWorktreeWorkspace({
+      sourceWorkspaceId: source.id,
+      name: 'Should not create another tab',
+      taskPrompt: task,
+    })
+
+    assert.equal(second.id, first.id)
+    assert.equal(mgr.getWorkspaces().filter((workspace) => workspace.kind === 'worktree').length, 1)
+    await mgr.removeWorkspace(first.id)
+  })
+})
+
+test('adopts an explicitly named external worktree without deleting it on close', async () => {
+  await freshDataDir()
+  const repo = await project()
+  await writeFile(join(repo, 'README.md'), 'external worktree\n', 'utf-8')
+  const git = (args: string[], cwd = repo): string => {
+    const result = spawnSync('git', args, { cwd, encoding: 'utf-8' })
+    assert.equal(result.status, 0, result.stderr || `git ${args.join(' ')} failed`)
+    return result.stdout.trim()
+  }
+  git(['init'])
+  git(['config', 'user.email', 'pi-desktop@example.test'])
+  git(['config', 'user.name', 'Pi Desktop Tests'])
+  git(['add', '.'])
+  git(['commit', '-m', 'initial'])
+  const external = join(await project(), 'checkout')
+  git(['worktree', 'add', '-b', 'feature/existing', external])
+
+  await withManager(async (mgr) => {
+    const source = await mgr.createWorkspace('Repo', repo)
+    const adopted = await mgr.createWorktreeWorkspace({
+      sourceWorkspaceId: source.id,
+      taskPrompt: 'Continue work in feature/existing',
+    })
+
+    assert.equal(adopted.path.replaceAll('\\', '/'), external.replaceAll('\\', '/'))
+    assert.equal(adopted.branch, 'feature/existing')
+    assert.equal(adopted.managed, false)
+    const result = await mgr.removeWorkspace(adopted.id)
+    assert.equal(result.worktreeRemoved, undefined)
+    assert.equal(existsSync(external), true)
+  })
+
+  git(['worktree', 'remove', external])
+})
+
 test('load recovers from .bak when the live workspaces file is corrupted', async () => {
   await freshDataDir()
   const proj = await project()

--- a/src/main/workspace-manager.test.ts
+++ b/src/main/workspace-manager.test.ts
@@ -213,6 +213,32 @@ test('adopts an explicitly named external worktree without deleting it on close'
   git(['worktree', 'remove', external])
 })
 
+test('closing a session runtime removes its tab and only marks empty sessions disposable', async () => {
+  await freshDataDir()
+
+  await withManager(async (mgr) => {
+    const workspace = await mgr.createWorkspace('Alpha', await project())
+    const emptyPath = join(await project(), 'empty.jsonl')
+    await writeFile(emptyPath, JSON.stringify({ type: 'session', id: 'empty' }) + '\n', 'utf-8')
+    const emptyRuntime = await mgr.activateSession(workspace.id, emptyPath)
+    const emptyResult = await mgr.closeSessionRuntime(emptyRuntime.runtimeId)
+
+    assert.equal(emptyResult?.empty, true)
+    assert.equal(mgr.getSessionRuntime(emptyRuntime.runtimeId), null)
+
+    const contentPath = join(await project(), 'content.jsonl')
+    await writeFile(contentPath, [
+      JSON.stringify({ type: 'session', id: 'content' }),
+      JSON.stringify({ type: 'message', message: { role: 'user', content: [{ type: 'text', text: 'keep me' }] } }),
+    ].join('\n') + '\n', 'utf-8')
+    const contentRuntime = await mgr.activateSession(workspace.id, contentPath)
+    const contentResult = await mgr.closeSessionRuntime(contentRuntime.runtimeId)
+
+    assert.equal(contentResult?.empty, false)
+    assert.equal(existsSync(contentPath), true)
+  })
+})
+
 test('load recovers from .bak when the live workspaces file is corrupted', async () => {
   await freshDataDir()
   const proj = await project()

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -3,10 +3,22 @@ import { readFile, writeFile, mkdir, rename, copyFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { PiRpcManager } from './pi-rpc-manager'
 import { FileService } from './file-service'
-import type { FileChangeEvent, PiStartOptions } from '../shared/ipc-contracts'
+import type {
+  FileChangeEvent,
+  PiStartOptions,
+  WorkspaceRemoveResult,
+  WorkspaceTabOptions,
+} from '../shared/ipc-contracts'
 import { getGuiDataPath } from './app-data-paths'
 import { pathsEqual } from './session-paths'
 import { appLog } from './app-log'
+import {
+  createGitWorktree,
+  inspectGitRepository,
+  removeGitWorktree,
+  worktreeBranchName,
+  worktreeTargetPath,
+} from './git-worktree'
 
 /**
  * Manages multiple workspaces (project directories), each with its own Pi process.
@@ -23,6 +35,12 @@ export interface Workspace {
   createdAt: number
   lastActiveAt: number
   color: string
+  /** Optional on disk for backward compatibility with older workspace files. */
+  kind?: 'folder' | 'worktree'
+  repoRoot?: string
+  branch?: string
+  baseRef?: string
+  sourceWasDirty?: boolean
 }
 
 interface WorkspaceState {
@@ -216,6 +234,7 @@ export class WorkspaceManager {
       createdAt: Date.now(),
       lastActiveAt: Date.now(),
       color: WORKSPACE_COLORS[this.nextColorIndex % WORKSPACE_COLORS.length],
+      kind: 'folder',
     }
 
     this.nextColorIndex++
@@ -252,11 +271,16 @@ export class WorkspaceManager {
     return workspace
   }
 
-  async removeWorkspace(workspaceId: string): Promise<void> {
+  async removeWorkspace(workspaceId: string): Promise<WorkspaceRemoveResult> {
     const index = this.workspaces.findIndex((w) => w.id === workspaceId)
     if (index === -1) throw new Error(`Workspace not found: ${workspaceId}`)
+    const workspace = this.workspaces[index]
+    let worktreeRemoved: boolean | undefined
+    let preservedWorktreePath: string | undefined
 
-    // Stop Pi process and file watcher for this workspace
+    // Stop Pi process and file watcher for this workspace before touching a
+    // managed worktree. Git refuses dirty worktree removal, which is exactly
+    // the protection we want when a tab is closed with edits still present.
     const piManager = this.piManagers.get(workspaceId)
     if (piManager) {
       piManager.stop()
@@ -266,6 +290,16 @@ export class WorkspaceManager {
     if (fileService) {
       fileService.stopWatching()
       this.fileServices.delete(workspaceId)
+    }
+    if (workspace.kind === 'worktree' && workspace.repoRoot) {
+      try {
+        await removeGitWorktree(workspace.repoRoot, workspace.path)
+        worktreeRemoved = true
+      } catch (err) {
+        // Keep dirty/missing worktrees on disk instead of forcing deletion.
+        preservedWorktreePath = workspace.path
+        appLog.warn('workspaces', 'Preserved managed worktree while closing tab', err)
+      }
     }
 
     this.workspaces.splice(index, 1)
@@ -282,6 +316,7 @@ export class WorkspaceManager {
     for (const listener of this.workspaceRemovedListeners) {
       listener(workspaceId)
     }
+    return { worktreeRemoved, preservedWorktreePath }
   }
 
   async renameWorkspace(workspaceId: string, name: string): Promise<void> {
@@ -301,6 +336,9 @@ export class WorkspaceManager {
   async changeWorkspacePath(workspaceId: string, newPath: string): Promise<void> {
     const workspace = this.workspaces.find((w) => w.id === workspaceId)
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`)
+    if (workspace.kind === 'worktree') {
+      throw new Error('Managed worktree tabs cannot change folder; close the tab and create another one')
+    }
     if (!existsSync(newPath)) throw new Error(`Folder does not exist: ${newPath}`)
 
     workspace.path = newPath
@@ -323,6 +361,50 @@ export class WorkspaceManager {
   activeWorkspacePathExists(): boolean {
     const ws = this.getActiveWorkspace()
     return ws ? existsSync(ws.path) : false
+  }
+
+  /**
+   * Create an app-owned Git worktree that becomes an independent tab. The
+   * worktree starts from HEAD; source-tab edits stay in the source tab.
+   * The new workspace is not activated here; the renderer performs the normal
+   * guarded tab switch after the Pi process has been started.
+   */
+  async createWorktreeWorkspace(options: WorkspaceTabOptions = {}): Promise<Workspace> {
+    const source = options.sourceWorkspaceId
+      ? this.workspaces.find((w) => w.id === options.sourceWorkspaceId)
+      : this.getActiveWorkspace()
+    if (!source) throw new Error('No source workspace available for a new tab')
+    if (!existsSync(source.path)) throw new Error(`Source folder does not exist: ${source.path}`)
+
+    const git = await inspectGitRepository(source.path)
+    const sourceWasDirty = git.status.trim().length > 0
+    const id = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const label = options.name?.trim() || `${source.name}-tab`
+    const branch = worktreeBranchName(label, id)
+    const targetPath = worktreeTargetPath(getGuiDataPath('worktrees'), git.repoRoot, id)
+    await createGitWorktree({ sourceCwd: source.path, targetPath, branch })
+
+    const workspace: Workspace = {
+      id,
+      name: options.name?.trim() || `${source.name} · tab`,
+      path: targetPath,
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+      color: WORKSPACE_COLORS[this.nextColorIndex % WORKSPACE_COLORS.length],
+      kind: 'worktree',
+      repoRoot: git.repoRoot,
+      branch,
+      baseRef: git.head,
+      sourceWasDirty,
+    }
+    this.nextColorIndex++
+    this.workspaces.push(workspace)
+    const piManager = new PiRpcManager()
+    this.piManagers.set(workspace.id, piManager)
+    this.wirePiManager(piManager)
+    this.fileServices.set(workspace.id, new FileService(targetPath))
+    await this.saveWorkspaces()
+    return workspace
   }
 
   async startPiForWorkspace(workspaceId: string, options?: PiStartOptions): Promise<void> {
@@ -375,7 +457,10 @@ export class WorkspaceManager {
       return
     }
 
-    this.workspaces = state.workspaces ?? []
+    this.workspaces = (state.workspaces ?? []).map((workspace) => ({
+      ...workspace,
+      kind: workspace.kind ?? 'folder',
+    }))
     this.activeWorkspaceId = state.activeWorkspaceId ?? null
 
     // Create file services and Pi managers for loaded workspaces

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -1,4 +1,4 @@
-import { dirname, basename } from 'path'
+import { dirname, basename, resolve } from 'path'
 import { readFile, writeFile, mkdir, rename, copyFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { PiRpcManager } from './pi-rpc-manager'
@@ -690,7 +690,9 @@ export class WorkspaceManager {
     }
 
     const entries = await listGitWorktrees(sourcePath).catch(() => [])
-    const candidates = entries.filter((entry) => !entry.bare && existsSync(entry.path) && entry.branch)
+    const candidates = entries
+      .filter((entry) => !entry.bare && existsSync(entry.path) && entry.branch)
+      .map((entry) => ({ ...entry, path: resolve(entry.path) }))
     const matches = candidates.filter((entry) => {
       const branch = entry.branch!
       if (pullRequestBranch) return branch === pullRequestBranch

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -10,10 +10,12 @@ import type {
   WorkspaceTabOptions,
   SessionRuntimeInfo,
   SessionRuntimeActivity,
+  SessionRuntimeCloseResult,
 } from '../shared/ipc-contracts'
 import { getGuiDataPath } from './app-data-paths'
 import { pathsEqual, pathGroupKey } from './session-paths'
 import { appLog } from './app-log'
+import { readFirstUserMessage } from './session-metadata'
 import {
   createGitWorktree,
   inspectGitRepository,
@@ -382,6 +384,51 @@ export class WorkspaceManager {
     entry.info = { ...entry.info, activity: null }
     this.emitSessionRuntime(entry)
     entry.manager.stop()
+  }
+
+  /** Close a session tab without deleting a non-empty session from disk. */
+  async closeSessionRuntime(runtimeId: string): Promise<SessionRuntimeCloseResult | null> {
+    const entry = this.sessionRuntimes.get(runtimeId)
+    if (!entry) return null
+
+    const { workspaceId, sessionPath } = entry.info
+    const empty = sessionPath ? (await readFirstUserMessage(sessionPath)) === null : true
+    const wasActive = this.activeRuntimeId === runtimeId
+    const replacementCandidates = wasActive
+      ? [...this.sessionRuntimes.values()]
+        .filter((candidate) => candidate.info.workspaceId === workspaceId && candidate.info.runtimeId !== runtimeId)
+        .reverse()
+      : []
+    const replacement = replacementCandidates.find((candidate) => candidate.info.sessionPath) ?? replacementCandidates[0]
+
+    entry.info = { ...entry.info, activity: null }
+    entry.manager.stop()
+    if (sessionPath) this.runtimeBySessionPath.delete(pathGroupKey(sessionPath))
+    this.sessionRuntimes.delete(runtimeId)
+
+    if (this.activeRuntimeByWorkspace.get(workspaceId) === runtimeId) {
+      if (replacement) this.activeRuntimeByWorkspace.set(workspaceId, replacement.info.runtimeId)
+      else this.activeRuntimeByWorkspace.delete(workspaceId)
+    }
+    if (wasActive) this.activeRuntimeId = replacement?.info.runtimeId ?? null
+
+    const closed: SessionRuntimeInfo = {
+      ...entry.info,
+      ...entry.manager.getStatus(),
+      active: false,
+      activity: null,
+      closed: true,
+    }
+    for (const listener of this.sessionRuntimeListeners) listener(closed)
+    if (replacement && wasActive) this.emitSessionRuntime(replacement)
+
+    return {
+      runtimeId,
+      workspaceId,
+      sessionPath,
+      empty,
+      deleted: false,
+    }
   }
 
   sendCommandToSessionRuntime(runtimeId: string, command: Record<string, unknown>): Promise<unknown> {

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -288,6 +288,19 @@ export class WorkspaceManager {
       .map((entry) => this.snapshotRuntime(entry))
   }
 
+  /** Drop inactive header-only sessions so abandoned New Session tabs do not linger. */
+  async pruneEmptySessionRuntimes(): Promise<SessionRuntimeCloseResult[]> {
+    const candidates = [...this.sessionRuntimes.values()]
+      .filter((entry) => entry.info.runtimeId !== this.activeRuntimeId && entry.info.sessionPath && entry.info.activity === null)
+    const closed: SessionRuntimeCloseResult[] = []
+    for (const entry of candidates) {
+      if (await readFirstUserMessage(entry.info.sessionPath!) !== null) continue
+      const result = await this.closeSessionRuntime(entry.info.runtimeId)
+      if (result) closed.push(result)
+    }
+    return closed
+  }
+
   getActiveSessionRuntime(): SessionRuntimeInfo | null {
     if (!this.activeRuntimeId) return null
     const entry = this.sessionRuntimes.get(this.activeRuntimeId)

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -377,6 +377,12 @@ export class WorkspaceManager {
     entry.manager.stop()
   }
 
+  sendCommandToSessionRuntime(runtimeId: string, command: Record<string, unknown>): Promise<unknown> {
+    const entry = this.sessionRuntimes.get(runtimeId)
+    if (!entry) return Promise.reject(new Error(`Session runtime not found: ${runtimeId}`))
+    return entry.manager.sendCommand(command)
+  }
+
   async initialize(): Promise<void> {
     await this.loadWorkspaces()
 

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -8,9 +8,11 @@ import type {
   PiStartOptions,
   WorkspaceRemoveResult,
   WorkspaceTabOptions,
+  SessionRuntimeInfo,
+  SessionRuntimeActivity,
 } from '../shared/ipc-contracts'
 import { getGuiDataPath } from './app-data-paths'
-import { pathsEqual } from './session-paths'
+import { pathsEqual, pathGroupKey } from './session-paths'
 import { appLog } from './app-log'
 import {
   createGitWorktree,
@@ -21,7 +23,9 @@ import {
 } from './git-worktree'
 
 /**
- * Manages multiple workspaces (project directories), each with its own Pi process.
+ * Manages project workspaces and their independent Pi session runtimes.
+ * Multiple runtimes may share one workspace directory; the workspace list is
+ * persisted, while live runtime processes are intentionally in-memory.
  *
  * Persistence: workspace list stored in the Electron userData directory.
  */
@@ -57,12 +61,25 @@ export type PiManagerListener = (manager: PiRpcManager) => void
 export type ActiveWorkspaceListener = (workspaceId: string | null) => void
 export type FileChangeListener = (event: FileChangeEvent) => void
 export type WorkspaceRemovedListener = (workspaceId: string) => void
+export type SessionRuntimeListener = (runtime: SessionRuntimeInfo) => void
+
+interface SessionRuntimeEntry {
+  info: SessionRuntimeInfo
+  manager: PiRpcManager
+}
 
 export class WorkspaceManager {
   private workspaces: Workspace[] = []
   private activeWorkspaceId: string | null = null
   private piManagers = new Map<string, PiRpcManager>()
   private fileServices = new Map<string, FileService>()
+  // A workspace is a project container. Each live session gets its own Pi
+  // process, even when several sessions share the same workspace cwd.
+  private sessionRuntimes = new Map<string, SessionRuntimeEntry>()
+  private runtimeBySessionPath = new Map<string, string>()
+  private activeRuntimeByWorkspace = new Map<string, string>()
+  private activeRuntimeId: string | null = null
+  private sessionRuntimeListeners: SessionRuntimeListener[] = []
   private configPath: string
   private nextColorIndex = 0
   private piManagerListeners: PiManagerListener[] = []
@@ -128,6 +145,9 @@ export class WorkspaceManager {
     for (const manager of this.piManagers.values()) {
       this.attachListenerOnce(manager, listener)
     }
+    for (const entry of this.sessionRuntimes.values()) {
+      this.attachListenerOnce(entry.manager, listener)
+    }
   }
 
   onActiveWorkspaceChanged(listener: ActiveWorkspaceListener): void {
@@ -164,6 +184,199 @@ export class WorkspaceManager {
     listener(manager)
   }
 
+  onSessionRuntime(listener: SessionRuntimeListener): void {
+    this.sessionRuntimeListeners.push(listener)
+    for (const entry of this.sessionRuntimes.values()) listener(this.snapshotRuntime(entry))
+  }
+
+  private snapshotRuntime(entry: SessionRuntimeEntry): SessionRuntimeInfo {
+    return {
+      ...entry.info,
+      ...entry.manager.getStatus(),
+      active: entry.info.runtimeId === this.activeRuntimeId,
+    }
+  }
+
+  private emitSessionRuntime(entry: SessionRuntimeEntry): void {
+    const snapshot = this.snapshotRuntime(entry)
+    entry.info = { ...entry.info, ...snapshot }
+    for (const listener of this.sessionRuntimeListeners) listener(snapshot)
+  }
+
+  private emitRuntimeActivity(entry: SessionRuntimeEntry, activity: SessionRuntimeActivity | null): void {
+    if (entry.info.activity === activity) return
+    entry.info = { ...entry.info, activity }
+    this.emitSessionRuntime(entry)
+  }
+
+  private attachSessionRuntime(entry: SessionRuntimeEntry): void {
+    const { manager } = entry
+    manager.on('status-change', () => {
+      entry.info = { ...entry.info, ...manager.getStatus() }
+      if (entry.info.status === 'running' && entry.info.activity === 'failed') {
+        entry.info = { ...entry.info, activity: null }
+      }
+      this.emitSessionRuntime(entry)
+    })
+    manager.on('agent_start', () => this.emitRuntimeActivity(entry, 'working'))
+    manager.on('agent_end', () => this.emitRuntimeActivity(entry, 'completed'))
+    manager.on('extension_ui_request', (event: { method?: string }) => {
+      if (event.method === 'select' || event.method === 'confirm' || event.method === 'input' || event.method === 'editor') {
+        this.emitRuntimeActivity(entry, 'needs-approval')
+      }
+    })
+    manager.on('exit', () => {
+      // PiRpcManager only emits exit for an unexpected process death; deliberate
+      // stop() detaches listeners first. Preserve a visible failure marker even
+      // when the process died while idle.
+      this.emitRuntimeActivity(entry, 'failed')
+    })
+  }
+
+  private createSessionRuntime(workspaceId: string, sessionPath: string | null): SessionRuntimeEntry {
+    const runtimeId = `rt-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+    const manager = new PiRpcManager()
+    const entry: SessionRuntimeEntry = {
+      manager,
+      info: {
+        runtimeId,
+        workspaceId,
+        sessionPath,
+        sessionId: null,
+        status: 'stopped',
+        pid: null,
+        error: null,
+        activity: null,
+        active: false,
+      },
+    }
+    this.sessionRuntimes.set(runtimeId, entry)
+    if (sessionPath) this.runtimeBySessionPath.set(pathGroupKey(sessionPath), runtimeId)
+    this.wirePiManager(manager)
+    this.attachSessionRuntime(entry)
+    this.emitSessionRuntime(entry)
+    return entry
+  }
+
+  private setActiveRuntime(workspaceId: string, runtimeId: string | null): void {
+    const previous = this.activeRuntimeId
+    if (runtimeId) this.activeRuntimeByWorkspace.set(workspaceId, runtimeId)
+    else this.activeRuntimeByWorkspace.delete(workspaceId)
+    this.activeRuntimeId = this.activeWorkspaceId === workspaceId ? runtimeId : this.activeRuntimeId
+    if (previous && previous !== this.activeRuntimeId) {
+      const old = this.sessionRuntimes.get(previous)
+      if (old) this.emitSessionRuntime(old)
+    }
+    if (this.activeRuntimeId) {
+      const next = this.sessionRuntimes.get(this.activeRuntimeId)
+      if (next) this.emitSessionRuntime(next)
+    }
+  }
+
+  getSessionRuntimes(workspaceId?: string): SessionRuntimeInfo[] {
+    return [...this.sessionRuntimes.values()]
+      .filter((entry) => workspaceId === undefined || entry.info.workspaceId === workspaceId)
+      .map((entry) => this.snapshotRuntime(entry))
+  }
+
+  getActiveSessionRuntime(): SessionRuntimeInfo | null {
+    if (!this.activeRuntimeId) return null
+    const entry = this.sessionRuntimes.get(this.activeRuntimeId)
+    return entry ? this.snapshotRuntime(entry) : null
+  }
+
+  getSessionRuntime(runtimeId: string): SessionRuntimeInfo | null {
+    const entry = this.sessionRuntimes.get(runtimeId)
+    return entry ? this.snapshotRuntime(entry) : null
+  }
+
+  getSessionRuntimeForPath(sessionPath: string): SessionRuntimeInfo | null {
+    const runtimeId = this.runtimeBySessionPath.get(pathGroupKey(sessionPath))
+    return runtimeId ? this.getSessionRuntime(runtimeId) : null
+  }
+
+  runtimeIdFor(manager: PiRpcManager): string | null {
+    for (const [runtimeId, entry] of this.sessionRuntimes) {
+      if (entry.manager === manager) return runtimeId
+    }
+    return this.workspaceIdFor(manager)
+  }
+
+  sessionPathFor(manager: PiRpcManager): string | null {
+    for (const entry of this.sessionRuntimes.values()) {
+      if (entry.manager === manager) return entry.info.sessionPath
+    }
+    return null
+  }
+
+  /** Activate a session without waiting for Pi startup. */
+  async activateSession(workspaceId: string, sessionPath: string): Promise<SessionRuntimeInfo> {
+    const workspace = this.workspaces.find((item) => item.id === workspaceId)
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`)
+    if (this.activeWorkspaceId !== workspaceId) await this.setActiveWorkspace(workspaceId)
+    const key = pathGroupKey(sessionPath)
+    let runtimeId = this.runtimeBySessionPath.get(key)
+    let entry = runtimeId ? this.sessionRuntimes.get(runtimeId) : undefined
+    if (entry && entry.info.workspaceId !== workspaceId) {
+      throw new Error('Session is already attached to a different workspace runtime')
+    }
+    if (!entry) entry = this.createSessionRuntime(workspaceId, sessionPath)
+    runtimeId = entry.info.runtimeId
+    entry.info = { ...entry.info, activity: null }
+    this.setActiveRuntime(workspaceId, runtimeId)
+    this.emitSessionRuntime(entry)
+    return this.snapshotRuntime(entry)
+  }
+
+  /** Create an empty session runtime and make it active immediately. */
+  async createNewSessionRuntime(workspaceId: string): Promise<SessionRuntimeInfo> {
+    const workspace = this.workspaces.find((item) => item.id === workspaceId)
+    if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`)
+    if (this.activeWorkspaceId !== workspaceId) await this.setActiveWorkspace(workspaceId)
+    const entry = this.createSessionRuntime(workspaceId, null)
+    this.setActiveRuntime(workspaceId, entry.info.runtimeId)
+    return this.snapshotRuntime(entry)
+  }
+
+  async startSessionRuntime(runtimeId: string, options: PiStartOptions = {}): Promise<SessionRuntimeInfo> {
+    const entry = this.sessionRuntimes.get(runtimeId)
+    if (!entry) throw new Error(`Session runtime not found: ${runtimeId}`)
+    const workspace = this.workspaces.find((item) => item.id === entry.info.workspaceId)
+    if (!workspace) throw new Error(`Workspace not found: ${entry.info.workspaceId}`)
+    const startOptions = {
+      cwd: workspace.path,
+      ...(entry.info.sessionPath && !options.sessionPath && !options.forkSessionPath
+        ? { sessionPath: entry.info.sessionPath }
+        : {}),
+      ...options,
+    }
+    await entry.manager.start(startOptions)
+    const response = await entry.manager.sendCommand({ type: 'get_state' }).catch(() => null)
+    const data = response?.data as { sessionFile?: unknown; sessionId?: unknown } | undefined
+    const sessionPath = typeof data?.sessionFile === 'string' ? data.sessionFile : entry.info.sessionPath
+    if (sessionPath && sessionPath !== entry.info.sessionPath) {
+      if (entry.info.sessionPath) this.runtimeBySessionPath.delete(pathGroupKey(entry.info.sessionPath))
+      this.runtimeBySessionPath.set(pathGroupKey(sessionPath), runtimeId)
+    }
+    entry.info = {
+      ...entry.info,
+      sessionPath: sessionPath ?? null,
+      sessionId: typeof data?.sessionId === 'string' ? data.sessionId : entry.info.sessionId,
+      activity: null,
+      ...entry.manager.getStatus(),
+    }
+    this.emitSessionRuntime(entry)
+    return this.snapshotRuntime(entry)
+  }
+
+  stopSessionRuntime(runtimeId: string): void {
+    const entry = this.sessionRuntimes.get(runtimeId)
+    if (!entry) return
+    entry.info = { ...entry.info, activity: null }
+    this.emitSessionRuntime(entry)
+    entry.manager.stop()
+  }
+
   async initialize(): Promise<void> {
     await this.loadWorkspaces()
 
@@ -194,18 +407,32 @@ export class WorkspaceManager {
   }
 
   getPiManager(workspaceId: string): PiRpcManager | null {
+    const runtimeId = this.activeRuntimeByWorkspace.get(workspaceId)
+    if (runtimeId) return this.sessionRuntimes.get(runtimeId)?.manager ?? null
     return this.piManagers.get(workspaceId) ?? null
   }
 
   getActivePiManager(): PiRpcManager | null {
     if (!this.activeWorkspaceId) return null
-    return this.piManagers.get(this.activeWorkspaceId) ?? null
+    return this.getPiManager(this.activeWorkspaceId)
+  }
+
+  getPiManagerForSession(workspaceId: string, sessionId?: string): PiRpcManager | null {
+    if (sessionId) {
+      for (const entry of this.sessionRuntimes.values()) {
+        if (entry.info.workspaceId === workspaceId && entry.info.sessionId === sessionId) return entry.manager
+      }
+    }
+    return this.getPiManager(workspaceId)
   }
 
   /** Reverse lookup: the workspace id owning a given Pi manager, if any. */
   workspaceIdFor(manager: PiRpcManager): string | null {
     for (const [workspaceId, candidate] of this.piManagers) {
       if (candidate === manager) return workspaceId
+    }
+    for (const entry of this.sessionRuntimes.values()) {
+      if (entry.manager === manager) return entry.info.workspaceId
     }
     return null
   }
@@ -264,10 +491,20 @@ export class WorkspaceManager {
 
     const changed = this.activeWorkspaceId !== workspaceId
     workspace.lastActiveAt = Date.now()
+    const previousRuntimeId = this.activeRuntimeId
     this.activeWorkspaceId = workspaceId
+    this.activeRuntimeId = this.activeRuntimeByWorkspace.get(workspaceId) ?? null
 
     await this.saveWorkspaces()
     if (changed) this.emitActiveWorkspaceChanged()
+    if (previousRuntimeId && previousRuntimeId !== this.activeRuntimeId) {
+      const previous = this.sessionRuntimes.get(previousRuntimeId)
+      if (previous) this.emitSessionRuntime(previous)
+    }
+    if (this.activeRuntimeId) {
+      const active = this.sessionRuntimes.get(this.activeRuntimeId)
+      if (active) this.emitSessionRuntime(active)
+    }
     return workspace
   }
 
@@ -286,6 +523,14 @@ export class WorkspaceManager {
       piManager.stop()
       this.piManagers.delete(workspaceId)
     }
+    for (const [runtimeId, entry] of this.sessionRuntimes) {
+      if (entry.info.workspaceId !== workspaceId) continue
+      if (this.activeRuntimeId === runtimeId) this.activeRuntimeId = null
+      entry.manager.stop()
+      if (entry.info.sessionPath) this.runtimeBySessionPath.delete(pathGroupKey(entry.info.sessionPath))
+      this.sessionRuntimes.delete(runtimeId)
+    }
+    this.activeRuntimeByWorkspace.delete(workspaceId)
     const fileService = this.fileServices.get(workspaceId)
     if (fileService) {
       fileService.stopWatching()
@@ -308,11 +553,18 @@ export class WorkspaceManager {
     let activeChanged = false
     if (this.activeWorkspaceId === workspaceId) {
       this.activeWorkspaceId = this.workspaces.length > 0 ? this.workspaces[0].id : null
+      this.activeRuntimeId = this.activeWorkspaceId
+        ? this.activeRuntimeByWorkspace.get(this.activeWorkspaceId) ?? null
+        : null
       activeChanged = true
     }
 
     await this.saveWorkspaces()
     if (activeChanged) this.emitActiveWorkspaceChanged()
+    if (activeChanged && this.activeRuntimeId) {
+      const active = this.sessionRuntimes.get(this.activeRuntimeId)
+      if (active) this.emitSessionRuntime(active)
+    }
     for (const listener of this.workspaceRemovedListeners) {
       listener(workspaceId)
     }
@@ -342,10 +594,13 @@ export class WorkspaceManager {
     if (!existsSync(newPath)) throw new Error(`Folder does not exist: ${newPath}`)
 
     workspace.path = newPath
-    // Pi's working directory is bound at spawn, so a running Pi would keep
-    // operating in the old folder. Stop it here; the renderer restarts the
-    // active workspace's Pi, and an inactive one starts fresh on activation.
+    // Pi's working directory is bound at spawn, so every session runtime must
+    // stop before the project path changes. The renderer restarts the active
+    // runtime after this commits; inactive sessions restart when selected.
     this.piManagers.get(workspaceId)?.stop()
+    for (const entry of this.sessionRuntimes.values()) {
+      if (entry.info.workspaceId === workspaceId) this.stopSessionRuntime(entry.info.runtimeId)
+    }
     const oldFs = this.fileServices.get(workspaceId)
     oldFs?.stopWatching()
     this.fileServices.set(workspaceId, new FileService(newPath))
@@ -411,37 +666,37 @@ export class WorkspaceManager {
     const workspace = this.workspaces.find((w) => w.id === workspaceId)
     if (!workspace) throw new Error(`Workspace not found: ${workspaceId}`)
 
-    let piManager = this.piManagers.get(workspaceId)
-    if (!piManager) {
-      piManager = new PiRpcManager()
-      this.piManagers.set(workspaceId, piManager)
+    const runtimeId = this.activeRuntimeByWorkspace.get(workspaceId)
+    let runtime = runtimeId ? this.sessionRuntimes.get(runtimeId) : undefined
+    if (!runtime) {
+      runtime = this.createSessionRuntime(workspaceId, options?.sessionPath ?? null)
+      this.activeRuntimeByWorkspace.set(workspaceId, runtime.info.runtimeId)
+      if (this.activeWorkspaceId === workspaceId) this.activeRuntimeId = runtime.info.runtimeId
     }
-    this.wirePiManager(piManager)
 
-    // Caller-supplied cwd (e.g. a validated fallback) takes precedence over the
-    // workspace path. Default to the workspace path when no override is given.
-    await piManager.start({
+    await this.startSessionRuntime(runtime.info.runtimeId, {
       cwd: workspace.path,
       ...options,
     })
   }
 
   stopPiForWorkspace(workspaceId: string): void {
-    const piManager = this.piManagers.get(workspaceId)
-    if (piManager) {
-      piManager.stop()
-    }
+    const runtimeId = this.activeRuntimeByWorkspace.get(workspaceId)
+    const runtime = runtimeId ? this.sessionRuntimes.get(runtimeId) : undefined
+    if (runtime) this.stopSessionRuntime(runtimeId!)
+    else this.piManagers.get(workspaceId)?.stop()
   }
 
   stopAll(): void {
-    for (const [, manager] of this.piManagers) {
-      manager.stop()
-    }
-    for (const [, fs] of this.fileServices) {
-      fs.stopWatching()
-    }
+    for (const [, manager] of this.piManagers) manager.stop()
+    for (const [, entry] of this.sessionRuntimes) entry.manager.stop()
+    for (const [, fs] of this.fileServices) fs.stopWatching()
     this.watchingWorkspaceId = null
     this.piManagers.clear()
+    this.sessionRuntimes.clear()
+    this.runtimeBySessionPath.clear()
+    this.activeRuntimeByWorkspace.clear()
+    this.activeRuntimeId = null
     this.fileServices.clear()
   }
 

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path'
+import { dirname, basename } from 'path'
 import { readFile, writeFile, mkdir, rename, copyFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { PiRpcManager } from './pi-rpc-manager'
@@ -17,10 +17,13 @@ import { appLog } from './app-log'
 import {
   createGitWorktree,
   inspectGitRepository,
+  listGitWorktrees,
   removeGitWorktree,
+  slugifyWorktreePart,
   worktreeBranchName,
   worktreeTargetPath,
 } from './git-worktree'
+import { extractGitHubPullRequestUrl, resolvePullRequestHeadBranch } from './git-conveyor'
 
 /**
  * Manages project workspaces and their independent Pi session runtimes.
@@ -45,6 +48,10 @@ export interface Workspace {
   branch?: string
   baseRef?: string
   sourceWasDirty?: boolean
+  /** False for an existing user worktree adopted by the app; never delete it on close. */
+  managed?: boolean
+  /** Original task text when the app created or adopted this worktree. */
+  taskPrompt?: string
 }
 
 interface WorkspaceState {
@@ -542,7 +549,7 @@ export class WorkspaceManager {
       fileService.stopWatching()
       this.fileServices.delete(workspaceId)
     }
-    if (workspace.kind === 'worktree' && workspace.repoRoot) {
+    if (workspace.kind === 'worktree' && workspace.managed !== false && workspace.repoRoot) {
       try {
         await removeGitWorktree(workspace.repoRoot, workspace.path)
         worktreeRemoved = true
@@ -624,11 +631,89 @@ export class WorkspaceManager {
     return ws ? existsSync(ws.path) : false
   }
 
+  private async adoptExistingWorktree(
+    repoRoot: string,
+    entry: { path: string; head: string | null; branch: string | null },
+    taskPrompt: string,
+  ): Promise<Workspace> {
+    const existing = this.workspaces.find((workspace) => pathsEqual(workspace.path, entry.path))
+    if (existing) return existing
+
+    const id = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const branchLabel = entry.branch?.split('/').pop() || basename(entry.path) || 'Existing worktree'
+    const workspace: Workspace = {
+      id,
+      name: branchLabel,
+      path: entry.path,
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+      color: WORKSPACE_COLORS[this.nextColorIndex % WORKSPACE_COLORS.length],
+      kind: 'worktree',
+      repoRoot,
+      ...(entry.branch ? { branch: entry.branch } : {}),
+      ...(entry.head ? { baseRef: entry.head } : {}),
+      managed: false,
+      taskPrompt,
+    }
+    this.nextColorIndex++
+    this.workspaces.push(workspace)
+    const piManager = new PiRpcManager()
+    this.piManagers.set(workspace.id, piManager)
+    this.wirePiManager(piManager)
+    this.fileServices.set(workspace.id, new FileService(entry.path))
+    await this.saveWorkspaces()
+    return workspace
+  }
+
   /**
-   * Create an app-owned Git worktree that becomes an independent tab. The
-   * worktree starts from HEAD; source-tab edits stay in the source tab.
-   * The new workspace is not activated here; the renderer performs the normal
-   * guarded tab switch after the Pi process has been started.
+   * Reuse an existing checkout when the task identifies it safely. Exact task
+   * metadata and a GitHub PR head branch are deterministic; a branch named in
+   * the task is also accepted, but ambiguous matches are ignored.
+   */
+  private async findRelatedWorktree(sourcePath: string, repoRoot: string, taskPrompt: string): Promise<Workspace | null> {
+    const normalizedTask = taskPrompt.trim().replace(/\s+/g, ' ').toLowerCase()
+    if (!normalizedTask) return null
+
+    const savedMatch = this.workspaces.find((workspace) =>
+      workspace.kind === 'worktree' &&
+      workspace.taskPrompt?.trim().replace(/\s+/g, ' ').toLowerCase() === normalizedTask &&
+      !!workspace.repoRoot &&
+      pathsEqual(workspace.repoRoot, repoRoot) &&
+      existsSync(workspace.path)
+    )
+    if (savedMatch) return savedMatch
+
+    let pullRequestBranch: string | null = null
+    const pullRequestUrl = extractGitHubPullRequestUrl(taskPrompt)
+    if (pullRequestUrl) {
+      pullRequestBranch = await resolvePullRequestHeadBranch(sourcePath, pullRequestUrl).catch(() => null)
+    }
+
+    const entries = await listGitWorktrees(sourcePath).catch(() => [])
+    const candidates = entries.filter((entry) => !entry.bare && existsSync(entry.path) && entry.branch)
+    const matches = candidates.filter((entry) => {
+      const branch = entry.branch!
+      if (pullRequestBranch) return branch === pullRequestBranch
+      // Generated Pi task branches carry the slug of the first task line. A
+      // branch explicitly written in the prompt is also safe when it is not a
+      // generic default branch; never guess from arbitrary short words.
+      const firstLineSlug = taskPrompt.split(/\r?\n/, 1)[0]?.trim().slice(0, 60)
+      const generatedPrefix = firstLineSlug ? `pi/${slugifyWorktreePart(firstLineSlug)}-` : ''
+      return (generatedPrefix && branch.toLowerCase().startsWith(generatedPrefix.toLowerCase())) ||
+        (branch.includes('/') && normalizedTask.includes(branch.toLowerCase()))
+    })
+    if (matches.length !== 1) return null
+
+    const match = matches[0]
+    const existing = this.workspaces.find((workspace) => pathsEqual(workspace.path, match.path))
+    return existing ?? this.adoptExistingWorktree(repoRoot, match, taskPrompt.trim())
+  }
+
+  /**
+   * Create an app-owned Git worktree that becomes an independent tab, unless
+   * the task already points at a related local worktree. New worktrees start
+   * from HEAD; source-tab edits stay in the source tab. The workspace is not
+   * activated here; the renderer performs the normal guarded tab switch.
    */
   async createWorktreeWorkspace(options: WorkspaceTabOptions = {}): Promise<Workspace> {
     const source = options.sourceWorkspaceId
@@ -638,6 +723,11 @@ export class WorkspaceManager {
     if (!existsSync(source.path)) throw new Error(`Source folder does not exist: ${source.path}`)
 
     const git = await inspectGitRepository(source.path)
+    const taskPrompt = options.taskPrompt?.trim() || ''
+    if (taskPrompt) {
+      const related = await this.findRelatedWorktree(source.path, git.repoRoot, taskPrompt)
+      if (related) return related
+    }
     const sourceWasDirty = git.status.trim().length > 0
     const id = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     const label = options.name?.trim() || `${source.name}-tab`
@@ -657,6 +747,8 @@ export class WorkspaceManager {
       branch,
       baseRef: git.head,
       sourceWasDirty,
+      managed: true,
+      ...(taskPrompt ? { taskPrompt } : {}),
     }
     this.nextColorIndex++
     this.workspaces.push(workspace)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,8 @@ import type {
   ArchivedSessionsMap,
   AppSettings,
   Workspace,
+  WorkspaceTabOptions,
+  WorkspaceRemoveResult,
   InstalledPackage,
   InstalledSkill,
   CatalogPackage,
@@ -52,6 +54,10 @@ import type {
   PermissionRulesRemoveResult,
   PendingPromptCounts,
   WorkspaceActivityMap,
+  WorkflowRunSummary,
+  WorkflowRunDetail,
+  WorkflowControlAction,
+  WorkflowControlResult,
 } from '../shared/ipc-contracts'
 import type { ThemeFile } from '../shared/theme/theme-file'
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
@@ -145,7 +151,8 @@ interface PiDesktopAPI {
   workspace: {
     list(): Promise<Workspace[]>
     create(name: string, path: string): Promise<Workspace>
-    remove(workspaceId: string): Promise<void>
+    createTab(options?: WorkspaceTabOptions): Promise<Workspace>
+    remove(workspaceId: string): Promise<WorkspaceRemoveResult>
     rename(workspaceId: string, name: string): Promise<void>
     changePath(workspaceId: string, newPath: string): Promise<void>
     pathExists(): Promise<boolean>
@@ -249,6 +256,18 @@ interface PiDesktopAPI {
   // Activity stats
   activity: {
     getStats(): Promise<ActivityStatsResult>
+  }
+
+  // Dynamic workflow run monitoring
+  workflows: {
+    list(): Promise<WorkflowRunSummary[]>
+    getRun(workspaceId: string, runId: string): Promise<WorkflowRunDetail>
+    /**
+     * Dispatch stop/resume to the run's owning workspace Pi process. Never
+     * fakes a local status change; the persisted run flips on the next poll.
+     */
+    control(workspaceId: string, runId: string, action: WorkflowControlAction): Promise<WorkflowControlResult>
+    setPersistAgentSessions(enabled: boolean): Promise<void>
   }
 
   // Diagnostics report
@@ -386,6 +405,7 @@ const api: PiDesktopAPI = {
     getActive: () => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_GET_ACTIVE),
     startPi: (workspaceId, options) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_START_PI, workspaceId, options),
     stopPi: (workspaceId) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_STOP_PI, workspaceId),
+    createTab: (options) => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_CREATE_TAB, options),
     getActivity: () => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_ACTIVITY_GET),
     takePendingActivation: () => ipcRenderer.invoke(IPC_CHANNELS.WORKSPACE_TAKE_PENDING_ACTIVATION),
   },
@@ -468,6 +488,13 @@ const api: PiDesktopAPI = {
 
   activity: {
     getStats: () => ipcRenderer.invoke(IPC_CHANNELS.ACTIVITY_GET_STATS),
+  },
+
+  workflows: {
+    list: () => ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_LIST),
+    getRun: (workspaceId, runId) => ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_GET_RUN, workspaceId, runId),
+    control: (workspaceId, runId, action) => ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_CONTROL, workspaceId, runId, action),
+    setPersistAgentSessions: (enabled) => ipcRenderer.invoke(IPC_CHANNELS.WORKFLOW_SET_PERSISTENCE, enabled),
   },
 
   diagnostics: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   SessionDeleteResult,
   ArchivedSessionsMap,
   AppSettings,
+  AgentInstallationsResult,
   Workspace,
   WorkspaceTabOptions,
   WorkspaceRemoveResult,
@@ -79,6 +80,7 @@ interface PiDesktopAPI {
     stop(): Promise<PiStatus>
     restart(options?: PiStartOptions): Promise<PiStatus>
     getStatus(): Promise<PiStatus>
+    detectInstallations(): Promise<AgentInstallationsResult>
   }
 
   // Pi commands
@@ -345,6 +347,7 @@ const api: PiDesktopAPI = {
     stop: () => ipcRenderer.invoke(IPC_CHANNELS.PI_STOP),
     restart: (options?: PiStartOptions) => ipcRenderer.invoke(IPC_CHANNELS.PI_RESTART, options),
     getStatus: () => ipcRenderer.invoke(IPC_CHANNELS.PI_STATUS),
+    detectInstallations: () => ipcRenderer.invoke(IPC_CHANNELS.PI_DETECT_INSTALLATIONS),
   },
 
   commands: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -59,6 +59,7 @@ import type {
   WorkflowControlAction,
   WorkflowControlResult,
   SessionRuntimeInfo,
+  SessionLaunchTaskOptions,
 } from '../shared/ipc-contracts'
 import type { ThemeFile } from '../shared/theme/theme-file'
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
@@ -87,6 +88,7 @@ interface PiDesktopAPI {
   // Session management
   session: {
     createNew(): Promise<SessionRuntimeInfo>
+    launchTask(options: SessionLaunchTaskOptions): Promise<SessionRuntimeInfo>
     switch(sessionPath: string, cwd?: string): Promise<SessionRuntimeInfo>
     listRuntimes(): Promise<SessionRuntimeInfo[]>
     fork(entryId?: string): Promise<unknown>
@@ -341,6 +343,7 @@ const api: PiDesktopAPI = {
 
   session: {
     createNew: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_NEW),
+    launchTask: (options) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LAUNCH_TASK, options),
     switch: (sessionPath, cwd) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_SWITCH, sessionPath, cwd),
     listRuntimes: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LIST_RUNTIMES),
     fork: (entryId) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_FORK, entryId),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -58,6 +58,7 @@ import type {
   WorkflowRunDetail,
   WorkflowControlAction,
   WorkflowControlResult,
+  SessionRuntimeInfo,
 } from '../shared/ipc-contracts'
 import type { ThemeFile } from '../shared/theme/theme-file'
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
@@ -85,8 +86,9 @@ interface PiDesktopAPI {
 
   // Session management
   session: {
-    createNew(): Promise<unknown>
-    switch(sessionPath: string): Promise<unknown>
+    createNew(): Promise<SessionRuntimeInfo>
+    switch(sessionPath: string, cwd?: string): Promise<SessionRuntimeInfo>
+    listRuntimes(): Promise<SessionRuntimeInfo[]>
     fork(entryId?: string): Promise<unknown>
     clone(): Promise<unknown>
     list(cwd?: string): Promise<SessionListItem[]>
@@ -312,6 +314,7 @@ interface PiDesktopAPI {
   onEvent(callback: (event: PiRpcEvent) => void): () => void
   onPendingPrompts(callback: (counts: PendingPromptCounts) => void): () => void
   onWorkspaceActivity(callback: (map: WorkspaceActivityMap) => void): () => void
+  onSessionRuntime(callback: (runtime: SessionRuntimeInfo) => void): () => void
   onActivateWorkspace(callback: (payload: { workspaceId: string }) => void): () => void
   onFileChange(callback: (event: FileChangeEvent) => void): () => void
   onMenuAction(callback: (action: string) => void): () => void
@@ -338,7 +341,8 @@ const api: PiDesktopAPI = {
 
   session: {
     createNew: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_NEW),
-    switch: (sessionPath) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_SWITCH, sessionPath),
+    switch: (sessionPath, cwd) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_SWITCH, sessionPath, cwd),
+    listRuntimes: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LIST_RUNTIMES),
     fork: (entryId) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_FORK, entryId),
     clone: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_CLONE),
     list: (cwd) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LIST, cwd),
@@ -558,6 +562,14 @@ const api: PiDesktopAPI = {
     ipcRenderer.on(IPC_CHANNELS.EVENT_WORKSPACE_ACTIVITY, handler)
     return () => {
       ipcRenderer.removeListener(IPC_CHANNELS.EVENT_WORKSPACE_ACTIVITY, handler)
+    }
+  },
+
+  onSessionRuntime: (callback) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: SessionRuntimeInfo) => callback(data)
+    ipcRenderer.on(IPC_CHANNELS.EVENT_SESSION_RUNTIME, handler)
+    return () => {
+      ipcRenderer.removeListener(IPC_CHANNELS.EVENT_SESSION_RUNTIME, handler)
     }
   },
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,6 +60,11 @@ import type {
   WorkflowControlResult,
   SessionRuntimeInfo,
   SessionLaunchTaskOptions,
+  WorkspaceActivationIntent,
+  GitConveyorStatus,
+  GitConveyorCommitOptions,
+  GitConveyorPullRequestOptions,
+  GitConveyorPullRequestResult,
 } from '../shared/ipc-contracts'
 import type { ThemeFile } from '../shared/theme/theme-file'
 import { IPC_CHANNELS } from '../shared/ipc-contracts'
@@ -170,7 +175,7 @@ interface PiDesktopAPI {
      * Consume the activation intent from a notification clicked while no
      * window existed (macOS closed-window case). Null when there is none.
      */
-    takePendingActivation(): Promise<string | null>
+    takePendingActivation(): Promise<WorkspaceActivationIntent | null>
   }
 
   // Package management
@@ -215,6 +220,14 @@ interface PiDesktopAPI {
     autoGetAll(): Promise<Record<string, string>>
     autoEnsure(sessions: Array<{ sessionId: string; path: string }>): Promise<Record<string, string>>
     autoRemove(sessionId: string): Promise<void>
+  }
+
+  // Git issue-to-PR conveyor. All mutating actions require explicit renderer clicks.
+  git: {
+    status(): Promise<GitConveyorStatus>
+    commit(options: GitConveyorCommitOptions): Promise<GitConveyorStatus>
+    push(): Promise<GitConveyorStatus>
+    createPullRequest(options: GitConveyorPullRequestOptions): Promise<GitConveyorPullRequestResult>
   }
 
   // Notes (reusable prompts / commands)
@@ -317,7 +330,7 @@ interface PiDesktopAPI {
   onPendingPrompts(callback: (counts: PendingPromptCounts) => void): () => void
   onWorkspaceActivity(callback: (map: WorkspaceActivityMap) => void): () => void
   onSessionRuntime(callback: (runtime: SessionRuntimeInfo) => void): () => void
-  onActivateWorkspace(callback: (payload: { workspaceId: string }) => void): () => void
+  onActivateWorkspace(callback: (payload: WorkspaceActivationIntent) => void): () => void
   onFileChange(callback: (event: FileChangeEvent) => void): () => void
   onMenuAction(callback: (action: string) => void): () => void
 }
@@ -462,6 +475,13 @@ const api: PiDesktopAPI = {
     autoRemove: (sessionId) => ipcRenderer.invoke(IPC_CHANNELS.TAG_AUTO_REMOVE, sessionId),
   },
 
+  git: {
+    status: () => ipcRenderer.invoke(IPC_CHANNELS.GIT_CONVEYOR_STATUS),
+    commit: (options) => ipcRenderer.invoke(IPC_CHANNELS.GIT_CONVEYOR_COMMIT, options),
+    push: () => ipcRenderer.invoke(IPC_CHANNELS.GIT_CONVEYOR_PUSH),
+    createPullRequest: (options) => ipcRenderer.invoke(IPC_CHANNELS.GIT_CONVEYOR_CREATE_PR, options),
+  },
+
   notes: {
     list: () => ipcRenderer.invoke(IPC_CHANNELS.NOTES_LIST),
     create: (input) => ipcRenderer.invoke(IPC_CHANNELS.NOTES_CREATE, input),
@@ -577,7 +597,7 @@ const api: PiDesktopAPI = {
   },
 
   onActivateWorkspace: (callback) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { workspaceId: string }) => callback(data)
+    const handler = (_event: Electron.IpcRendererEvent, data: WorkspaceActivationIntent) => callback(data)
     ipcRenderer.on(IPC_CHANNELS.EVENT_ACTIVATE_WORKSPACE, handler)
     return () => {
       ipcRenderer.removeListener(IPC_CHANNELS.EVENT_ACTIVATE_WORKSPACE, handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -59,6 +59,7 @@ import type {
   WorkflowControlAction,
   WorkflowControlResult,
   SessionRuntimeInfo,
+  SessionRuntimeCloseResult,
   SessionLaunchTaskOptions,
   WorkspaceActivationIntent,
   GitConveyorStatus,
@@ -94,6 +95,7 @@ interface PiDesktopAPI {
   session: {
     createNew(): Promise<SessionRuntimeInfo>
     launchTask(options: SessionLaunchTaskOptions): Promise<SessionRuntimeInfo>
+    closeRuntime(runtimeId: string): Promise<SessionRuntimeCloseResult | null>
     switch(sessionPath: string, cwd?: string): Promise<SessionRuntimeInfo>
     listRuntimes(): Promise<SessionRuntimeInfo[]>
     fork(entryId?: string): Promise<unknown>
@@ -357,6 +359,7 @@ const api: PiDesktopAPI = {
   session: {
     createNew: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_NEW),
     launchTask: (options) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LAUNCH_TASK, options),
+    closeRuntime: (runtimeId) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_CLOSE_RUNTIME, runtimeId),
     switch: (sessionPath, cwd) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_SWITCH, sessionPath, cwd),
     listRuntimes: () => ipcRenderer.invoke(IPC_CHANNELS.SESSION_LIST_RUNTIMES),
     fork: (entryId) => ipcRenderer.invoke(IPC_CHANNELS.SESSION_FORK, entryId),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,6 +7,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'"
     />
+    <link rel="icon" type="image/svg+xml" href="./src/assets/pi-logo.svg" />
     <title>Pi Desktop</title>
   </head>
   <body class="bg-neutral-950 text-neutral-100 antialiased">

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -10,6 +10,8 @@ import { HomeScreen } from './components/home-screen'
 import { NotesPanel } from './components/notes-panel'
 import { SkillsPanel } from './components/skills-panel'
 import { DiagnosticsPanel } from './components/diagnostics-panel'
+import { MissionControl } from './components/mission-control'
+import { TaskLauncher } from './components/task-launcher'
 import { NotePicker } from './components/note-picker'
 import { CommandPalette } from './components/command-palette'
 import { ExtensionUiDialog, AppConfirmDialog } from './components/extension-ui-dialog'
@@ -154,6 +156,7 @@ export function App(): React.JSX.Element {
               ) : (
                 <>
                   {currentView === 'home' && <HomeScreen />}
+                  {currentView === 'mission-control' && <MissionControl />}
                   {/* Kept mounted (just hidden) so the chat scroll position survives
                       navigating to another view and back. */}
                   <div className={currentView === 'chat' ? 'flex min-w-0 flex-1 flex-col overflow-hidden' : 'hidden'}>
@@ -180,6 +183,7 @@ export function App(): React.JSX.Element {
       <ExtensionUiDialog />
       <AppConfirmDialog />
       <NotePicker />
+      <TaskLauncher />
       <CommandPalette />
       {ContextMenuComponent}
     </div>

--- a/src/renderer/src/app.tsx
+++ b/src/renderer/src/app.tsx
@@ -14,6 +14,8 @@ import { NotePicker } from './components/note-picker'
 import { CommandPalette } from './components/command-palette'
 import { ExtensionUiDialog, AppConfirmDialog } from './components/extension-ui-dialog'
 import { ReviewRail } from './components/review-rail'
+import { WorkspaceTabs } from './components/workspace-tabs'
+import { WorkflowNavigator } from './components/workflow-navigator'
 import { useContextMenu, buildDefaultContextMenu } from './components/context-menu'
 import { usePiEvents, useMenuActions, useInitialize, useNotePickerShortcut } from './hooks'
 import { useFolderDrop } from './hooks/use-folder-drop'
@@ -34,6 +36,9 @@ export function App(): React.JSX.Element {
   const updateInfo = useAppStore((state) => state.updateInfo)
   const updateDismissed = useAppStore((state) => state.updateDismissed)
   const dismissUpdate = useAppStore((state) => state.dismissUpdate)
+  const workflowPanelOpen = useAppStore((state) => state.workflowPanelOpen)
+  const workflowPanelFilter = useAppStore((state) => state.workflowPanelFilter)
+  const workflowPanelWorkspaceId = useAppStore((state) => state.workflowPanelWorkspaceId)
 
   // Global context menu
   const { show, ContextMenuComponent } = useContextMenu()
@@ -80,11 +85,9 @@ export function App(): React.JSX.Element {
   // empty-chat center prompt is the "minimal" launch surface when not opening Home.
   const isHome = currentView === 'home'
   const showChrome = !isHome
-  // Chat has its own toolbar toggle; other chrome views need a top-left reopen
-  // control when the sidebar is closed (otherwise only the status bar has one).
-  const showSidebarReopen = showChrome && !sidebarOpen && currentView !== 'chat'
-
   const showUpdateBanner = !!updateInfo?.updateAvailable && !updateDismissed
+  const globalWorkflowOpen =
+    showChrome && workflowPanelOpen && !workflowPanelFilter && workflowPanelWorkspaceId === null
 
   return (
     <div className="relative flex h-screen flex-col bg-app text-primary">
@@ -128,42 +131,52 @@ export function App(): React.JSX.Element {
           </button>
         </div>
       )}
+      {isHome && !sidebarOpen && (
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          className="absolute left-3 top-3 z-30 animate-fade-in rounded-md border border-border-strong bg-surface/95 p-1.5 text-muted shadow-sm backdrop-blur-sm transition-colors hover:bg-surface-hover hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+          title="Show sidebar"
+          aria-label="Show sidebar"
+        >
+          <PanelLeft size={16} />
+        </button>
+      )}
       <div className="flex flex-1 overflow-hidden">
         {sidebarOpen && showChrome && <Sidebar />}
 
-        <div className="relative flex min-w-0 flex-1 overflow-hidden">
-          {showSidebarReopen && (
-            <button
-              type="button"
-              onClick={toggleSidebar}
-              className="absolute left-2 top-2 z-30 rounded-md border border-border-strong bg-surface/95 p-1.5 text-muted shadow-sm backdrop-blur-sm hover:bg-surface-hover hover:text-primary transition-colors"
-              title="Show sidebar"
-              aria-label="Show sidebar"
-            >
-              <PanelLeft size={16} />
-            </button>
-          )}
-          <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-            {currentView === 'home' && <HomeScreen />}
-            {/* Kept mounted (just hidden) so the chat scroll position survives
-                navigating to another view and back. */}
-            <div className={currentView === 'chat' ? 'flex min-w-0 flex-1 flex-col overflow-hidden' : 'hidden'}>
-              <ChatPanel />
-            </div>
-            {currentView === 'settings' && <SettingsPanel />}
-            {currentView === 'sessions' && <SessionPanel />}
-            {currentView === 'timeline' && <Timeline />}
-            {currentView === 'packages' && <PackageBrowser />}
-            {currentView === 'diff' && <DiffViewer />}
-            {currentView === 'notes' && <NotesPanel />}
-            {currentView === 'skills' && <SkillsPanel />}
-            {currentView === 'diagnostics' && <DiagnosticsPanel />}
-          </main>
-          {currentView === 'chat' && <ReviewRail />}
+        <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+          {showChrome && <WorkspaceTabs />}
+          <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+            <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+              {globalWorkflowOpen ? (
+                <WorkflowNavigator embedded />
+              ) : (
+                <>
+                  {currentView === 'home' && <HomeScreen />}
+                  {/* Kept mounted (just hidden) so the chat scroll position survives
+                      navigating to another view and back. */}
+                  <div className={currentView === 'chat' ? 'flex min-w-0 flex-1 flex-col overflow-hidden' : 'hidden'}>
+                    <ChatPanel />
+                  </div>
+                  {currentView === 'settings' && <SettingsPanel />}
+                  {currentView === 'sessions' && <SessionPanel />}
+                  {currentView === 'timeline' && <Timeline />}
+                  {currentView === 'packages' && <PackageBrowser />}
+                  {currentView === 'diff' && <DiffViewer />}
+                  {currentView === 'notes' && <NotesPanel />}
+                  {currentView === 'skills' && <SkillsPanel />}
+                  {currentView === 'diagnostics' && <DiagnosticsPanel />}
+                </>
+              )}
+            </main>
+            {currentView === 'chat' && !globalWorkflowOpen && <ReviewRail />}
+          </div>
         </div>
       </div>
 
       {showChrome && <StatusBar />}
+      {showChrome && !globalWorkflowOpen && <WorkflowNavigator />}
       <ExtensionUiDialog />
       <AppConfirmDialog />
       <NotePicker />

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -683,9 +683,9 @@ export function ChatInput(): React.JSX.Element {
           </span>
 
           {!isDisabled && (
-            <div className="flex shrink-0 items-center gap-0.5 rounded-lg border border-border-strong/80 bg-card/60 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+            <div className="flex h-6 shrink-0 items-center gap-0 rounded-md bg-card/60 ring-1 ring-inset ring-border-strong/80 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
               <ModelSelector compact />
-              <div className="h-4 w-px bg-border" aria-hidden="true" />
+              <div className="h-3.5 w-px bg-border" aria-hidden="true" />
               <ThinkingLevelSelector />
             </div>
           )}

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -4,6 +4,8 @@ import { useChatKeyboard, useCommandCatalog } from '../hooks'
 import { ComposerPermissionMenu } from './composer-permission-menu'
 import { CommandResults } from './command-results'
 import { SubagentProgress } from './subagent-progress'
+import { ModelSelector } from './model-selector'
+import { ThinkingLevelSelector } from './thinking-level-selector'
 import { CornerDownLeft, Square, Paperclip, X, FileText, StickyNote, Users, Search } from 'lucide-react'
 import {
   SUPPORTED_IMAGE_EXTENSIONS,
@@ -672,13 +674,21 @@ export function ChatInput(): React.JSX.Element {
             </button>
           )}
 
-          <span className="ml-auto mr-1 text-[11px] text-faint">
+          <span className="ml-auto mr-1 hidden text-[11px] text-faint sm:inline">
             {isStreaming ? (
               <span className="text-warning animate-pulse">Streaming…</span>
             ) : (
               'Shift+Enter newline'
             )}
           </span>
+
+          {!isDisabled && (
+            <div className="flex shrink-0 items-center gap-0.5 rounded-lg border border-border-strong/80 bg-card/60 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+              <ModelSelector compact />
+              <div className="h-4 w-px bg-border" aria-hidden="true" />
+              <ThinkingLevelSelector />
+            </div>
+          )}
 
           {isStreaming ? (
             <button

--- a/src/renderer/src/components/chat-input.tsx
+++ b/src/renderer/src/components/chat-input.tsx
@@ -652,6 +652,7 @@ export function ChatInput(): React.JSX.Element {
           </button>
           {councilEnabled && (
             <button
+              type="button"
               onClick={() => {
                 const value = textareaRef.current?.value.trim()
                 if (value) {
@@ -664,7 +665,7 @@ export function ChatInput(): React.JSX.Element {
               }}
               disabled={isDisabled || isStreaming}
               className="hover:bg-highlight-strong flex items-center justify-center rounded-md p-1.5 text-dim hover:text-secondary transition-colors disabled:opacity-50"
-              title="Plan with Council"
+              title={isDisabled ? 'Start Pi/OMP before planning with Council' : 'Plan with Council'}
               aria-label="Plan with Council"
             >
               <Users size={15} />

--- a/src/renderer/src/components/chat-panel.tsx
+++ b/src/renderer/src/components/chat-panel.tsx
@@ -36,6 +36,7 @@ import {
   X,
   ChevronDown,
   Loader2,
+  Workflow as WorkflowIcon,
 } from 'lucide-react'
 
 // Fallback padding when the composer has not measured yet (~idle pill + gradient).
@@ -72,6 +73,7 @@ export function ChatPanel(): React.JSX.Element {
   const fileSearchOpen = useAppStore((state) => state.fileSearchOpen)
   const toggleFileSearch = useAppStore((state) => state.toggleFileSearch)
   const previewTarget = useAppStore((state) => state.previewTarget)
+  const workflowPanelOpen = useAppStore((state) => state.workflowPanelOpen)
 
   // sidePanel lives in the store so it survives view switches (e.g. Settings
   // round-trip). Widths stay local — resetting them on remount is benign.
@@ -192,6 +194,21 @@ export function ChatPanel(): React.JSX.Element {
                 active={terminalOpen}
                 onClick={() => useAppStore.getState().toggleTerminal()}
                 title="Terminal"
+              />
+              <ToolbarButton
+                icon={<WorkflowIcon size={14} />}
+                active={workflowPanelOpen}
+                onClick={() => {
+                  // Session-surface button: while a session is active this opens
+                  // THAT session's runs (scoped by Pi's header UUID, the exact
+                  // identifier persisted runs carry). The global list is only a
+                  // fallback for the no-session state; closing preserves scope.
+                  const state = useAppStore.getState()
+                  if (state.workflowPanelOpen) state.setWorkflowPanelOpen(false)
+                  else if (state.sessionState?.sessionId) state.openWorkflowRunsForSession(state.sessionState.sessionId)
+                  else state.setWorkflowPanelOpen(true)
+                }}
+                title="Workflow runs"
               />
             </div>
           </div>

--- a/src/renderer/src/components/chat-project-picker.tsx
+++ b/src/renderer/src/components/chat-project-picker.tsx
@@ -13,7 +13,7 @@ import { pathsEqual } from '../../../shared/path-compare'
 export function ChatProjectPicker(): React.JSX.Element {
   const workspaces = useAppStore((s) => s.workspaces)
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)
-  const switchWorkspace = useAppStore((s) => s.switchWorkspace)
+  const activateWorkspace = useAppStore((s) => s.activateWorkspace)
   const createWorkspace = useAppStore((s) => s.createWorkspace)
   const startPi = useAppStore((s) => s.startPi)
 
@@ -77,13 +77,13 @@ export function ChatProjectPicker(): React.JSX.Element {
     setBusy(true)
     try {
       if (id) {
-        if (!(await switchWorkspace(id, { skipSessionLoad: true }))) {
+        if (!(await activateWorkspace(id))) {
           setSelectedId(previousId)
         }
       } else {
         const homeWs = await ensureHomeWorkspace()
         if (homeWs) {
-          if (!(await switchWorkspace(homeWs.id, { skipSessionLoad: true }))) {
+          if (!(await activateWorkspace(homeWs.id))) {
             setSelectedId(previousId)
           }
         } else {

--- a/src/renderer/src/components/command-palette.tsx
+++ b/src/renderer/src/components/command-palette.tsx
@@ -144,7 +144,7 @@ export function CommandPalette(): React.JSX.Element | null {
       if ('kind' in entry) {
         if (entry.kind === 'workspace') {
           if (entry.workspace.id !== activeWorkspace?.id) {
-            void useAppStore.getState().switchWorkspace(entry.workspace.id)
+            void useAppStore.getState().activateWorkspace(entry.workspace.id)
           }
         } else if (entry.kind === 'session') {
           void useAppStore.getState().openSessionItem(entry.session)

--- a/src/renderer/src/components/context-menu.tsx
+++ b/src/renderer/src/components/context-menu.tsx
@@ -13,6 +13,7 @@ import {
   MessageSquare,
   StickyNote,
   Pencil,
+  Workflow as WorkflowIcon,
 } from 'lucide-react'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
 import { useAppStore } from '../store'
@@ -351,6 +352,10 @@ export interface SessionContextMenuActions {
   // Optional: when provided, a "Rename…" item is shown (above Delete). Callers
   // pass this only for the active session, since Pi's rename targets it.
   onRename?: (session: SessionListItem) => void
+  // Optional: when provided, a "Workflow Runs" item is shown (below Open). It
+  // must open scoped to Pi's header UUID — the identifier runs carry — never
+  // the session filename stem.
+  onRuns?: (session: SessionListItem) => void
 }
 
 export function buildSessionContextMenu(
@@ -366,6 +371,14 @@ export function buildSessionContextMenu(
       icon: <MessageSquare size={14} />,
       action: () => actions.onOpen(session),
     },
+    ...(actions.onRuns
+      ? [{
+          id: 'session-runs',
+          label: 'Workflow Runs',
+          icon: <WorkflowIcon size={14} />,
+          action: () => actions.onRuns!(session),
+        }]
+      : []),
     {
       id: 'divider-session-1',
       label: '',

--- a/src/renderer/src/components/diff-viewer.tsx
+++ b/src/renderer/src/components/diff-viewer.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
 } from 'lucide-react'
 import { formatIpcError } from '../utils/ipc-error'
+import { GitConveyorActions } from './git-conveyor-actions'
 
 interface DiffLine {
   type: 'add' | 'remove' | 'context' | 'header' | 'hunk'
@@ -82,6 +83,7 @@ export function DiffViewer({ onClose }: DiffViewerProps = {}): React.JSX.Element
           </span>
         </div>
         <div className="flex items-center gap-2">
+          <GitConveyorActions onChanged={loadDiff} />
           <button
             onClick={() => setStagedMode(!stagedMode)}
             className={clsx(

--- a/src/renderer/src/components/diff-viewer.tsx
+++ b/src/renderer/src/components/diff-viewer.tsx
@@ -74,45 +74,51 @@ export function DiffViewer({ onClose }: DiffViewerProps = {}): React.JSX.Element
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <div className="flex items-center gap-2">
-          <GitCompare size={16} className="text-muted" />
-          <h2 className="text-sm font-medium text-primary">Diff Viewer</h2>
-          <span className="rounded-full bg-card px-2 py-0.5 text-xs text-dim">
-            {files.length} file{files.length !== 1 ? 's' : ''}
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <GitConveyorActions onChanged={loadDiff} />
-          <button
-            onClick={() => setStagedMode(!stagedMode)}
-            className={clsx(
-              'rounded px-2 py-1 text-xs transition-colors',
-              stagedMode
-                ? 'bg-success-bg text-success'
-                : 'bg-card text-muted hover:text-secondary'
-            )}
-          >
-            {stagedMode ? 'Staged' : 'Working'}
-          </button>
-          <button
-            onClick={loadDiff}
-            className="rounded p-1.5 text-dim hover:bg-surface-hover hover:text-secondary transition-colors"
-          >
-            <RefreshCw size={14} />
-          </button>
-          <button
-            onClick={() => {
-              if (onClose) {
-                onClose()
-              } else {
-                setCurrentView('chat')
-              }
-            }}
-            className="rounded p-1.5 text-dim hover:bg-surface-hover hover:text-secondary transition-colors"
-          >
-            <X size={14} />
-          </button>
+      <div className="shrink-0 border-b border-border px-4 py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="order-1 flex min-w-0 flex-1 items-center gap-2">
+            <GitCompare size={16} className="shrink-0 text-muted" />
+            <h2 className="truncate text-sm font-medium text-primary">Diff Viewer</h2>
+            <span className="shrink-0 rounded-full bg-card px-2 py-0.5 text-xs text-dim">
+              {files.length} file{files.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+          <div className="order-2 flex shrink-0 items-center gap-2">
+            <button
+              onClick={() => setStagedMode(!stagedMode)}
+              className={clsx(
+                'rounded px-2 py-1 text-xs transition-colors',
+                stagedMode
+                  ? 'bg-success-bg text-success'
+                  : 'bg-card text-muted hover:text-secondary'
+              )}
+            >
+              {stagedMode ? 'Staged' : 'Working'}
+            </button>
+            <button
+              onClick={loadDiff}
+              className="rounded p-1.5 text-dim transition-colors hover:bg-surface-hover hover:text-secondary"
+              aria-label="Refresh diff"
+            >
+              <RefreshCw size={14} />
+            </button>
+            <button
+              onClick={() => {
+                if (onClose) {
+                  onClose()
+                } else {
+                  setCurrentView('chat')
+                }
+              }}
+              className="rounded p-1.5 text-dim transition-colors hover:bg-surface-hover hover:text-secondary"
+              aria-label="Close diff viewer"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          <div className="order-3 min-w-0 basis-full border-t border-border pt-2">
+            <GitConveyorActions onChanged={loadDiff} />
+          </div>
         </div>
       </div>
 

--- a/src/renderer/src/components/git-conveyor-actions.tsx
+++ b/src/renderer/src/components/git-conveyor-actions.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ExternalLink, GitCommitHorizontal, GitPullRequest, Loader2, Upload } from 'lucide-react'
+import { clsx } from 'clsx'
+import type { GitConveyorStatus } from '../../../shared/ipc-contracts'
+import { formatIpcError } from '../utils/ipc-error'
+
+export function GitConveyorActions({ onChanged }: { onChanged?: () => void }): React.JSX.Element {
+  const [status, setStatus] = useState<GitConveyorStatus | null>(null)
+  const [busy, setBusy] = useState<'commit' | 'push' | 'pr' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [feedback, setFeedback] = useState<string | null>(null)
+
+  const refresh = useCallback(async (): Promise<void> => {
+    try {
+      setStatus(await window.piDesktop.git.status())
+      setError(null)
+    } catch (err) {
+      setStatus(null)
+      setError(formatIpcError(err))
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const timer = window.setInterval(() => void refresh(), 5000)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  const run = async <T,>(kind: 'commit' | 'push' | 'pr', action: () => Promise<T>, success: (result: T) => string): Promise<void> => {
+    if (busy) return
+    setBusy(kind)
+    setError(null)
+    setFeedback(null)
+    try {
+      const result = await action()
+      setFeedback(success(result))
+      await refresh()
+      onChanged?.()
+    } catch (err) {
+      setError(formatIpcError(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const commit = (): void => {
+    const message = window.prompt('Commit message', status?.lastCommitMessage ?? 'chore: update implementation')
+    if (message === null || !message.trim()) return
+    void run('commit', () => window.piDesktop.git.commit({ message }), (next) => `Committed ${next.head.slice(0, 8)}.`)
+  }
+
+  const push = (): void => {
+    if (status?.dirtyFiles) {
+      setError('Commit the working tree before pushing.')
+      return
+    }
+    void run('push', () => window.piDesktop.git.push(), (next) => next.ahead > 0 ? `Pushed ${next.ahead} commit${next.ahead === 1 ? '' : 's'}.` : 'Branch pushed.')
+  }
+
+  const createPr = (): void => {
+    if (!status?.branch) {
+      setError('A named branch is required to create a pull request.')
+      return
+    }
+    if (status.dirtyFiles || status.ahead > 0) {
+      setError(status.dirtyFiles ? 'Commit changes before creating a pull request.' : 'Push the branch before creating a pull request.')
+      return
+    }
+    const title = window.prompt('Pull request title', status.lastCommitMessage ?? status.branch)
+    if (title === null || !title.trim()) return
+    const body = window.prompt('Pull request description', '## Summary\n\n## Verification\n')
+    if (body === null) return
+    void run('pr', async () => {
+      const result = await window.piDesktop.git.createPullRequest({ title, body })
+      if (result.url) void window.piDesktop.system.openExternal(result.url)
+      return result
+    }, (result) => result.url ? `Pull request created: ${result.url}` : 'Pull request created.')
+  }
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+      {status && (
+        <span className="mr-1 max-w-44 truncate text-[10px] text-faint" title={status.branch ?? undefined}>
+          {status.branch ?? 'detached'}{status.dirtyFiles > 0 ? ` · ${status.dirtyFiles} changed` : ''}
+        </span>
+      )}
+      <button type="button" onClick={commit} disabled={busy !== null || !status?.dirtyFiles} className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:cursor-not-allowed disabled:opacity-40" title="Stage all changes and commit">
+        {busy === 'commit' ? <Loader2 size={11} className="animate-spin" /> : <GitCommitHorizontal size={11} />}
+        Commit
+      </button>
+      <button type="button" onClick={push} disabled={busy !== null || !status || !!status.dirtyFiles || !status.branch} className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:cursor-not-allowed disabled:opacity-40" title="Push the current branch">
+        {busy === 'push' ? <Loader2 size={11} className="animate-spin" /> : <Upload size={11} />}
+        Push
+      </button>
+      <button type="button" onClick={createPr} disabled={busy !== null || !status || !!status.dirtyFiles || !!status.ahead || !status.branch} className={clsx('flex items-center gap-1 rounded border border-accent/50 px-2 py-1 text-[10px] text-accent-fg transition-colors hover:bg-accent-bg/20 disabled:cursor-not-allowed disabled:opacity-40')} title="Create a pull request with GitHub CLI">
+        {busy === 'pr' ? <Loader2 size={11} className="animate-spin" /> : <GitPullRequest size={11} />}
+        PR
+      </button>
+      {status?.remoteUrl && <ExternalLink size={11} className="text-faint" aria-hidden="true" />}
+      {(error || feedback) && <span className={clsx('basis-full truncate text-[10px]', error ? 'text-error' : 'text-success')} role="status" title={error ?? feedback ?? undefined}>{error ?? feedback}</span>}
+    </div>
+  )
+}

--- a/src/renderer/src/components/git-conveyor-actions.tsx
+++ b/src/renderer/src/components/git-conveyor-actions.tsx
@@ -78,21 +78,21 @@ export function GitConveyorActions({ onChanged }: { onChanged?: () => void }): R
   }
 
   return (
-    <div className="flex min-w-0 flex-wrap items-center justify-end gap-1.5">
+    <div className="flex min-w-0 flex-wrap items-center justify-start gap-1.5 lg:justify-end">
       {status && (
-        <span className="mr-1 max-w-44 truncate text-[10px] text-faint" title={status.branch ?? undefined}>
+        <span className="basis-full mr-1 max-w-44 truncate text-[10px] text-faint sm:basis-auto" title={status.branch ?? undefined}>
           {status.branch ?? 'detached'}{status.dirtyFiles > 0 ? ` · ${status.dirtyFiles} changed` : ''}
         </span>
       )}
-      <button type="button" onClick={commit} disabled={busy !== null || !status?.dirtyFiles} className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:cursor-not-allowed disabled:opacity-40" title="Stage all changes and commit">
+      <button type="button" onClick={commit} disabled={busy !== null || !status?.dirtyFiles} className="flex shrink-0 items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:cursor-not-allowed disabled:opacity-40" title="Stage all changes and commit">
         {busy === 'commit' ? <Loader2 size={11} className="animate-spin" /> : <GitCommitHorizontal size={11} />}
         Commit
       </button>
-      <button type="button" onClick={push} disabled={busy !== null || !status || !!status.dirtyFiles || !status.branch} className="flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:cursor-not-allowed disabled:opacity-40" title="Push the current branch">
+      <button type="button" onClick={push} disabled={busy !== null || !status || !!status.dirtyFiles || !status.branch} className="flex shrink-0 items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:cursor-not-allowed disabled:opacity-40" title="Push the current branch">
         {busy === 'push' ? <Loader2 size={11} className="animate-spin" /> : <Upload size={11} />}
         Push
       </button>
-      <button type="button" onClick={createPr} disabled={busy !== null || !status || !!status.dirtyFiles || !!status.ahead || !status.branch} className={clsx('flex items-center gap-1 rounded border border-accent/50 px-2 py-1 text-[10px] text-accent-fg transition-colors hover:bg-accent-bg/20 disabled:cursor-not-allowed disabled:opacity-40')} title="Create a pull request with GitHub CLI">
+      <button type="button" onClick={createPr} disabled={busy !== null || !status || !!status.dirtyFiles || !!status.ahead || !status.branch} className={clsx('flex shrink-0 items-center gap-1 rounded border border-accent/50 px-2 py-1 text-[10px] text-accent-fg transition-colors hover:bg-accent-bg/20 disabled:cursor-not-allowed disabled:opacity-40')} title="Create a pull request with GitHub CLI">
         {busy === 'pr' ? <Loader2 size={11} className="animate-spin" /> : <GitPullRequest size={11} />}
         PR
       </button>

--- a/src/renderer/src/components/home-screen.tsx
+++ b/src/renderer/src/components/home-screen.tsx
@@ -38,10 +38,9 @@ export function HomeInfoSummary({ compact }: { compact?: boolean }): React.JSX.E
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)
   const sessionList = useAppStore((s) => s.sessionList)
   const archivedSessions = useAppStore((s) => s.archivedSessions)
-  const switchWorkspace = useAppStore((s) => s.switchWorkspace)
+  const activateWorkspace = useAppStore((s) => s.activateWorkspace)
   const createWorkspace = useAppStore((s) => s.createWorkspace)
   const switchSession = useAppStore((s) => s.switchSession)
-  const startPi = useAppStore((s) => s.startPi)
   const setCurrentView = useAppStore((s) => s.setCurrentView)
   const requestChatScrollToBottom = useAppStore((s) => s.requestChatScrollToBottom)
 
@@ -82,7 +81,7 @@ export function HomeInfoSummary({ compact }: { compact?: boolean }): React.JSX.E
   const openWorkspace = async (workspaceId: string): Promise<void> => {
     setBusy(true)
     try {
-      if (!(await switchWorkspace(workspaceId))) return
+      if (!(await activateWorkspace(workspaceId))) return
       if (useAppStore.getState().piStatus !== 'error') {
         requestChatScrollToBottom()
         setCurrentView('chat')
@@ -104,15 +103,13 @@ export function HomeInfoSummary({ compact }: { compact?: boolean }): React.JSX.E
         }
         targetId = ws?.id
       }
-      // A declined "Pi is still working" warning stops the whole open, since the
-      // session switch below would tear the running turn down regardless.
+      // Workspace/session activation is non-destructive; the target Pi runtime
+      // hydrates in the background while Chat opens immediately.
       if (targetId) {
-        if (!(await switchWorkspace(targetId))) return
-      } else {
-        await startPi()
+        if (!(await activateWorkspace(targetId, { start: false }))) return
       }
       if (useAppStore.getState().piStatus === 'error') return
-      await switchSession(session.path)
+      await switchSession(session.path, session.projectPath)
       requestChatScrollToBottom()
       setCurrentView('chat')
     } finally {
@@ -124,7 +121,7 @@ export function HomeInfoSummary({ compact }: { compact?: boolean }): React.JSX.E
     if (!activeWorkspace) return
     setBusy(true)
     try {
-      if (!(await switchWorkspace(activeWorkspace.id))) return
+      if (!(await activateWorkspace(activeWorkspace.id))) return
       if (useAppStore.getState().piStatus !== 'error') setCurrentView('diff')
     } finally {
       setBusy(false)
@@ -282,7 +279,7 @@ function EmptyHint({ children }: { children: React.ReactNode }): React.JSX.Eleme
 
 function HomeScreenInfo(): React.JSX.Element {
   const activeWorkspace = useAppStore((s) => s.activeWorkspace)
-  const switchWorkspace = useAppStore((s) => s.switchWorkspace)
+  const activateWorkspace = useAppStore((s) => s.activateWorkspace)
   const createWorkspace = useAppStore((s) => s.createWorkspace)
   const createNewSession = useAppStore((s) => s.createNewSession)
   const setCurrentView = useAppStore((s) => s.setCurrentView)
@@ -307,7 +304,7 @@ function HomeScreenInfo(): React.JSX.Element {
         ws = useAppStore.getState().workspaces.find((w) => pathsEqual(w.path, path))
       }
       if (ws) {
-        if (!(await switchWorkspace(ws.id))) return
+        if (!(await activateWorkspace(ws.id))) return
         goChatUnlessError()
       }
     } finally {
@@ -322,7 +319,7 @@ function HomeScreenInfo(): React.JSX.Element {
     }
     setBusy(true)
     try {
-      if (!(await switchWorkspace(activeWorkspace.id))) return
+      if (!(await activateWorkspace(activeWorkspace.id))) return
       if (useAppStore.getState().piStatus === 'error') return
       await createNewSession()
       requestChatScrollToBottom()

--- a/src/renderer/src/components/home-screen.tsx
+++ b/src/renderer/src/components/home-screen.tsx
@@ -9,6 +9,7 @@ import {
   GitCompare,
   AlertTriangle,
   Settings as SettingsIcon,
+  Play,
 } from 'lucide-react'
 import { useAppStore } from '../store'
 import piLogo from '../assets/pi-logo.svg'
@@ -282,6 +283,7 @@ function HomeScreenInfo(): React.JSX.Element {
   const activateWorkspace = useAppStore((s) => s.activateWorkspace)
   const createWorkspace = useAppStore((s) => s.createWorkspace)
   const createNewSession = useAppStore((s) => s.createNewSession)
+  const setTaskLauncherOpen = useAppStore((s) => s.setTaskLauncherOpen)
   const setCurrentView = useAppStore((s) => s.setCurrentView)
   const requestChatScrollToBottom = useAppStore((s) => s.requestChatScrollToBottom)
   const [busy, setBusy] = useState(false)
@@ -340,7 +342,7 @@ function HomeScreenInfo(): React.JSX.Element {
           <p className="mt-1 text-sm text-dim">Open a workspace or pick up where you left off.</p>
         </div>
 
-        <div className="mb-6 grid gap-3 sm:grid-cols-2">
+        <div className="mb-6 grid gap-3 sm:grid-cols-3">
           <button
             onClick={() => void openFolder()}
             className="flex w-full items-center gap-3 rounded-lg border border-border-strong bg-surface px-4 py-3 text-left transition-colors hover:border-border-strong-hover hover:bg-surface-hover"
@@ -361,6 +363,16 @@ function HomeScreenInfo(): React.JSX.Element {
               <div className="truncate text-xs text-dim">
                 {activeWorkspace ? `In ${activeWorkspace.name}` : 'Pick a folder first'}
               </div>
+            </div>
+          </button>
+          <button
+            onClick={() => setTaskLauncherOpen(true)}
+            className="flex w-full items-center gap-3 rounded-lg border border-accent/50 bg-accent-bg/30 px-4 py-3 text-left transition-colors hover:border-accent hover:bg-accent-bg/50"
+          >
+            <Play size={18} className="shrink-0 text-accent-fg" />
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-primary">New Task</div>
+              <div className="truncate text-xs text-dim">Start work in a fresh Pi session</div>
             </div>
           </button>
         </div>

--- a/src/renderer/src/components/mission-control.tsx
+++ b/src/renderer/src/components/mission-control.tsx
@@ -71,6 +71,11 @@ export function MissionControl(): React.JSX.Element {
     }
   }
 
+  const reviewRuntime = async (runtime: SessionRuntimeInfo): Promise<void> => {
+    await openRuntime(runtime)
+    if (useAppStore.getState().activeSessionRuntimeId === runtime.runtimeId) setCurrentView('diff')
+  }
+
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-5xl px-6 py-7">
@@ -132,13 +137,24 @@ export function MissionControl(): React.JSX.Element {
                       <div className="truncate text-[11px] text-faint">{workspace?.name ?? 'Unknown project'} · {runtimeState(runtime)}</div>
                     </div>
                     {canOpen && (
-                      <button
-                        type="button"
-                        onClick={() => void openRuntime(runtime)}
-                        className="flex shrink-0 items-center gap-1 rounded px-2 py-1 text-[11px] text-muted transition-colors hover:bg-highlight hover:text-primary"
-                      >
-                        Open <ArrowUpRight size={11} />
-                      </button>
+                      <div className="flex shrink-0 items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => void openRuntime(runtime)}
+                          className="flex items-center gap-1 rounded px-2 py-1 text-[11px] text-muted transition-colors hover:bg-highlight hover:text-primary"
+                        >
+                          Open <ArrowUpRight size={11} />
+                        </button>
+                        {(runtime.activity === 'completed' || workspace?.kind === 'worktree') && (
+                          <button
+                            type="button"
+                            onClick={() => void reviewRuntime(runtime)}
+                            className="rounded border border-accent/40 px-2 py-1 text-[10px] text-accent-fg transition-colors hover:bg-accent-bg/20"
+                          >
+                            Review
+                          </button>
+                        )}
+                      </div>
                     )}
                   </div>
                 )

--- a/src/renderer/src/components/mission-control.tsx
+++ b/src/renderer/src/components/mission-control.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { AlertCircle, ArrowUpRight, CheckCircle2, Inbox, Loader2, Play, RefreshCw, XCircle } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAppStore } from '../store'
 import { getSessionTitle } from '../utils/session-title'
 import { pathsEqual } from '../../../shared/path-compare'
+import { canResumeRun } from '../utils/workflow-runs'
 import { SessionRuntimeIndicator } from './session-runtime-indicator'
 import type { SessionRuntimeInfo, WorkflowRunSummary } from '../../../shared/ipc-contracts'
 
@@ -19,6 +20,8 @@ export function MissionControl(): React.JSX.Element {
   const setCurrentView = useAppStore((state) => state.setCurrentView)
   const setTaskLauncherOpen = useAppStore((state) => state.setTaskLauncherOpen)
   const openWorkflowRunsForWorkspace = useAppStore((state) => state.openWorkflowRunsForWorkspace)
+  const [controlBusy, setControlBusy] = useState<string | null>(null)
+  const [controlError, setControlError] = useState<string | null>(null)
 
   useEffect(() => {
     void refreshWorkflowRuns()
@@ -38,6 +41,21 @@ export function MissionControl(): React.JSX.Element {
   )
   const attentionCount = runtimes.filter((runtime) => runtime.activity === 'needs-approval' || runtime.activity === 'failed' || runtime.status === 'error').length +
     workflowRuns.filter((run) => run.status === 'paused' || run.status === 'failed').length
+
+  const resumeRun = async (run: WorkflowRunSummary): Promise<void> => {
+    if (controlBusy) return
+    setControlBusy(run.runId)
+    setControlError(null)
+    try {
+      const result = await window.piDesktop.workflows.control(run.workspaceId, run.runId, 'resume')
+      if (!result.ok) setControlError(`Could not proceed with ${run.workflowName}: ${result.reason ?? 'control unavailable'}`)
+      else await refreshWorkflowRuns()
+    } catch {
+      setControlError(`Could not proceed with ${run.workflowName}. Open the run for details.`)
+    } finally {
+      setControlBusy(null)
+    }
+  }
 
   const openRuntime = async (runtime: SessionRuntimeInfo): Promise<void> => {
     if (!runtime.sessionPath) return
@@ -143,9 +161,20 @@ export function MissionControl(): React.JSX.Element {
           {recentRuns.length === 0 ? (
             <EmptyState>No workflow runs yet.</EmptyState>
           ) : (
-            <div className="space-y-2">
-              {recentRuns.map((run) => <WorkflowRow key={`${run.workspaceId}:${run.runId}`} run={run} onOpen={() => openWorkflowRunsForWorkspace(run.workspaceId)} />)}
-            </div>
+            <>
+              {controlError && <div className="mb-2 rounded border border-error/40 bg-error-bg/20 px-3 py-2 text-[11px] text-error" role="status">{controlError}</div>}
+              <div className="space-y-2">
+              {recentRuns.map((run) => (
+                <WorkflowRow
+                  key={`${run.workspaceId}:${run.runId}`}
+                  run={run}
+                  onOpen={() => openWorkflowRunsForWorkspace(run.workspaceId)}
+                  onResume={() => void resumeRun(run)}
+                  resumeBusy={controlBusy === run.runId}
+                />
+                ))}
+              </div>
+            </>
           )}
         </section>
       </div>
@@ -153,21 +182,41 @@ export function MissionControl(): React.JSX.Element {
   )
 }
 
-function WorkflowRow({ run, onOpen }: { run: WorkflowRunSummary; onOpen: () => void }): React.JSX.Element {
+function WorkflowRow({
+  run,
+  onOpen,
+  onResume,
+  resumeBusy,
+}: {
+  run: WorkflowRunSummary
+  onOpen: () => void
+  onResume: () => void
+  resumeBusy: boolean
+}): React.JSX.Element {
   const Icon = run.status === 'completed' ? CheckCircle2 : run.status === 'failed' || run.status === 'aborted' ? XCircle : run.status === 'paused' ? AlertCircle : Loader2
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      className="flex w-full items-center gap-3 rounded-lg border border-border bg-surface/50 px-3 py-3 text-left transition-colors hover:border-border-strong hover:bg-surface-hover"
-    >
-      <Icon size={14} className={clsx('shrink-0', run.status === 'running' || run.status === 'pending' ? 'animate-spin text-accent-fg' : run.status === 'completed' ? 'text-success' : run.status === 'paused' ? 'text-warning' : 'text-error')} />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm text-primary">{run.workflowName}</div>
-        <div className="truncate text-[11px] text-faint">{run.workspaceName} · {run.currentPhase ?? run.status}</div>
-      </div>
-      <span className="shrink-0 text-[11px] capitalize text-muted">{run.status}</span>
-    </button>
+    <div className="flex w-full items-center gap-3 rounded-lg border border-border bg-surface/50 px-3 py-2 transition-colors hover:border-border-strong hover:bg-surface-hover">
+      <button type="button" onClick={onOpen} className="flex min-w-0 flex-1 items-center gap-3 py-1 text-left">
+        <Icon size={14} className={clsx('shrink-0', run.status === 'running' || run.status === 'pending' ? 'animate-spin text-accent-fg' : run.status === 'completed' ? 'text-success' : run.status === 'paused' ? 'text-warning' : 'text-error')} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm text-primary">{run.workflowName}</div>
+          <div className="truncate text-[11px] text-faint">{run.workspaceName} · {run.currentPhase ?? run.status}</div>
+        </div>
+        <span className="shrink-0 text-[11px] capitalize text-muted">{run.status}</span>
+      </button>
+      {canResumeRun(run.status) && (
+        <button
+          type="button"
+          onClick={onResume}
+          disabled={resumeBusy}
+          className="flex shrink-0 items-center gap-1 rounded border border-success/40 px-2 py-1 text-[10px] font-medium text-success transition-colors hover:bg-success-bg/20 disabled:cursor-not-allowed disabled:opacity-50"
+          title={run.status === 'paused' ? 'Proceed with this workflow' : 'Retry this workflow'}
+        >
+          {resumeBusy ? <Loader2 size={11} className="animate-spin" /> : <Play size={11} />}
+          {run.status === 'paused' ? 'Proceed' : 'Retry'}
+        </button>
+      )}
+    </div>
   )
 }
 

--- a/src/renderer/src/components/mission-control.tsx
+++ b/src/renderer/src/components/mission-control.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useMemo } from 'react'
+import { AlertCircle, ArrowUpRight, CheckCircle2, Inbox, Loader2, Play, RefreshCw, XCircle } from 'lucide-react'
+import { clsx } from 'clsx'
+import { useAppStore } from '../store'
+import { getSessionTitle } from '../utils/session-title'
+import { pathsEqual } from '../../../shared/path-compare'
+import { SessionRuntimeIndicator } from './session-runtime-indicator'
+import type { SessionRuntimeInfo, WorkflowRunSummary } from '../../../shared/ipc-contracts'
+
+export function MissionControl(): React.JSX.Element {
+  const workspaces = useAppStore((state) => state.workspaces)
+  const sessionList = useAppStore((state) => state.sessionList)
+  const sessionRuntimes = useAppStore((state) => state.sessionRuntimes)
+  const workflowRuns = useAppStore((state) => state.workflowRuns)
+  const refreshWorkflowRuns = useAppStore((state) => state.refreshWorkflowRuns)
+  const openSessionItem = useAppStore((state) => state.openSessionItem)
+  const activateWorkspace = useAppStore((state) => state.activateWorkspace)
+  const switchSession = useAppStore((state) => state.switchSession)
+  const setCurrentView = useAppStore((state) => state.setCurrentView)
+  const setTaskLauncherOpen = useAppStore((state) => state.setTaskLauncherOpen)
+  const openWorkflowRunsForWorkspace = useAppStore((state) => state.openWorkflowRunsForWorkspace)
+
+  useEffect(() => {
+    void refreshWorkflowRuns()
+    const timer = window.setInterval(() => void refreshWorkflowRuns(), 5000)
+    return () => window.clearInterval(timer)
+  }, [refreshWorkflowRuns])
+
+  const runtimes = useMemo(
+    () => Object.values(sessionRuntimes)
+      .filter((runtime) => runtime.status !== 'stopped' || runtime.activity !== null)
+      .sort((a, b) => Number(b.active) - Number(a.active)),
+    [sessionRuntimes]
+  )
+  const recentRuns = useMemo(
+    () => [...workflowRuns].sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)).slice(0, 8),
+    [workflowRuns]
+  )
+  const attentionCount = runtimes.filter((runtime) => runtime.activity === 'needs-approval' || runtime.activity === 'failed' || runtime.status === 'error').length +
+    workflowRuns.filter((run) => run.status === 'paused' || run.status === 'failed').length
+
+  const openRuntime = async (runtime: SessionRuntimeInfo): Promise<void> => {
+    if (!runtime.sessionPath) return
+    const workspace = workspaces.find((item) => item.id === runtime.workspaceId)
+    if (!workspace) return
+    const session = sessionList.find((item) => pathsEqual(item.path, runtime.sessionPath!))
+    if (session) {
+      await openSessionItem(session)
+    } else {
+      if (!(await activateWorkspace(workspace.id, { start: false }))) return
+      await switchSession(runtime.sessionPath, workspace.path)
+      setCurrentView('chat')
+    }
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-6 py-7">
+        <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2">
+              <Inbox size={19} className="text-accent-fg" />
+              <h1 className="text-lg font-semibold text-primary">Mission Control</h1>
+              {attentionCount > 0 && (
+                <span className="rounded-full bg-warning-bg px-2 py-0.5 text-[10px] font-medium text-warning">
+                  {attentionCount} needs attention
+                </span>
+              )}
+            </div>
+            <p className="mt-1 text-xs text-dim">Background sessions and workflow runs, from every project.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void refreshWorkflowRuns()}
+              className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-primary"
+              title="Refresh workflow runs"
+            >
+              <RefreshCw size={12} />
+              Refresh
+            </button>
+            <button
+              type="button"
+              onClick={() => setTaskLauncherOpen(true)}
+              className="flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-hover"
+            >
+              <Play size={12} />
+              New task
+            </button>
+          </div>
+        </div>
+
+        <section className="mb-6">
+          <SectionHeading title="Live sessions" count={runtimes.length} />
+          {runtimes.length === 0 ? (
+            <EmptyState>No live session runtimes yet. Start a task to put Pi to work in the background.</EmptyState>
+          ) : (
+            <div className="grid gap-2 md:grid-cols-2">
+              {runtimes.map((runtime) => {
+                const workspace = workspaces.find((item) => item.id === runtime.workspaceId)
+                const session = runtime.sessionPath
+                  ? sessionList.find((item) => pathsEqual(item.path, runtime.sessionPath!))
+                  : undefined
+                const title = session
+                  ? getSessionTitle(session.name, session.sessionId, session.preview)
+                  : runtime.sessionId ?? 'Starting session'
+                const canOpen = !!runtime.sessionPath && !!workspace
+                return (
+                  <div key={runtime.runtimeId} className="flex items-center gap-3 rounded-lg border border-border bg-surface/50 px-3 py-3">
+                    <SessionRuntimeIndicator runtime={runtime} />
+                    {!runtime.activity && runtime.status === 'running' && <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-success" title="Pi is idle" />}
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm text-primary">{title}</div>
+                      <div className="truncate text-[11px] text-faint">{workspace?.name ?? 'Unknown project'} · {runtimeState(runtime)}</div>
+                    </div>
+                    {canOpen && (
+                      <button
+                        type="button"
+                        onClick={() => void openRuntime(runtime)}
+                        className="flex shrink-0 items-center gap-1 rounded px-2 py-1 text-[11px] text-muted transition-colors hover:bg-highlight hover:text-primary"
+                      >
+                        Open <ArrowUpRight size={11} />
+                      </button>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </section>
+
+        <section>
+          <div className="mb-2 flex items-center justify-between">
+            <SectionHeading title="Workflow activity" count={workflowRuns.length} />
+            <button
+              type="button"
+              onClick={() => openWorkflowRunsForWorkspace(null)}
+              className="text-[11px] text-muted transition-colors hover:text-accent-fg"
+            >
+              Open all workflows
+            </button>
+          </div>
+          {recentRuns.length === 0 ? (
+            <EmptyState>No workflow runs yet.</EmptyState>
+          ) : (
+            <div className="space-y-2">
+              {recentRuns.map((run) => <WorkflowRow key={`${run.workspaceId}:${run.runId}`} run={run} onOpen={() => openWorkflowRunsForWorkspace(run.workspaceId)} />)}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function WorkflowRow({ run, onOpen }: { run: WorkflowRunSummary; onOpen: () => void }): React.JSX.Element {
+  const Icon = run.status === 'completed' ? CheckCircle2 : run.status === 'failed' || run.status === 'aborted' ? XCircle : run.status === 'paused' ? AlertCircle : Loader2
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="flex w-full items-center gap-3 rounded-lg border border-border bg-surface/50 px-3 py-3 text-left transition-colors hover:border-border-strong hover:bg-surface-hover"
+    >
+      <Icon size={14} className={clsx('shrink-0', run.status === 'running' || run.status === 'pending' ? 'animate-spin text-accent-fg' : run.status === 'completed' ? 'text-success' : run.status === 'paused' ? 'text-warning' : 'text-error')} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm text-primary">{run.workflowName}</div>
+        <div className="truncate text-[11px] text-faint">{run.workspaceName} · {run.currentPhase ?? run.status}</div>
+      </div>
+      <span className="shrink-0 text-[11px] capitalize text-muted">{run.status}</span>
+    </button>
+  )
+}
+
+function SectionHeading({ title, count }: { title: string; count: number }): React.JSX.Element {
+  return (
+    <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-dim">
+      <span>{title}</span>
+      <span className="rounded-full bg-card px-1.5 py-0.5 text-[10px] font-normal text-faint">{count}</span>
+    </div>
+  )
+}
+
+function EmptyState({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return <div className="rounded-lg border border-dashed border-border px-4 py-5 text-center text-xs text-faint">{children}</div>
+}
+
+function runtimeState(runtime: SessionRuntimeInfo): string {
+  if (runtime.activity === 'needs-approval') return 'needs approval'
+  if (runtime.activity === 'working' || runtime.status === 'starting') return 'working'
+  if (runtime.activity === 'failed' || runtime.status === 'error') return 'failed'
+  if (runtime.activity === 'completed') return 'completed'
+  return runtime.status === 'running' ? 'idle' : runtime.status
+}

--- a/src/renderer/src/components/model-selector.tsx
+++ b/src/renderer/src/components/model-selector.tsx
@@ -7,13 +7,14 @@ import { Cpu, ChevronUp, Check, Loader2, Search } from 'lucide-react'
 
 interface ModelSelectorProps {
   className?: string
+  compact?: boolean
 }
 
 /**
  * Searchable model picker for the status bar.
  * Opens upward; loads models when Pi is running.
  */
-export function ModelSelector({ className }: ModelSelectorProps): React.JSX.Element {
+export function ModelSelector({ className, compact = false }: ModelSelectorProps): React.JSX.Element {
   const sessionState = useAppStore((state) => state.sessionState)
   const setModel = useAppStore((state) => state.setModel)
   const piStatus = useAppStore((state) => state.piStatus)
@@ -117,7 +118,11 @@ export function ModelSelector({ className }: ModelSelectorProps): React.JSX.Elem
       <button
         type="button"
         onClick={() => void open()}
-        className="flex items-center gap-1 text-dim hover:text-secondary transition-colors"
+        className={clsx(
+          'flex h-7 max-w-52 items-center gap-1 rounded-md px-2 text-[11px] transition-colors active:scale-[0.98]',
+          isOpen ? 'bg-surface-hover text-primary' : 'text-dim hover:bg-surface-hover hover:text-secondary',
+          compact && 'max-w-40',
+        )}
         title="Select model (Ctrl+P to cycle when Pi is running)"
         aria-label="Select model"
         aria-expanded={isOpen}

--- a/src/renderer/src/components/model-selector.tsx
+++ b/src/renderer/src/components/model-selector.tsx
@@ -119,9 +119,9 @@ export function ModelSelector({ className, compact = false }: ModelSelectorProps
         type="button"
         onClick={() => void open()}
         className={clsx(
-          'flex h-7 max-w-52 items-center gap-1 rounded-md px-2 text-[11px] transition-colors active:scale-[0.98]',
+          'flex h-6 max-w-52 items-center gap-1 rounded-md px-2 text-[11px] transition-colors active:scale-[0.98]',
           isOpen ? 'bg-surface-hover text-primary' : 'text-dim hover:bg-surface-hover hover:text-secondary',
-          compact && 'max-w-40',
+          compact && 'max-w-36',
         )}
         title="Select model (Ctrl+P to cycle when Pi is running)"
         aria-label="Select model"

--- a/src/renderer/src/components/session-panel.tsx
+++ b/src/renderer/src/components/session-panel.tsx
@@ -9,11 +9,14 @@ import { pathsEqual } from '../../../shared/path-compare'
 import { useContextMenu, buildSessionContextMenu } from './context-menu'
 import { getSessionMenuPosition, type MenuPosition } from './session-menu-position'
 import { resolveRunSessionId } from '../utils/workflow-runs'
+import { SessionRuntimeIndicator } from './session-runtime-indicator'
 
 export function SessionPanel(): React.JSX.Element {
   const sessionList = useAppStore((state) => state.sessionList)
   const sessionState = useAppStore((state) => state.sessionState)
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
+  const activeSessionRuntimeId = useAppStore((state) => state.activeSessionRuntimeId)
+  const sessionRuntimes = useAppStore((state) => state.sessionRuntimes)
   const createNewSession = useAppStore((state) => state.createNewSession)
   const refreshSessionList = useAppStore((state) => state.refreshSessionList)
   const archivedSessions = useAppStore((state) => state.archivedSessions)
@@ -313,7 +316,7 @@ export function SessionPanel(): React.JSX.Element {
                         <SessionEntry
                           key={session.path}
                           session={session}
-                          isActive={sessionState?.sessionFile === session.path}
+                          isActive={sessionState?.sessionFile === session.path || sessionRuntimes[activeSessionRuntimeId ?? '']?.sessionPath === session.path}
                           onSelect={() => handleSwitchSession(session)}
                         />
                       ))}
@@ -367,6 +370,7 @@ function SessionEntry({
   const unarchiveSession = useAppStore((state) => state.unarchiveSession)
   const deleteSession = useAppStore((state) => state.deleteSession)
   const openWorkflowRunsForSession = useAppStore((state) => state.openWorkflowRunsForSession)
+  const sessionRuntimes = useAppStore((state) => state.sessionRuntimes)
 
   const tags = sessionTags[session.sessionId] ?? []
   const autoTag = autoTags[session.sessionId]
@@ -561,6 +565,10 @@ function SessionEntry({
             active
           </span>
         )}
+        {(() => {
+          const runtime = Object.values(sessionRuntimes).find((item) => item.sessionPath && pathsEqual(item.sessionPath, session.path))
+          return runtime ? <SessionRuntimeIndicator runtime={runtime} /> : null
+        })()}
       </div>
 
       {/* Kebab menu trigger — always visible so the actions are discoverable.

--- a/src/renderer/src/components/session-panel.tsx
+++ b/src/renderer/src/components/session-panel.tsx
@@ -1,12 +1,14 @@
 import { useAppStore } from '../store'
 import { getSessionTitle } from '../utils/session-title'
-import { FolderOpen, Plus, Clock, Search, ChevronRight, ChevronDown, FolderTree, Tag, X, MoreVertical, Archive, ArchiveRestore, Trash2, Sparkles } from 'lucide-react'
+import { FolderOpen, Plus, Clock, Search, ChevronRight, ChevronDown, FolderTree, Tag, X, MoreVertical, Archive, ArchiveRestore, Trash2, Sparkles, Workflow as WorkflowIcon } from 'lucide-react'
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
+import { pathsEqual } from '../../../shared/path-compare'
 import { useContextMenu, buildSessionContextMenu } from './context-menu'
 import { getSessionMenuPosition, type MenuPosition } from './session-menu-position'
+import { resolveRunSessionId } from '../utils/workflow-runs'
 
 export function SessionPanel(): React.JSX.Element {
   const sessionList = useAppStore((state) => state.sessionList)
@@ -17,6 +19,8 @@ export function SessionPanel(): React.JSX.Element {
   const archivedSessions = useAppStore((state) => state.archivedSessions)
   const showArchived = useAppStore((state) => state.showArchived)
   const toggleShowArchived = useAppStore((state) => state.toggleShowArchived)
+  const sessionsScope = useAppStore((state) => state.sessionsScope)
+  const setSessionsScope = useAppStore((state) => state.setSessionsScope)
   const ensureAutoTags = useAppStore((state) => state.ensureAutoTags)
   const settings = useAppStore((state) => state.settings)
   const toggleSessionGroupCollapsed = useAppStore((state) => state.toggleSessionGroupCollapsed)
@@ -32,7 +36,6 @@ export function SessionPanel(): React.JSX.Element {
   }, [sessionList, ensureAutoTags])
 
   const [searchQuery, setSearchQuery] = useState('')
-  const [showAllProjects, setShowAllProjects] = useState(true)
 
   // Collapsed project groups are persisted in settings so the layout survives
   // navigating away and app restarts.
@@ -45,13 +48,18 @@ export function SessionPanel(): React.JSX.Element {
     return sessionList.filter((s) => s.sessionId in archivedSessions).length
   }, [sessionList, archivedSessions])
 
-  // Group sessions by project (after filtering by archive state)
+  // Group sessions by project (after filtering by archive state and the
+  // All Sessions / Current Only scope). The scope lives in the store so it
+  // survives panel remounts and can be set by sidebar entry points.
   const groupedSessions = useMemo(() => {
     const groups = new Map<string, SessionListItem[]>()
+    const scopedToCurrent = sessionsScope === 'current'
+    const activePath = activeWorkspace?.path
 
     for (const session of sessionList) {
       const isArchived = session.sessionId in archivedSessions
       if (isArchived && !showArchived) continue
+      if (scopedToCurrent && (!activePath || !pathsEqual(session.projectPath, activePath))) continue
 
       const key = session.projectPath || 'unknown'
       if (!groups.has(key)) groups.set(key, [])
@@ -66,7 +74,7 @@ export function SessionPanel(): React.JSX.Element {
     })
 
     return sorted
-  }, [sessionList, archivedSessions, showArchived])
+  }, [sessionList, archivedSessions, showArchived, sessionsScope, activeWorkspace?.path])
 
   // Filter by search
   const filteredGroups = useMemo(() => {
@@ -95,7 +103,7 @@ export function SessionPanel(): React.JSX.Element {
     void toggleSessionGroupCollapsed(project)
   }
 
-  const totalSessions = sessionList.length
+  const totalSessions = groupedSessions.reduce((total, [, sessions]) => total + sessions.length, 0)
   const totalProjects = groupedSessions.length
 
   return (
@@ -140,15 +148,21 @@ export function SessionPanel(): React.JSX.Element {
             />
           </div>
           <button
-            onClick={() => setShowAllProjects(!showAllProjects)}
+            onClick={() => setSessionsScope(sessionsScope === 'current' ? 'all' : 'current')}
+            aria-pressed={sessionsScope === 'current'}
+            title={
+              sessionsScope === 'current'
+                ? 'Show sessions from every project'
+                : 'Only show sessions from the current project'
+            }
             className={clsx(
               'rounded-md px-3 py-2 text-xs transition-colors',
-              showAllProjects
+              sessionsScope === 'all'
                 ? 'bg-accent-bg text-accent-fg'
                 : 'bg-card text-muted hover:text-secondary'
             )}
           >
-            {showAllProjects ? 'All Projects' : 'Current Only'}
+            {sessionsScope === 'all' ? 'All Sessions' : 'Current Only'}
           </button>
           <button
             onClick={toggleShowArchived}
@@ -175,14 +189,21 @@ export function SessionPanel(): React.JSX.Element {
           </div>
         )}
 
-        {/* Sessions grouped by project */}
+        {/* Sessions grouped by project. Current Only is intentionally a flat,
+            non-collapsible project view; grouping remains useful in All Sessions. */}
         {filteredGroups.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 text-dim">
             <FolderOpen size={32} className="mb-3 text-faint" />
             <p className="text-sm">
-              {searchQuery ? 'No sessions match your search' : 'No sessions yet'}
+              {searchQuery
+                ? 'No sessions match your search'
+                : sessionsScope === 'current' && activeWorkspace
+                  ? 'No sessions in this project yet'
+                  : sessionsScope === 'current'
+                    ? 'Open a project to see its sessions'
+                    : 'No sessions yet'}
             </p>
-            {!searchQuery && (
+            {!searchQuery && sessionsScope !== 'current' && (
               <button
                 onClick={createNewSession}
                 className="mt-3 text-sm text-accent-fg/80 hover:text-accent-fg"
@@ -194,64 +215,98 @@ export function SessionPanel(): React.JSX.Element {
         ) : (
           <div className="space-y-2">
             {filteredGroups.map(([projectPath, sessions]) => {
-              // Default expanded; collapse only when the user has collapsed this
-              // group. An active search force-expands so matches stay visible.
-              const isExpanded = searchQuery.trim() !== '' || !collapsedGroups.has(projectPath)
-              const isCurrentProject = projectPath === activeWorkspace?.path
+              const projectScoped = sessionsScope === 'current'
+              // Current Only always shows its sessions. All Sessions keeps the
+              // persisted collapse preference and expands search matches.
+              const isExpanded = projectScoped || searchQuery.trim() !== '' || !collapsedGroups.has(projectPath)
               const projectName = sessions[0]?.projectName ?? 'Unknown'
               const latestSession = sessions[0]
+              const isCurrentProject = !!activeWorkspace && pathsEqual(projectPath, activeWorkspace.path)
 
               return (
                 <div
                   key={projectPath}
                   className={clsx(
-                    'rounded-lg border overflow-hidden',
+                    'overflow-hidden rounded-lg border',
                     isCurrentProject
                       ? 'border-accent-bg bg-accent-bg'
                       : 'border-border bg-surface/30'
                   )}
                 >
                   {/* Project header */}
-                  <button
-                    onClick={() => toggleProject(projectPath)}
-                    className="flex w-full items-center gap-2 px-4 py-2.5 hover:bg-surface-hover/30 transition-colors"
-                  >
-                    {isExpanded ? (
-                      <ChevronDown size={14} className="text-dim shrink-0" />
-                    ) : (
-                      <ChevronRight size={14} className="text-dim shrink-0" />
-                    )}
-                    <FolderTree
-                      size={14}
-                      className={clsx(
-                        'shrink-0',
-                        isCurrentProject ? 'text-accent-fg' : 'text-dim'
-                      )}
-                    />
-                    <div className="min-w-0 flex-1 text-left">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-primary">
-                          {projectName}
-                        </span>
-                        {isCurrentProject && (
-                          <span className="rounded bg-accent-bg px-1.5 py-0.5 text-[10px] text-accent-fg">
-                            current
-                          </span>
+                  {projectScoped ? (
+                    <div className="flex items-center gap-2 px-4 py-2.5">
+                      <FolderTree
+                        size={14}
+                        className={clsx(
+                          'shrink-0',
+                          isCurrentProject ? 'text-accent-fg' : 'text-dim'
                         )}
-                        <span className="text-xs text-faint">
-                          {sessions.length} session{sessions.length !== 1 ? 's' : ''}
-                        </span>
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-primary">
+                            {projectName}
+                          </span>
+                          {isCurrentProject && (
+                            <span className="rounded bg-accent-bg px-1.5 py-0.5 text-[10px] text-accent-fg">
+                              current
+                            </span>
+                          )}
+                          <span className="text-xs text-faint">
+                            {sessions.length} session{sessions.length !== 1 ? 's' : ''}
+                          </span>
+                        </div>
+                        <div className="truncate text-[11px] text-faint">
+                          {projectPath}
+                        </div>
                       </div>
-                      <div className="text-[11px] text-faint truncate">
-                        {projectPath}
+                      <div className="shrink-0 text-[10px] text-faint">
+                        {formatRelativeTime(latestSession.lastModified)}
                       </div>
                     </div>
-                    <div className="text-[10px] text-faint shrink-0">
-                      {formatRelativeTime(latestSession.lastModified)}
-                    </div>
-                  </button>
+                  ) : (
+                    <button
+                      onClick={() => void toggleProject(projectPath)}
+                      className="flex w-full items-center gap-2 px-4 py-2.5 transition-colors hover:bg-surface-hover/30"
+                      aria-expanded={isExpanded}
+                    >
+                      {isExpanded ? (
+                        <ChevronDown size={14} className="shrink-0 text-dim" />
+                      ) : (
+                        <ChevronRight size={14} className="shrink-0 text-dim" />
+                      )}
+                      <FolderTree
+                        size={14}
+                        className={clsx(
+                          'shrink-0',
+                          isCurrentProject ? 'text-accent-fg' : 'text-dim'
+                        )}
+                      />
+                      <div className="min-w-0 flex-1 text-left">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-primary">
+                            {projectName}
+                          </span>
+                          {isCurrentProject && (
+                            <span className="rounded bg-accent-bg px-1.5 py-0.5 text-[10px] text-accent-fg">
+                              current
+                            </span>
+                          )}
+                          <span className="text-xs text-faint">
+                            {sessions.length} session{sessions.length !== 1 ? 's' : ''}
+                          </span>
+                        </div>
+                        <div className="truncate text-[11px] text-faint">
+                          {projectPath}
+                        </div>
+                      </div>
+                      <div className="shrink-0 text-[10px] text-faint">
+                        {formatRelativeTime(latestSession.lastModified)}
+                      </div>
+                    </button>
+                  )}
 
-                  {/* Sessions in this project */}
                   {isExpanded && (
                     <div className="border-t border-border/50">
                       {sessions.map((session) => (
@@ -311,6 +366,7 @@ function SessionEntry({
   const archiveSession = useAppStore((state) => state.archiveSession)
   const unarchiveSession = useAppStore((state) => state.unarchiveSession)
   const deleteSession = useAppStore((state) => state.deleteSession)
+  const openWorkflowRunsForSession = useAppStore((state) => state.openWorkflowRunsForSession)
 
   const tags = sessionTags[session.sessionId] ?? []
   const autoTag = autoTags[session.sessionId]
@@ -363,7 +419,7 @@ function SessionEntry({
     setMenuPosition(getSessionMenuPosition({
       triggerRect: rect,
       menuWidth: 150,
-      menuHeight: 74,
+      menuHeight: 112,
       viewportWidth: window.innerWidth,
       viewportHeight: window.innerHeight,
     }))
@@ -412,6 +468,7 @@ function SessionEntry({
         // Use the inline confirmation row in this surface (UX matches the
         // existing flow) instead of a window.confirm.
         onDelete: () => setConfirmingDelete(true),
+        onRuns: (s) => openWorkflowRunsForSession(resolveRunSessionId(s.piSessionId, s.sessionId) ?? s.sessionId),
       })
     )
   }
@@ -527,6 +584,15 @@ function SessionEntry({
           className="fixed z-[9999] min-w-[150px] rounded-md border border-border-strong bg-surface py-1 text-sm shadow-xl shadow-black/40"
           style={{ left: menuPosition.x, top: menuPosition.y }}
         >
+          <button
+            onClick={() => {
+              setMenuOpen(false)
+              openWorkflowRunsForSession(resolveRunSessionId(session.piSessionId, session.sessionId) ?? session.sessionId)
+            }}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-secondary hover:bg-surface-hover"
+          >
+            <WorkflowIcon size={13} /> Workflow runs
+          </button>
           <button
             onClick={handleArchive}
             className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-secondary hover:bg-surface-hover"

--- a/src/renderer/src/components/session-runtime-indicator.tsx
+++ b/src/renderer/src/components/session-runtime-indicator.tsx
@@ -1,0 +1,23 @@
+import { AlertCircle, CheckCircle2, Loader2, XCircle } from 'lucide-react'
+import type { SessionRuntimeInfo } from '../../../shared/ipc-contracts'
+
+export function SessionRuntimeIndicator({ runtime }: { runtime: SessionRuntimeInfo }): React.JSX.Element | null {
+  const working = runtime.activity === 'working' || runtime.status === 'starting'
+  const needsApproval = runtime.activity === 'needs-approval'
+  const completed = runtime.activity === 'completed'
+  const failed = runtime.activity === 'failed' || runtime.status === 'error'
+
+  if (working) {
+    return <Loader2 size={12} className="shrink-0 animate-spin text-accent-fg" aria-label="Pi is working" />
+  }
+  if (needsApproval) {
+    return <AlertCircle size={12} className="shrink-0 text-warning" aria-label="Pi is waiting for approval" />
+  }
+  if (completed) {
+    return <CheckCircle2 size={12} className="shrink-0 text-success" aria-label="Pi finished" />
+  }
+  if (failed) {
+    return <XCircle size={12} className="shrink-0 text-error" aria-label="Pi stopped with an error" />
+  }
+  return null
+}

--- a/src/renderer/src/components/settings-panel.tsx
+++ b/src/renderer/src/components/settings-panel.tsx
@@ -228,7 +228,7 @@ export function SettingsPanel(): React.JSX.Element {
   }, [settings])
 
   const handleSelectPath = async () => {
-    const path = await window.piDesktop.system.openDialog({ title: 'Select Pi Executable', mode: 'file' })
+    const path = await window.piDesktop.system.openDialog({ title: 'Select Agent Executable', mode: 'file' })
     if (path) {
       setPiPath(path)
       setSettingsDraft({ piExecutablePath: path })
@@ -533,11 +533,11 @@ export function SettingsPanel(): React.JSX.Element {
           </div>
         </div>
 
-        {/* Pi Configuration */}
-        <SettingsSection title="Pi Configuration">
+        {/* Agent Configuration */}
+        <SettingsSection title="Agent Configuration">
           <SettingsRow
-            label="Pi Executable"
-            description="Path to Pi's cli.js or its install directory. Leave as 'pi' to auto-detect."
+            label="Agent Executable"
+            description="Path to Pi/OMP, their cli.js, or an install directory. Use 'pi' or 'omp' to select an installed engine."
           >
             <div className="flex gap-2">
               <input

--- a/src/renderer/src/components/settings-panel.tsx
+++ b/src/renderer/src/components/settings-panel.tsx
@@ -2,6 +2,7 @@ import { useAppStore } from '../store'
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { clsx } from 'clsx'
 import type {
+  AgentInstallation,
   AppSettings,
   PermissionMode,
   CouncilConfig,
@@ -10,7 +11,7 @@ import type {
   PermissionRulesWorkspaceStatus,
 } from '../../../shared/ipc-contracts'
 import type { ThemeFile } from '../../../shared/theme/theme-file'
-import { Settings, Save, RotateCcw, FolderOpen, Check, ChevronDown } from 'lucide-react'
+import { Settings, Save, RotateCcw, FolderOpen, RefreshCw, Check, ChevronDown } from 'lucide-react'
 import { DEFAULT_SETTINGS } from '../../../shared/default-settings'
 import { PermissionSelector } from './permission-selector'
 import { PermissionRulesEditor } from './permission-rules-editor'
@@ -58,7 +59,14 @@ export function SettingsPanel(): React.JSX.Element {
   // what makes edits survive leaving/returning to Settings without saving.
   const draft0 = useAppStore.getState().settingsDraft
 
-  const [piPath, setPiPath] = useState(draft0.piExecutablePath ?? settings?.piExecutablePath ?? DEFAULT_SETTINGS.piExecutablePath)
+  const initialPiPath = draft0.piExecutablePath ?? settings?.piExecutablePath ?? DEFAULT_SETTINGS.piExecutablePath
+  const [piPath, setPiPath] = useState(initialPiPath)
+  const [customAgentPathMode, setCustomAgentPathMode] = useState(() => {
+    const normalized = initialPiPath.trim().toLowerCase()
+    return Boolean(initialPiPath.trim()) && normalized !== 'pi' && normalized !== 'omp'
+  })
+  const [detectedAgentInstalls, setDetectedAgentInstalls] = useState<AgentInstallation[]>([])
+  const [scanningAgentInstalls, setScanningAgentInstalls] = useState(false)
   const [theme, setTheme] = useState(draft0.theme ?? settings?.theme ?? DEFAULT_SETTINGS.theme)
   const [themeActionError, setThemeActionError] = useState<string | null>(null)
   const [themeEditorState, setThemeEditorState] = useState<{
@@ -99,6 +107,23 @@ export function SettingsPanel(): React.JSX.Element {
   // Free-text draft for the timeout field so the user can clear it and type a
   // new value; it is clamped and persisted only on blur / Enter (not per keystroke).
   const [timeoutDraft, setTimeoutDraft] = useState('')
+
+  const scanAgentInstallations = useCallback(async (): Promise<void> => {
+    setScanningAgentInstalls(true)
+    try {
+      const result = await window.piDesktop.pi.detectInstallations()
+      setDetectedAgentInstalls(result.installations)
+    } catch {
+      setDetectedAgentInstalls([])
+    } finally {
+      setScanningAgentInstalls(false)
+    }
+  }, [])
+
+  // Detect available agent engines on mount.
+  useEffect(() => {
+    void scanAgentInstallations()
+  }, [scanAgentInstallations])
 
   // Detect available council agents on mount
   useEffect(() => {
@@ -212,7 +237,10 @@ export function SettingsPanel(): React.JSX.Element {
     didInitRef.current = true
     const store = useAppStore.getState()
     const draft = store.settingsDraft
-    setPiPath(draft.piExecutablePath ?? settings.piExecutablePath)
+    const nextPiPath = draft.piExecutablePath ?? settings.piExecutablePath
+    setPiPath(nextPiPath)
+    const normalizedPiPath = nextPiPath.trim().toLowerCase()
+    setCustomAgentPathMode(Boolean(nextPiPath.trim()) && normalizedPiPath !== 'pi' && normalizedPiPath !== 'omp')
     setTheme(draft.theme ?? settings.theme)
     setFontSize(draft.fontSize ?? settings.fontSize)
     setTerminalFontSize(draft.terminalFontSize ?? settings.terminalFontSize)
@@ -227,13 +255,41 @@ export function SettingsPanel(): React.JSX.Element {
     setPermissionMode(draft.permissionMode ?? settings.permissionMode)
   }, [settings])
 
-  const handleSelectPath = async () => {
-    const path = await window.piDesktop.system.openDialog({ title: 'Select Agent Executable', mode: 'file' })
-    if (path) {
-      setPiPath(path)
-      setSettingsDraft({ piExecutablePath: path })
-    }
+  const setAgentPath = (path: string, custom = true): void => {
+    setPiPath(path)
+    setCustomAgentPathMode(custom)
+    setSettingsDraft({ piExecutablePath: path })
   }
+
+  const handleAgentSelection = (value: string): void => {
+    if (value === '__auto__') {
+      setAgentPath('pi', false)
+      return
+    }
+    if (value === '__custom__') {
+      if (!customAgentPathMode) setAgentPath('', true)
+      return
+    }
+    setAgentPath(value, false)
+  }
+
+  const handleSelectPath = async (): Promise<void> => {
+    const path = await window.piDesktop.system.openDialog({ title: 'Select Agent Executable', mode: 'file' })
+    if (path) setAgentPath(path)
+  }
+
+  const autoAgentSelection = !customAgentPathMode && (piPath.trim().toLowerCase() === 'pi' || piPath.trim() === '')
+  const detectedAgentSelection = !customAgentPathMode && detectedAgentInstalls.some((installation) => installation.path === piPath)
+  const agentSelection = customAgentPathMode
+    ? '__custom__'
+    : autoAgentSelection
+      ? '__auto__'
+      : detectedAgentSelection
+        ? piPath
+        : piPath.trim().toLowerCase() === 'omp' && !detectedAgentInstalls.some((installation) => installation.kind === 'omp')
+          ? 'omp'
+          : '__custom__'
+  const showCustomAgentPath = customAgentPathMode || agentSelection === 'omp'
 
   const resolveEffectiveThemeId = (themeId: string): string => {
     if (themeId !== 'system') return themeId
@@ -493,6 +549,7 @@ export function SettingsPanel(): React.JSX.Element {
     }
 
     setPiPath(defaults.piExecutablePath!)
+    setCustomAgentPathMode(false)
     setTheme(defaults.theme!)
     setFontSize(defaults.fontSize!)
     setTerminalFontSize(defaults.terminalFontSize!)
@@ -536,25 +593,58 @@ export function SettingsPanel(): React.JSX.Element {
         {/* Agent Configuration */}
         <SettingsSection title="Agent Configuration">
           <SettingsRow
-            label="Agent Executable"
-            description="Path to Pi/OMP, their cli.js, or an install directory. Use 'pi' or 'omp' to select an installed engine."
+            label="Agent Installation"
+            description="Auto-detect Pi and OMP, choose an installed engine, or use a custom executable/path."
+            stack
           >
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={piPath}
-                onChange={(e) => {
-                  setPiPath(e.target.value)
-                  setSettingsDraft({ piExecutablePath: e.target.value })
-                }}
-                className="flex-1 rounded-md border border-border-strong bg-surface px-3 py-1.5 text-sm text-primary focus:border-focus focus:outline-none"
-              />
-              <button
-                onClick={handleSelectPath}
-                className="rounded-md border border-border-strong px-3 py-1.5 text-sm text-muted hover:bg-surface-hover transition-colors"
-              >
-                <FolderOpen size={14} />
-              </button>
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-2">
+                <select
+                  value={agentSelection}
+                  onChange={(e) => handleAgentSelection(e.target.value)}
+                  className="min-w-0 flex-1 appearance-none rounded-md border border-border-strong bg-surface px-3 py-1.5 text-sm text-primary hover:border-border-strong-hover focus:border-focus focus:outline-none"
+                >
+                  <option value="__auto__">Auto-detect (Pi first, then OMP)</option>
+                  {detectedAgentInstalls.map((installation) => (
+                    <option key={`${installation.kind}:${installation.path}`} value={installation.path}>
+                      {installation.kind === 'omp' ? 'OMP' : 'Pi'} — {installation.path}
+                    </option>
+                  ))}
+                  {agentSelection === 'omp' && <option value="omp">OMP (not found)</option>}
+                  <option value="__custom__">Custom path…</option>
+                </select>
+                <button
+                  onClick={handleSelectPath}
+                  title="Choose executable or install directory"
+                  className="rounded-md border border-border-strong px-3 py-1.5 text-sm text-muted hover:bg-surface-hover transition-colors"
+                >
+                  <FolderOpen size={14} />
+                </button>
+                <button
+                  onClick={() => void scanAgentInstallations()}
+                  disabled={scanningAgentInstalls}
+                  title="Rescan installed agents"
+                  className="rounded-md border border-border-strong px-3 py-1.5 text-sm text-muted hover:bg-surface-hover transition-colors disabled:opacity-50"
+                >
+                  <RefreshCw size={14} className={scanningAgentInstalls ? 'animate-spin' : undefined} />
+                </button>
+              </div>
+              {showCustomAgentPath && (
+                <input
+                  type="text"
+                  value={piPath === 'pi' || piPath === 'omp' ? '' : piPath}
+                  onChange={(e) => setAgentPath(e.target.value)}
+                  placeholder="Path to executable, cli.js, or install directory"
+                  className="w-full rounded-md border border-border-strong bg-surface px-3 py-1.5 text-sm text-primary focus:border-focus focus:outline-none"
+                />
+              )}
+              <div className="text-xs text-dim">
+                {scanningAgentInstalls
+                  ? 'Scanning common install locations and PATH…'
+                  : detectedAgentInstalls.length > 0
+                    ? `${detectedAgentInstalls.length} installed engine${detectedAgentInstalls.length === 1 ? '' : 's'} detected`
+                    : 'No Pi or OMP installation detected yet'}
+              </div>
             </div>
           </SettingsRow>
         </SettingsSection>

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   PanelLeftClose,
   Clock,
   Activity,
+  LayoutDashboard,
   Package,
   Layers,
   ChevronDown,
@@ -56,6 +57,7 @@ export function Sidebar(): React.JSX.Element {
   const sessionRuntimes = useAppStore((state) => state.sessionRuntimes)
   const activeSessionRuntimeId = useAppStore((state) => state.activeSessionRuntimeId)
   const createNewSession = useAppStore((state) => state.createNewSession)
+  const setTaskLauncherOpen = useAppStore((state) => state.setTaskLauncherOpen)
   const openFolderAsWorkspace = useAppStore((state) => state.openFolderAsWorkspace)
   const openWorkflowRunsForSession = useAppStore((state) => state.openWorkflowRunsForSession)
   const openWorkflowRunsForWorkspace = useAppStore((state) => state.openWorkflowRunsForWorkspace)
@@ -503,6 +505,13 @@ export function Sidebar(): React.JSX.Element {
               }}
               title="Sessions in this project"
             />
+            <SidebarItem
+              icon={<Plus size={14} />}
+              label="New task"
+              active={false}
+              onClick={() => setTaskLauncherOpen(true)}
+              title="Start a task in a new Pi session"
+            />
           </div>
         </div>
         <div>
@@ -513,6 +522,16 @@ export function Sidebar(): React.JSX.Element {
             )}
           </div>
           <div className="space-y-0.5">
+            <SidebarItem
+              icon={<LayoutDashboard size={14} />}
+              label="Mission Control"
+              active={currentView === 'mission-control'}
+              onClick={() => {
+                setWorkflowPanelOpen(false)
+                setCurrentView('mission-control')
+              }}
+              title="All background sessions and workflows"
+            />
             <SidebarItem
               icon={<WorkflowIcon size={14} />}
               label="Workflows"

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Sparkles,
   Stethoscope,
   Pencil,
+  Workflow as WorkflowIcon,
 } from 'lucide-react'
 import { useMemo, useState, useRef } from 'react'
 import { StatusPopover } from './status-popover'
@@ -29,6 +30,7 @@ import { getSessionRowLabels } from './sidebar-session-labels'
 import { ResizeHandle } from './resize-handle'
 import { getSessionTitle } from '../utils/session-title'
 import { formatRelativeTime } from '../utils/format-relative-time'
+import { resolveRunSessionId } from '../utils/workflow-runs'
 import { clampSidebarWidth, resolveSidebarWidth } from '../../../shared/sidebar-width'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
 
@@ -51,6 +53,14 @@ export function Sidebar(): React.JSX.Element {
   const sessionState = useAppStore((state) => state.sessionState)
   const sessionList = useAppStore((state) => state.sessionList)
   const createNewSession = useAppStore((state) => state.createNewSession)
+  const openFolderAsWorkspace = useAppStore((state) => state.openFolderAsWorkspace)
+  const openWorkflowRunsForSession = useAppStore((state) => state.openWorkflowRunsForSession)
+  const openWorkflowRunsForWorkspace = useAppStore((state) => state.openWorkflowRunsForWorkspace)
+  const setWorkflowPanelOpen = useAppStore((state) => state.setWorkflowPanelOpen)
+  const workflowPanelOpen = useAppStore((state) => state.workflowPanelOpen)
+  const workflowPanelWorkspaceId = useAppStore((state) => state.workflowPanelWorkspaceId)
+  const workflowPanelFilter = useAppStore((state) => state.workflowPanelFilter)
+  const setSessionsScope = useAppStore((state) => state.setSessionsScope)
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
   const archivedSessions = useAppStore((state) => state.archivedSessions)
   const archiveSession = useAppStore((state) => state.archiveSession)
@@ -203,6 +213,33 @@ export function Sidebar(): React.JSX.Element {
     }))
   }
 
+  const recentSessionsForWorkspace = useMemo(() => {
+    if (!activeWorkspace?.path) return []
+    return activeSessions
+      .filter((session) => pathsEqual(session.projectPath, activeWorkspace.path))
+      .sort((a, b) => b.lastModified - a.lastModified)
+      .slice(0, MAX_SESSIONS_PER_GROUP)
+  }, [activeSessions, activeWorkspace?.path])
+
+  const startNewSession = async (): Promise<void> => {
+    if (!activeWorkspace) {
+      setCurrentView('home')
+      return
+    }
+    setCurrentView('chat')
+    await createNewSession()
+  }
+
+  const openProject = async (): Promise<void> => {
+    const path = await window.piDesktop.system.openDialog({ title: 'Open Project' })
+    if (path) await openFolderAsWorkspace(path)
+  }
+
+  const openToolView = (view: 'packages' | 'notes' | 'skills' | 'diagnostics' | 'settings'): void => {
+    setWorkflowPanelOpen(false)
+    setCurrentView(view)
+  }
+
   // Workspace auto-switch/create + session switch + show Chat, shared with the
   // session panel and the quick switcher.
   const openSession = useAppStore((state) => state.openSessionItem)
@@ -223,6 +260,7 @@ export function Sidebar(): React.JSX.Element {
         onDelete: (s) => { deleteSession(s) },
         // Rename only offered for the active session (Pi renames the active one).
         onRename: isActive ? () => startSessionRename('recent') : undefined,
+        onRuns: (s) => openWorkflowRunsForSession(resolveRunSessionId(s.piSessionId, s.sessionId) ?? s.sessionId),
       })
     )
   }
@@ -246,6 +284,10 @@ export function Sidebar(): React.JSX.Element {
     options?: { nested?: boolean }
   ): React.JSX.Element => {
     const labels = getSessionRowLabels(session)
+    // Runs are keyed by Pi's header UUID, never the filename stem (the
+    // tags/archive registry key). The stem suffix IS the UUID, so it is a
+    // safe fallback when a row's header is unreadable.
+    const workflowSessionId = resolveRunSessionId(session.piSessionId, session.sessionId) ?? session.sessionId
     const isActive = sessionState?.sessionFile === session.path
     const nested = options?.nested ?? false
 
@@ -266,36 +308,49 @@ export function Sidebar(): React.JSX.Element {
     }
 
     return (
-      <button
-        key={session.path}
-        onClick={() => openSession(session)}
-        onDoubleClick={() => { if (isActive) startSessionRename('recent') }}
-        onContextMenu={(e) => handleSessionRightClick(e, session)}
-        // The full title leads, so a preview too long for the current width is
-        // still readable on hover.
-        title={`${labels.title}\n\n${isActive
-          ? 'Click to open · double-click to rename · right-click for actions'
-          : 'Click to open · right-click for actions'}`}
-        className={clsx(
-          'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
-          nested && 'pl-2',
-          isActive
-            ? 'bg-card text-primary'
-            : 'hover:bg-highlight text-muted hover:text-secondary'
-        )}
-      >
-        <Clock size={12} className="shrink-0" />
-        <div className="min-w-0 flex-1">
-          <div className="truncate">{labels.title}</div>
-          {/* The title is now the session's name or first message, so the time it
-              displaced moves here. Recent rows are already grouped by workspace,
-              which makes the project name the less useful of the two subtitles —
-              the home screen, which is not grouped, shows the project instead. */}
-          <div className="truncate text-[11px] text-faint">
-            {formatRelativeTime(session.lastModified, Date.now())}
+      <div key={session.path} className="group relative">
+        <button
+          onClick={() => openSession(session)}
+          onDoubleClick={() => { if (isActive) startSessionRename('recent') }}
+          onContextMenu={(e) => handleSessionRightClick(e, session)}
+          // The full title leads, so a preview too long for the current width is
+          // still readable on hover.
+          title={`${labels.title}\n\n${isActive
+            ? 'Click to open · double-click to rename · right-click for actions'
+            : 'Click to open · right-click for actions'}`}
+          className={clsx(
+            'flex w-full items-center gap-2 rounded px-2 py-1.5 pr-7 text-left text-sm transition-colors',
+            nested && 'pl-2',
+            isActive
+              ? 'bg-card text-primary'
+              : 'hover:bg-highlight text-muted hover:text-secondary'
+          )}
+        >
+          <Clock size={12} className="shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate">{labels.title}</div>
+            {/* The title is now the session's name or first message, so the time it
+                displaced moves here. Recent rows are already grouped by workspace,
+                which makes the project name the less useful of the two subtitles —
+                the home screen, which is not grouped, shows the project instead. */}
+            <div className="truncate text-[11px] text-faint">
+              {formatRelativeTime(session.lastModified, Date.now())}
+            </div>
           </div>
-        </div>
-      </button>
+        </button>
+        {/* Sibling (not child) of the row button, so no nested interactive
+            elements: the row's click/double-click/context-menu never fire for
+            this icon. Shows an empty filtered state when the session has no runs. */}
+        <button
+          type="button"
+          onClick={() => openWorkflowRunsForSession(workflowSessionId)}
+          className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-faint opacity-0 transition-opacity hover:bg-highlight hover:text-accent-fg focus-visible:opacity-100 group-hover:opacity-100"
+          title="Workflow runs for this session"
+          aria-label="Workflow runs for this session"
+        >
+          <WorkflowIcon size={12} />
+        </button>
+      </div>
     )
   }
 
@@ -360,6 +415,23 @@ export function Sidebar(): React.JSX.Element {
       <div className="flex h-12 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2">
           <StatusPopover />
+          {/* Compact Home replaces the duplicate Pi-activity popover: workspace
+              activity already lives in the switcher row, tab icons, and switcher
+              dropdown, so the header keeps only system status + Home. */}
+          <button
+            type="button"
+            onClick={() => setCurrentView('home')}
+            className={clsx(
+              'rounded p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus',
+              currentView === 'home'
+                ? 'bg-card text-accent-fg'
+                : 'text-muted hover:bg-surface-hover hover:text-primary'
+            )}
+            title="Home (Esc to launcher)"
+            aria-label="Home"
+          >
+            <Home size={16} />
+          </button>
           <span className="text-sm font-medium text-primary">Pi Desktop</span>
         </div>
         <button
@@ -372,76 +444,95 @@ export function Sidebar(): React.JSX.Element {
         </button>
       </div>
 
-      {/* Workspace switcher */}
-      <WorkspaceSwitcher />
-
-      {/* New session button */}
-      <div className="px-3 py-2">
-        <button
-          onClick={createNewSession}
-          className="flex w-full items-center gap-2 rounded-md bg-card px-3 py-2 text-sm text-primary hover:bg-elevated transition-colors"
-        >
-          <Plus size={14} />
-          New Session
-        </button>
+      {/* Project + primary action */}
+      <div className="border-b border-border pb-3">
+        <div className="flex items-center justify-between px-3 pt-3">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-faint">Project</div>
+          <button
+            type="button"
+            onClick={() => void openProject()}
+            className="rounded p-1 text-muted transition-colors hover:bg-highlight hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+            title="Open project folder (Ctrl/Cmd+O)"
+            aria-label="Open project folder"
+          >
+            <FolderOpen size={14} />
+          </button>
+        </div>
+        <WorkspaceSwitcher onOpenProject={() => void openProject()} />
+        <div className="px-3">
+          <button
+            type="button"
+            onClick={() => void startNewSession()}
+            disabled={!activeWorkspace}
+            className="group flex w-full items-center gap-2 rounded-lg bg-accent px-3 py-2.5 text-sm font-medium text-white shadow-sm shadow-accent/20 transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
+            title={activeWorkspace ? 'Start a new session in this project (Ctrl/Cmd+N)' : 'Open a project first'}
+          >
+            <Plus size={15} className="shrink-0 transition-transform group-hover:rotate-90" />
+            <span className="flex-1 text-left">New session</span>
+            <kbd className="rounded border border-white/20 bg-white/10 px-1.5 py-0.5 text-[10px] font-medium text-white/75">Ctrl N</kbd>
+          </button>
+          <div className="mt-1.5 px-1 text-[11px] text-faint">
+            {activeWorkspace ? `Starts in ${activeWorkspace.name}` : 'Open a project to begin'}
+          </div>
+        </div>
       </div>
 
       {/* Navigation */}
-      <nav className="space-y-0.5 px-2 py-1">
-        <SidebarItem
-          icon={<Home size={14} />}
-          label="Home"
-          active={currentView === 'home'}
-          onClick={() => setCurrentView('home')}
-        />
-        <SidebarItem
-          icon={<MessageSquare size={14} />}
-          label="Chat"
-          active={currentView === 'chat'}
-          onClick={() => setCurrentView('chat')}
-        />
-        <SidebarItem
-          icon={<FolderOpen size={14} />}
-          label="Sessions"
-          active={currentView === 'sessions'}
-          onClick={() => setCurrentView('sessions')}
-        />
-        <SidebarItem
-          icon={<Activity size={14} />}
-          label="Timeline"
-          active={currentView === 'timeline'}
-          onClick={() => setCurrentView('timeline')}
-        />
-        <SidebarItem
-          icon={<Package size={14} />}
-          label="Packages"
-          active={currentView === 'packages'}
-          onClick={() => setCurrentView('packages')}
-        />
-        <SidebarItem
-          icon={<StickyNote size={14} />}
-          label="Notes"
-          active={currentView === 'notes'}
-          onClick={() => setCurrentView('notes')}
-        />
-        <SidebarItem
-          icon={<Sparkles size={14} />}
-          label="Skills"
-          active={currentView === 'skills'}
-          onClick={() => setCurrentView('skills')}
-        />
-        <SidebarItem
-          icon={<Stethoscope size={14} />}
-          label="Diagnostics"
-          active={currentView === 'diagnostics'}
-          onClick={() => setCurrentView('diagnostics')}
-        />
-        <SidebarItem
-          icon={<Settings size={14} />}
-          label="Settings"
-          active={currentView === 'settings'}
-          onClick={() => setCurrentView('settings')}
-        />
+      <nav className="space-y-3 border-b border-border px-2 py-3">
+        <div>
+          <div className="mb-1 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-faint">Workspace</div>
+          <div className="space-y-0.5">
+            <SidebarItem
+              icon={<MessageSquare size={14} />}
+              label="Chat"
+              active={currentView === 'chat'}
+              onClick={() => setCurrentView('chat')}
+            />
+            <SidebarItem
+              icon={<FolderOpen size={14} />}
+              label="Sessions"
+              active={currentView === 'sessions'}
+              onClick={() => {
+                setSessionsScope('current')
+                setCurrentView('sessions')
+              }}
+              title="Sessions in this project"
+            />
+          </div>
+        </div>
+        <div>
+          <div className="mb-1 flex items-center gap-1 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-faint">
+            <span>Activity</span>
+            {activeWorkspace && (
+              <span className="min-w-0 truncate normal-case">· {activeWorkspace.name}</span>
+            )}
+          </div>
+          <div className="space-y-0.5">
+            <SidebarItem
+              icon={<WorkflowIcon size={14} />}
+              label="Workflows"
+              // Only highlighted when THIS project's scope is open, so it never
+              // fights the Tools' global "All Workflows" entry. With no project
+              // open the entry falls back to the global list (same as the old
+              // behavior) but stays unhighlighted.
+              active={
+                !!activeWorkspace &&
+                workflowPanelOpen &&
+                !workflowPanelFilter &&
+                workflowPanelWorkspaceId === activeWorkspace.id
+              }
+              onClick={() => openWorkflowRunsForWorkspace(activeWorkspace?.id ?? null)}
+              title={activeWorkspace ? `Workflow runs in ${activeWorkspace.name}` : 'All workflow runs (no project open)'}
+            />
+            <SidebarItem
+              icon={<Activity size={14} />}
+              label="Timeline"
+              active={currentView === 'timeline'}
+              onClick={() => setCurrentView('timeline')}
+              title={activeWorkspace ? `Timeline for ${activeWorkspace.name}` : 'Timeline'}
+            />
+          </div>
+        </div>
       </nav>
 
       {/* Current session info */}
@@ -456,37 +547,80 @@ export function Sidebar(): React.JSX.Element {
             <div className="mt-1 text-xs text-dim">{sessionState.messageCount} messages</div>
           </div>
         ) : (
-          <button
-            type="button"
-            onClick={() => setCurrentView('chat')}
-            onDoubleClick={() => startSessionRename('current')}
-            onContextMenu={handleCurrentSessionRightClick}
-            className="mx-3 mt-2 rounded-md bg-surface p-3 text-left transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-border-strong"
-            title="Open current session in chat · double-click to rename"
-          >
-            <div className="text-xs font-medium text-muted uppercase tracking-wider">Current Session</div>
-            <div className="mt-1.5 text-sm text-primary truncate">
-              {getSessionTitle(sessionState.sessionName, sessionState.sessionId)}
-            </div>
-            {sessionState.model && (
-              <div className="mt-1 text-xs text-dim">
-                {sessionState.model.name}
+          <div className="group relative mx-3 mt-2">
+            <button
+              type="button"
+              onClick={() => setCurrentView('chat')}
+              onDoubleClick={() => startSessionRename('current')}
+              onContextMenu={handleCurrentSessionRightClick}
+              className="w-full rounded-md bg-surface p-3 pr-9 text-left transition-colors hover:bg-surface-hover focus:outline-none focus:ring-1 focus:ring-border-strong"
+              title="Open current session in chat · double-click to rename"
+            >
+              <div className="text-xs font-medium text-muted uppercase tracking-wider">Current Session</div>
+              <div className="mt-1.5 text-sm text-primary truncate">
+                {getSessionTitle(sessionState.sessionName, sessionState.sessionId)}
               </div>
-            )}
-            <div className="mt-1 text-xs text-dim">
-              {sessionState.messageCount} messages
-            </div>
-          </button>
+              {sessionState.model && (
+                <div className="mt-1 text-xs text-dim">
+                  {sessionState.model.name}
+                </div>
+              )}
+              <div className="mt-1 text-xs text-dim">
+                {sessionState.messageCount} messages
+              </div>
+            </button>
+            {/* Sibling overlay — the panel above stays a single non-nested button. */}
+            <button
+              type="button"
+              onClick={() => openWorkflowRunsForSession(sessionState.sessionId)}
+              className="absolute right-2 top-3 rounded p-1.5 text-faint opacity-0 transition-opacity hover:bg-highlight hover:text-accent-fg focus-visible:opacity-100 group-hover:opacity-100"
+              title="Workflow runs for this session"
+              aria-label="Workflow runs for this session"
+            >
+              <WorkflowIcon size={13} />
+            </button>
+          </div>
         )
       )}
 
-      {/* Recent sessions — one dropdown per workspace */}
-      <div className="mt-4 flex-1 overflow-y-auto px-2">
-        <div className="px-2 py-1 text-xs font-medium text-dim uppercase tracking-wider">
-          Recent Sessions
+      {/* Recent sessions for the active project. Cross-project history stays in Sessions. */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-3">
+        <div className="mb-1 flex items-center justify-between px-2">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-faint">
+            {activeWorkspace ? `Recent in ${activeWorkspace.name}` : 'Recent sessions'}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setSessionsScope('all')
+              setCurrentView('sessions')
+            }}
+            className="text-[11px] text-muted transition-colors hover:text-accent-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+          >
+            View all
+          </button>
         </div>
-        {recentGroups.length === 0 ? (
-          <div className="px-2 py-2 text-xs text-faint">No sessions yet</div>
+        {activeWorkspace ? (
+          recentSessionsForWorkspace.length === 0 ? (
+            <div className="mx-2 mt-2 rounded-lg border border-dashed border-border px-3 py-4 text-center text-xs text-faint">
+              No sessions in this project yet.
+              <button
+                type="button"
+                onClick={() => void startNewSession()}
+                className="mt-1 block w-full text-accent-fg transition-colors hover:text-accent"
+              >
+                Start one now
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-0.5">
+              {recentSessionsForWorkspace.map((session) => renderSessionRow(session))}
+            </div>
+          )
+        ) : recentGroups.length === 0 ? (
+          <div className="mx-2 mt-2 rounded-lg border border-dashed border-border px-3 py-4 text-center text-xs text-faint">
+            Open a project to see its sessions.
+          </div>
         ) : (
           recentGroups.map(renderRecentGroup)
         )}
@@ -514,6 +648,60 @@ export function Sidebar(): React.JSX.Element {
           )}
         </div>
       )}
+
+      {/* Secondary tools stay available without competing with project/session work. */}
+      <div className="shrink-0 border-t border-border px-2 py-2">
+        <div className="mb-1 px-3 text-[10px] font-semibold uppercase tracking-[0.14em] text-faint">Tools</div>
+        <div className="grid grid-cols-2 gap-0.5">
+          <SidebarItem
+            compact
+            icon={<Package size={13} />}
+            label="Packages"
+            active={currentView === 'packages'}
+            onClick={() => openToolView('packages')}
+          />
+          <SidebarItem
+            compact
+            icon={<StickyNote size={13} />}
+            label="Notes"
+            active={currentView === 'notes'}
+            onClick={() => openToolView('notes')}
+          />
+          <SidebarItem
+            compact
+            icon={<Sparkles size={13} />}
+            label="Skills"
+            active={currentView === 'skills'}
+            onClick={() => openToolView('skills')}
+          />
+          <SidebarItem
+            compact
+            icon={<Stethoscope size={13} />}
+            label="Diagnostics"
+            active={currentView === 'diagnostics'}
+            onClick={() => openToolView('diagnostics')}
+          />
+          {/* Global workflow list lives here — "browse everything" territory —
+              so the Activity section stays scoped to the current project. */}
+          <SidebarItem
+            compact
+            icon={<WorkflowIcon size={13} />}
+            label="All Workflows"
+            // Highlighted only when the global scope is open (never alongside
+            // the Activity entry, whose active state requires a workspace id).
+            active={workflowPanelOpen && !workflowPanelFilter && workflowPanelWorkspaceId === null}
+            onClick={() => openWorkflowRunsForWorkspace(null)}
+            title="Workflow runs from every project"
+          />
+          <SidebarItem
+            compact
+            icon={<Settings size={13} />}
+            label="Settings"
+            active={currentView === 'settings'}
+            onClick={() => openToolView('settings')}
+          />
+        </div>
+      </div>
       {SessionMenu}
     </aside>
     <ResizeHandle
@@ -526,11 +714,10 @@ export function Sidebar(): React.JSX.Element {
 
 // ─── Workspace Switcher ──────────────────────────────────────────────────────
 
-function WorkspaceSwitcher(): React.JSX.Element {
+function WorkspaceSwitcher({ onOpenProject }: { onOpenProject: () => void }): React.JSX.Element {
   const workspaces = useAppStore((state) => state.workspaces)
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
   const switchWorkspace = useAppStore((state) => state.switchWorkspace)
-  const createWorkspace = useAppStore((state) => state.createWorkspace)
   const removeWorkspace = useAppStore((state) => state.removeWorkspace)
   const renameWorkspace = useAppStore((state) => state.renameWorkspace)
   const changeWorkspaceFolder = useAppStore((state) => state.changeWorkspaceFolder)
@@ -552,18 +739,8 @@ function WorkspaceSwitcher(): React.JSX.Element {
   )
 
   const [isOpen, setIsOpen] = useState(false)
-  const [isCreating, setIsCreating] = useState(false)
   const [isRenaming, setIsRenaming] = useState(false)
   const [newName, setNewName] = useState('')
-  const [newPath, setNewPath] = useState('')
-
-  const handleCreate = async () => {
-    if (!newName.trim() || !newPath.trim()) return
-    await createWorkspace(newName.trim(), newPath.trim())
-    setNewName('')
-    setNewPath('')
-    setIsCreating(false)
-  }
 
   const handleRename = async () => {
     if (!activeWorkspace || !newName.trim()) return
@@ -606,11 +783,6 @@ function WorkspaceSwitcher(): React.JSX.Element {
     ])
   }
 
-  const handleSelectFolder = async () => {
-    const path = await window.piDesktop.system.openDialog({ title: 'Select Workspace Folder' })
-    if (path) setNewPath(path)
-  }
-
   return (
     <div className="px-3 py-2">
       {/* Current workspace */}
@@ -643,9 +815,14 @@ function WorkspaceSwitcher(): React.JSX.Element {
           title="Click to switch · double-click to rename · right-click for options"
           className="flex w-full items-center justify-between rounded-md px-3 py-2 text-sm text-primary hover:bg-surface-hover transition-colors"
         >
-          <div className="flex items-center gap-2 min-w-0">
-            <Layers size={14} style={{ color: activeWorkspace?.color ?? '#6b7280' }} />
-            <span className="truncate">{activeWorkspace?.name ?? 'No workspace'}</span>
+          <div className="flex min-w-0 items-center gap-2 text-left">
+            <Layers size={14} className="shrink-0" style={{ color: activeWorkspace?.color ?? '#6b7280' }} />
+            <div className="min-w-0">
+              <div className="truncate text-sm">{activeWorkspace?.name ?? 'No workspace'}</div>
+              {activeWorkspace && (
+                <div className="truncate text-[10px] text-faint">{activeWorkspace.path}</div>
+              )}
+            </div>
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
             {backgroundActivity && (
@@ -740,57 +917,17 @@ function WorkspaceSwitcher(): React.JSX.Element {
             </div>
           ))}
 
-          {/* Create new */}
-          {isCreating ? (
-            <div className="border-t border-border px-3 py-2 space-y-2">
-              <input
-                type="text"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="Workspace name"
-                className="w-full rounded border border-border-strong bg-card px-2 py-1 text-xs text-primary placeholder:text-faint focus:border-focus focus:outline-none"
-                autoFocus
-              />
-              <div className="flex gap-1">
-                <input
-                  type="text"
-                  value={newPath}
-                  onChange={(e) => setNewPath(e.target.value)}
-                  placeholder="/path/to/project"
-                  className="flex-1 rounded border border-border-strong bg-card px-2 py-1 text-xs text-primary placeholder:text-faint focus:border-focus focus:outline-none"
-                />
-                <button
-                  onClick={handleSelectFolder}
-                  className="rounded border border-border-strong px-2 py-1 text-xs text-muted hover:bg-elevated"
-                >
-                  ...
-                </button>
-              </div>
-              <div className="flex gap-1">
-                <button
-                  onClick={handleCreate}
-                  disabled={!newName.trim() || !newPath.trim()}
-                  className="flex-1 rounded bg-accent px-2 py-1 text-xs text-white hover:bg-accent-hover disabled:opacity-50"
-                >
-                  Create
-                </button>
-                <button
-                  onClick={() => setIsCreating(false)}
-                  className="rounded px-2 py-1 text-xs text-muted hover:text-primary"
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button
-              onClick={() => setIsCreating(true)}
-              className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-xs text-muted hover:bg-surface-hover hover:text-secondary transition-colors"
-            >
-              <Plus size={12} />
-              Add Workspace
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => {
+              setIsOpen(false)
+              onOpenProject()
+            }}
+            className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-secondary"
+          >
+            <FolderOpen size={12} />
+            Open project…
+          </button>
         </div>
       )}
     </div>
@@ -804,24 +941,31 @@ function SidebarItem({
   label,
   active,
   onClick,
+  compact = false,
+  title,
 }: {
   icon: React.ReactNode
   label: string
   active: boolean
   onClick: () => void
+  compact?: boolean
+  title?: string
 }): React.JSX.Element {
   return (
     <button
+      type="button"
       onClick={onClick}
+      title={title}
       className={clsx(
-        'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+        'flex w-full items-center gap-2 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus',
+        compact ? 'px-2 py-1.5 text-xs' : 'px-3 py-2 text-sm',
         active
           ? 'bg-card text-primary'
-          : 'hover:bg-highlight text-muted hover:text-secondary'
+          : 'text-muted hover:bg-highlight hover:text-secondary'
       )}
     >
       {icon}
-      {label}
+      <span className="truncate">{label}</span>
     </button>
   )
 }

--- a/src/renderer/src/components/sidebar.tsx
+++ b/src/renderer/src/components/sidebar.tsx
@@ -30,6 +30,7 @@ import { getSessionRowLabels } from './sidebar-session-labels'
 import { ResizeHandle } from './resize-handle'
 import { getSessionTitle } from '../utils/session-title'
 import { formatRelativeTime } from '../utils/format-relative-time'
+import { SessionRuntimeIndicator } from './session-runtime-indicator'
 import { resolveRunSessionId } from '../utils/workflow-runs'
 import { clampSidebarWidth, resolveSidebarWidth } from '../../../shared/sidebar-width'
 import type { SessionListItem } from '../../../shared/ipc-contracts'
@@ -52,6 +53,8 @@ export function Sidebar(): React.JSX.Element {
   const toggleSidebar = useAppStore((state) => state.toggleSidebar)
   const sessionState = useAppStore((state) => state.sessionState)
   const sessionList = useAppStore((state) => state.sessionList)
+  const sessionRuntimes = useAppStore((state) => state.sessionRuntimes)
+  const activeSessionRuntimeId = useAppStore((state) => state.activeSessionRuntimeId)
   const createNewSession = useAppStore((state) => state.createNewSession)
   const openFolderAsWorkspace = useAppStore((state) => state.openFolderAsWorkspace)
   const openWorkflowRunsForSession = useAppStore((state) => state.openWorkflowRunsForSession)
@@ -288,7 +291,8 @@ export function Sidebar(): React.JSX.Element {
     // tags/archive registry key). The stem suffix IS the UUID, so it is a
     // safe fallback when a row's header is unreadable.
     const workflowSessionId = resolveRunSessionId(session.piSessionId, session.sessionId) ?? session.sessionId
-    const isActive = sessionState?.sessionFile === session.path
+    const runtime = Object.values(sessionRuntimes).find((item) => item.sessionPath && pathsEqual(item.sessionPath, session.path))
+    const isActive = sessionState?.sessionFile === session.path || runtime?.runtimeId === activeSessionRuntimeId
     const nested = options?.nested ?? false
 
     // Inline rename for the active row.
@@ -337,6 +341,7 @@ export function Sidebar(): React.JSX.Element {
               {formatRelativeTime(session.lastModified, Date.now())}
             </div>
           </div>
+          {runtime && <SessionRuntimeIndicator runtime={runtime} />}
         </button>
         {/* Sibling (not child) of the row button, so no nested interactive
             elements: the row's click/double-click/context-menu never fire for
@@ -717,7 +722,7 @@ export function Sidebar(): React.JSX.Element {
 function WorkspaceSwitcher({ onOpenProject }: { onOpenProject: () => void }): React.JSX.Element {
   const workspaces = useAppStore((state) => state.workspaces)
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
-  const switchWorkspace = useAppStore((state) => state.switchWorkspace)
+  const activateWorkspace = useAppStore((state) => state.activateWorkspace)
   const removeWorkspace = useAppStore((state) => state.removeWorkspace)
   const renameWorkspace = useAppStore((state) => state.renameWorkspace)
   const changeWorkspaceFolder = useAppStore((state) => state.changeWorkspaceFolder)
@@ -866,7 +871,7 @@ function WorkspaceSwitcher({ onOpenProject }: { onOpenProject: () => void }): Re
             >
               <button
                 onClick={() => {
-                  switchWorkspace(ws.id)
+                  void activateWorkspace(ws.id)
                   setIsOpen(false)
                 }}
                 className="flex items-center gap-2 min-w-0 flex-1 text-left"

--- a/src/renderer/src/components/status-bar.tsx
+++ b/src/renderer/src/components/status-bar.tsx
@@ -246,7 +246,10 @@ function ThinkingLevelSelector(): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
-  const levels = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
+  const modelEfforts = sessionState?.model?.thinking?.efforts?.filter((level) => typeof level === 'string' && level.length > 0)
+  const levels = modelEfforts && modelEfforts.length > 0
+    ? ['off', ...modelEfforts.filter((level) => level !== 'off')]
+    : ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
   const currentLevel = sessionState?.thinkingLevel ?? 'medium'
 
   // Close on click outside

--- a/src/renderer/src/components/status-bar.tsx
+++ b/src/renderer/src/components/status-bar.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
   Check,
   GitBranch,
+  Workflow as WorkflowIcon,
 } from 'lucide-react'
 
 export function StatusBar(): React.JSX.Element {
@@ -32,6 +33,13 @@ export function StatusBar(): React.JSX.Element {
   const isCompacting = useAppStore((state) => state.sessionState?.isCompacting ?? false)
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
   const pendingPromptCounts = useAppStore((state) => state.pendingPromptCounts)
+  const workflowPanelOpen = useAppStore((state) => state.workflowPanelOpen)
+  const workflowRuns = useAppStore((state) => state.workflowRuns)
+  const activeWorkflowCount = workflowRuns.filter(
+    (run) =>
+      (!activeWorkspace || run.workspaceId === activeWorkspace.id) &&
+      (run.status === 'running' || run.status === 'paused')
+  ).length
 
   // Blocking prompts held for OTHER workspaces (any extension's select/
   // confirm/input/editor) — the active workspace's prompt is already on screen.
@@ -125,6 +133,29 @@ export function StatusBar(): React.JSX.Element {
 
       {/* Right section */}
       <div className="flex items-center gap-3">
+        {/* Dedicated workflow navigator */}
+        <button
+          onClick={() => {
+            // Session-surface button: opens the active session's runs (scoped by
+            // Pi's header UUID, the exact identifier persisted runs carry). The
+            // global list is only a fallback for the no-session state; closing
+            // preserves the scope so a close/reopen stays in-session.
+            const state = useAppStore.getState()
+            if (state.workflowPanelOpen) state.setWorkflowPanelOpen(false)
+            else if (state.sessionState?.sessionId) state.openWorkflowRunsForSession(state.sessionState.sessionId)
+            else state.setWorkflowPanelOpen(true)
+          }}
+          className={clsx(
+            'flex items-center gap-1 transition-colors',
+            workflowPanelOpen || activeWorkflowCount > 0 ? 'text-accent-fg' : 'text-dim hover:text-secondary'
+          )}
+          title="Open workflow runs"
+          aria-label="Open workflow runs"
+        >
+          <WorkflowIcon size={11} />
+          <span>{activeWorkflowCount > 0 ? `${activeWorkflowCount} workflow${activeWorkflowCount === 1 ? '' : 's'}` : 'workflows'}</span>
+        </button>
+
         {/* Model selector */}
         <ModelSelector />
 

--- a/src/renderer/src/components/status-bar.tsx
+++ b/src/renderer/src/components/status-bar.tsx
@@ -246,7 +246,7 @@ function ThinkingLevelSelector(): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
-  const levels = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const
+  const levels = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const
   const currentLevel = sessionState?.thinkingLevel ?? 'medium'
 
   // Close on click outside

--- a/src/renderer/src/components/status-bar.tsx
+++ b/src/renderer/src/components/status-bar.tsx
@@ -1,18 +1,15 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useAppStore, countPromptsWaitingElsewhere, formatPromptsWaiting } from '../store'
-import { ModelSelector } from './model-selector'
 import { clsx } from 'clsx'
 import {
   PanelLeft,
   PanelLeftClose,
   Terminal,
-  Zap,
   DollarSign,
   Layers,
   Minimize2,
   Settings,
   Loader2,
-  Check,
   GitBranch,
   Workflow as WorkflowIcon,
 } from 'lucide-react'
@@ -156,12 +153,6 @@ export function StatusBar(): React.JSX.Element {
           <span>{activeWorkflowCount > 0 ? `${activeWorkflowCount} workflow${activeWorkflowCount === 1 ? '' : 's'}` : 'workflows'}</span>
         </button>
 
-        {/* Model selector */}
-        <ModelSelector />
-
-        {/* Thinking level */}
-        <ThinkingLevelSelector />
-
         {/* Token usage */}
         {sessionStats?.contextUsage && (
           <div className="flex items-center gap-1 text-dim" title={`Context: ${sessionStats.contextUsage.tokens?.toLocaleString() ?? '?'} / ${sessionStats.contextUsage.contextWindow.toLocaleString()} tokens`}>
@@ -232,75 +223,6 @@ export function StatusBar(): React.JSX.Element {
           <Settings size={12} />
         </button>
       </div>
-    </div>
-  )
-}
-
-// ─── Thinking Level Selector ─────────────────────────────────────────────────
-
-function ThinkingLevelSelector(): React.JSX.Element {
-  const sessionState = useAppStore((state) => state.sessionState)
-  const setThinkingLevel = useAppStore((state) => state.setThinkingLevel)
-  const piStatus = useAppStore((state) => state.piStatus)
-
-  const [isOpen, setIsOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
-  const modelEfforts = sessionState?.model?.thinking?.efforts?.filter((level) => typeof level === 'string' && level.length > 0)
-  const levels = modelEfforts && modelEfforts.length > 0
-    ? ['off', ...modelEfforts.filter((level) => level !== 'off')]
-    : ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
-  const currentLevel = sessionState?.thinkingLevel ?? 'medium'
-
-  // Close on click outside
-  useEffect(() => {
-    if (!isOpen) return
-
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClick)
-    return () => document.removeEventListener('mousedown', handleClick)
-  }, [isOpen])
-
-  if (piStatus !== 'running') return <></>
-
-  return (
-    <div ref={ref} className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1 text-dim hover:text-secondary transition-colors"
-        title="Thinking level"
-      >
-        <Zap size={10} />
-        <span>{currentLevel}</span>
-      </button>
-
-      {isOpen && (
-        <div className="absolute bottom-full right-0 mb-1 w-32 rounded-lg border border-border-strong bg-surface shadow-xl shadow-black/40 py-1 animate-fade-in z-50">
-          {levels.map((level) => (
-            <button
-              key={level}
-              onClick={() => {
-                setThinkingLevel(level)
-                setIsOpen(false)
-              }}
-              className={clsx(
-                'flex w-full items-center gap-2 px-3 py-1.5 text-xs text-left hover:bg-surface-hover transition-colors',
-                currentLevel === level
-                  ? 'text-primary'
-                  : 'text-muted'
-              )}
-            >
-              {currentLevel === level && <Check size={10} className="text-success" />}
-              <span className={currentLevel === level ? '' : 'ml-[18px]'}>{level}</span>
-            </button>
-          ))}
-        </div>
-      )}
     </div>
   )
 }

--- a/src/renderer/src/components/task-launcher.tsx
+++ b/src/renderer/src/components/task-launcher.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react'
+import { Layers, Play, X } from 'lucide-react'
+import { useAppStore } from '../store'
+
+export function TaskLauncher(): React.JSX.Element | null {
+  const open = useAppStore((state) => state.taskLauncherOpen)
+  const setOpen = useAppStore((state) => state.setTaskLauncherOpen)
+  const workspaces = useAppStore((state) => state.workspaces)
+  const activeWorkspace = useAppStore((state) => state.activeWorkspace)
+  const launchTask = useAppStore((state) => state.launchTask)
+  const [workspaceId, setWorkspaceId] = useState('')
+  const [prompt, setPrompt] = useState('')
+  const [busy, setBusy] = useState(false)
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setWorkspaceId(activeWorkspace?.id ?? workspaces[0]?.id ?? '')
+    setPrompt('')
+    requestAnimationFrame(() => inputRef.current?.focus())
+  }, [open, activeWorkspace?.id, workspaces])
+
+  if (!open) return null
+
+  const close = (): void => {
+    if (!busy) setOpen(false)
+  }
+
+  const submit = async (): Promise<void> => {
+    if (!workspaceId || !prompt.trim() || busy) return
+    setBusy(true)
+    const launched = await launchTask({ workspaceId, prompt })
+    setBusy(false)
+    if (launched) setOpen(false)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/45 px-4 pt-[12vh]"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) close()
+      }}
+      role="presentation"
+    >
+      <section
+        className="w-full max-w-xl overflow-hidden rounded-xl border border-border-strong bg-surface shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="task-launcher-title"
+      >
+        <div className="flex items-start justify-between border-b border-border px-5 py-4">
+          <div>
+            <div className="flex items-center gap-2">
+              <Play size={16} className="text-accent-fg" />
+              <h2 id="task-launcher-title" className="text-sm font-semibold text-primary">New task</h2>
+            </div>
+            <p className="mt-1 text-xs text-dim">Start a fresh Pi session and send the task immediately.</p>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            disabled={busy}
+            className="rounded p-1 text-faint transition-colors hover:bg-surface-hover hover:text-primary disabled:opacity-50"
+            aria-label="Close task launcher"
+          >
+            <X size={15} />
+          </button>
+        </div>
+
+        <div className="space-y-4 px-5 py-4">
+          <label className="block">
+            <span className="mb-1.5 block text-xs font-medium text-secondary">Project</span>
+            <span className="flex items-center gap-2 rounded-md border border-border bg-app px-3 py-2">
+              <Layers size={14} className="shrink-0 text-muted" />
+              <select
+                value={workspaceId}
+                onChange={(event) => setWorkspaceId(event.target.value)}
+                disabled={busy || workspaces.length === 0}
+                className="min-w-0 flex-1 bg-transparent text-sm text-primary outline-none"
+              >
+                {workspaces.length === 0 && <option value="">Open a project first</option>}
+                {workspaces.map((workspace) => (
+                  <option key={workspace.id} value={workspace.id}>{workspace.name}</option>
+                ))}
+              </select>
+            </span>
+          </label>
+
+          <label className="block">
+            <span className="mb-1.5 block text-xs font-medium text-secondary">Task</span>
+            <textarea
+              ref={inputRef}
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              onKeyDown={(event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                  event.preventDefault()
+                  void submit()
+                }
+              }}
+              placeholder="Fix the failing tests, explain the root cause, and prepare the changes for review…"
+              rows={6}
+              disabled={busy}
+              className="w-full resize-y rounded-md border border-border bg-app px-3 py-2 text-sm leading-relaxed text-primary outline-none placeholder:text-faint focus:border-focus"
+            />
+          </label>
+
+          <p className="text-[11px] text-faint">
+            The task runs in a new session and continues in the background if you switch away. Use the isolated Git tab button when file isolation is required.
+          </p>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-border bg-app/40 px-5 py-3">
+          <button
+            type="button"
+            onClick={close}
+            disabled={busy}
+            className="rounded-md px-3 py-1.5 text-xs text-muted transition-colors hover:bg-surface-hover hover:text-primary disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void submit()}
+            disabled={busy || !workspaceId || !prompt.trim()}
+            className="flex items-center gap-1.5 rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Play size={12} />
+            {busy ? 'Starting…' : 'Start task'}
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/renderer/src/components/task-launcher.tsx
+++ b/src/renderer/src/components/task-launcher.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Layers, Play, X } from 'lucide-react'
+import { GitBranch, Layers, Play, X } from 'lucide-react'
 import { useAppStore } from '../store'
 
 export function TaskLauncher(): React.JSX.Element | null {
@@ -10,6 +10,7 @@ export function TaskLauncher(): React.JSX.Element | null {
   const launchTask = useAppStore((state) => state.launchTask)
   const [workspaceId, setWorkspaceId] = useState('')
   const [prompt, setPrompt] = useState('')
+  const [isolated, setIsolated] = useState(false)
   const [busy, setBusy] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
@@ -17,6 +18,7 @@ export function TaskLauncher(): React.JSX.Element | null {
     if (!open) return
     setWorkspaceId(activeWorkspace?.id ?? workspaces[0]?.id ?? '')
     setPrompt('')
+    setIsolated(false)
     requestAnimationFrame(() => inputRef.current?.focus())
   }, [open, activeWorkspace?.id, workspaces])
 
@@ -29,7 +31,7 @@ export function TaskLauncher(): React.JSX.Element | null {
   const submit = async (): Promise<void> => {
     if (!workspaceId || !prompt.trim() || busy) return
     setBusy(true)
-    const launched = await launchTask({ workspaceId, prompt })
+    const launched = await launchTask({ workspaceId, prompt, isolated })
     setBusy(false)
     if (launched) setOpen(false)
   }
@@ -105,8 +107,25 @@ export function TaskLauncher(): React.JSX.Element | null {
             />
           </label>
 
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border bg-app/50 px-3 py-2.5">
+            <input
+              type="checkbox"
+              checked={isolated}
+              onChange={(event) => setIsolated(event.target.checked)}
+              disabled={busy}
+              className="mt-0.5 accent-[var(--accent)]"
+            />
+            <span className="flex min-w-0 items-start gap-2">
+              <GitBranch size={14} className="mt-0.5 shrink-0 text-special" />
+              <span>
+                <span className="block text-xs font-medium text-secondary">Use an isolated Git worktree</span>
+                <span className="mt-0.5 block text-[11px] text-faint">Recommended for PR work; the source project remains untouched.</span>
+              </span>
+            </span>
+          </label>
+
           <p className="text-[11px] text-faint">
-            The task runs in a new session and continues in the background if you switch away. Use the isolated Git tab button when file isolation is required.
+            The task runs in a new session and continues in the background if you switch away. Ctrl/Cmd+Enter starts it.
           </p>
         </div>
 

--- a/src/renderer/src/components/task-launcher.tsx
+++ b/src/renderer/src/components/task-launcher.tsx
@@ -78,7 +78,8 @@ export function TaskLauncher(): React.JSX.Element | null {
                 value={workspaceId}
                 onChange={(event) => setWorkspaceId(event.target.value)}
                 disabled={busy || workspaces.length === 0}
-                className="min-w-0 flex-1 bg-transparent text-sm text-primary outline-none"
+                data-themed-select="true"
+                className="task-launcher-select min-w-0 flex-1 bg-transparent text-sm text-primary outline-none"
               >
                 {workspaces.length === 0 && <option value="">Open a project first</option>}
                 {workspaces.map((workspace) => (
@@ -119,13 +120,13 @@ export function TaskLauncher(): React.JSX.Element | null {
               <GitBranch size={14} className="mt-0.5 shrink-0 text-special" />
               <span>
                 <span className="block text-xs font-medium text-secondary">Use an isolated Git worktree</span>
-                <span className="mt-0.5 block text-[11px] text-faint">Recommended for PR work; the source project remains untouched.</span>
+                <span className="mt-0.5 block text-[11px] text-faint">Reuses a matching local PR/task worktree; otherwise creates one. The source project stays untouched.</span>
               </span>
             </span>
           </label>
 
           <p className="text-[11px] text-faint">
-            The task runs in a new session and continues in the background if you switch away. Ctrl/Cmd+Enter starts it.
+            The task runs in a new session and continues in the background if you switch away. Existing matching PR/task worktrees are reused. Ctrl/Cmd+Enter starts it.
           </p>
         </div>
 

--- a/src/renderer/src/components/thinking-level-selector.tsx
+++ b/src/renderer/src/components/thinking-level-selector.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, ChevronUp, Zap } from 'lucide-react'
+import { clsx } from 'clsx'
+import { useAppStore } from '../store'
+
+interface ThinkingLevelSelectorProps {
+  className?: string
+}
+
+/** Compact model-aware effort picker for the composer action rail. */
+export function ThinkingLevelSelector({ className }: ThinkingLevelSelectorProps): React.JSX.Element {
+  const sessionState = useAppStore((state) => state.sessionState)
+  const setThinkingLevel = useAppStore((state) => state.setThinkingLevel)
+  const piStatus = useAppStore((state) => state.piStatus)
+  const [isOpen, setIsOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  const modelEfforts = sessionState?.model?.thinking?.efforts?.filter(
+    (level) => typeof level === 'string' && level.length > 0,
+  )
+  const levels =
+    modelEfforts && modelEfforts.length > 0
+      ? ['off', ...modelEfforts.filter((level) => level !== 'off')]
+      : ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+  const currentLevel = sessionState?.thinkingLevel ?? 'medium'
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClick = (event: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(event.target as Node)) setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [isOpen])
+
+  if (piStatus !== 'running') return <></>
+
+  return (
+    <div ref={ref} className={clsx('relative', className)}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        className={clsx(
+          'flex h-7 items-center gap-1 rounded-md px-2 text-[11px] transition-colors active:scale-[0.98]',
+          isOpen ? 'bg-surface-hover text-primary' : 'text-dim hover:bg-surface-hover hover:text-secondary',
+        )}
+        title={`Thinking effort: ${currentLevel}`}
+        aria-label={`Thinking effort: ${currentLevel}`}
+        aria-expanded={isOpen}
+      >
+        <Zap size={11} className="shrink-0 text-accent-fg" />
+        <span>{currentLevel}</span>
+        <ChevronUp size={10} className={clsx('shrink-0 transition-transform', isOpen && 'rotate-180')} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full right-0 z-50 mb-2 w-40 overflow-hidden rounded-xl border border-border-strong bg-surface py-1 shadow-xl shadow-black/30 animate-fade-in">
+          <div className="border-b border-border px-3 py-2">
+            <div className="text-[10px] font-medium uppercase tracking-wide text-faint">Effort</div>
+            <div className="mt-0.5 text-xs text-dim">Model-aware thinking depth</div>
+          </div>
+          {levels.map((level) => (
+            <button
+              key={level}
+              type="button"
+              onClick={() => {
+                void setThinkingLevel(level)
+                setIsOpen(false)
+              }}
+              className={clsx(
+                'flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-surface-hover',
+                currentLevel === level ? 'text-primary' : 'text-muted',
+              )}
+            >
+              {currentLevel === level ? <Check size={11} className="text-success" /> : <span className="w-[11px]" />}
+              <span>{level}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/thinking-level-selector.tsx
+++ b/src/renderer/src/components/thinking-level-selector.tsx
@@ -41,7 +41,7 @@ export function ThinkingLevelSelector({ className }: ThinkingLevelSelectorProps)
         type="button"
         onClick={() => setIsOpen((open) => !open)}
         className={clsx(
-          'flex h-7 items-center gap-1 rounded-md px-2 text-[11px] transition-colors active:scale-[0.98]',
+          'flex h-6 items-center gap-1 rounded-md px-2 text-[11px] transition-colors active:scale-[0.98]',
           isOpen ? 'bg-surface-hover text-primary' : 'text-dim hover:bg-surface-hover hover:text-secondary',
         )}
         title={`Thinking effort: ${currentLevel}`}

--- a/src/renderer/src/components/workflow-navigator.tsx
+++ b/src/renderer/src/components/workflow-navigator.tsx
@@ -1,0 +1,816 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { clsx } from 'clsx'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Check,
+  ChevronRight,
+  Circle,
+  Code2,
+  Copy,
+  FileText,
+  GitBranch,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  Play,
+  RefreshCw,
+  ScrollText,
+  Square,
+  Workflow as WorkflowIcon,
+  X,
+  XCircle,
+} from 'lucide-react'
+import type {
+  WorkflowAgentDetail,
+  WorkflowAgentStatus,
+  WorkflowControlAction,
+  WorkflowControlReason,
+  WorkflowHistoryEntry,
+  WorkflowRunDetail,
+  WorkflowRunStatus,
+  WorkflowRunSummary,
+} from '../../../shared/ipc-contracts'
+import { useAppStore } from '../store'
+import { canAbortRun, canResumeRun, filterRunsBySession, filterRunsByWorkspace, isTerminalRun, runActiveAgentCount } from '../utils/workflow-runs'
+import { MarkdownRenderer } from './markdown-renderer'
+
+function formatTokens(total: number | undefined): string {
+  if (!total || total <= 0) return ''
+  if (total < 1000) return `${total} tok`
+  return `${(total / 1000).toFixed(total >= 10_000 ? 0 : 1)}k tok`
+}
+
+function formatCost(cost: number | undefined): string {
+  if (!cost || cost <= 0) return ''
+  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)}`
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (!ms || ms <= 0) return ''
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`
+  return `${Math.floor(ms / 60_000)}m ${Math.floor((ms % 60_000) / 1000)}s`
+}
+
+function statusLabel(status: WorkflowRunStatus): string {
+  return status === 'aborted' ? 'stopped' : status
+}
+
+function statusClass(status: WorkflowRunStatus): string {
+  if (status === 'running') return 'text-accent-fg'
+  if (status === 'failed' || status === 'aborted') return 'text-error'
+  if (status === 'completed') return 'text-success'
+  if (status === 'paused') return 'text-warning'
+  return 'text-muted'
+}
+
+function RunStatus({ status }: { status: WorkflowRunStatus }): React.JSX.Element {
+  if (status === 'running') return <Loader2 size={15} className="animate-spin text-accent-fg" />
+  if (status === 'completed') return <Check size={15} className="text-success" />
+  if (status === 'failed' || status === 'aborted') return <XCircle size={15} className="text-error" />
+  return <Circle size={13} className={statusClass(status)} />
+}
+
+function AgentStatus({ status, runStatus }: { status: WorkflowAgentStatus; runStatus: WorkflowRunStatus }): React.JSX.Element {
+  // A terminal run's persisted agents can be frozen at 'running' (the extension
+  // never flips them when it aborts/fails a run). Never show those as active.
+  if (status === 'running' && !isTerminalRun(runStatus)) return <Loader2 size={13} className="animate-spin text-accent-fg" />
+  if (status === 'done') return <Check size={13} className="text-success" />
+  if (status === 'error') return <XCircle size={13} className="text-error" />
+  return <Circle size={10} className="text-faint" />
+}
+
+function AgentCounts({ run }: { run: WorkflowRunSummary }): { done: number; running: number; total: number; percent: number } {
+  const done = run.agents.filter((agent) => agent.status === 'done' || agent.status === 'skipped').length
+  const running = runActiveAgentCount(run.agents, run.status)
+  const total = run.agents.length
+  return { done, running, total, percent: total ? Math.round((done / total) * 100) : 0 }
+}
+
+function RunCard({ run, onOpen }: { run: WorkflowRunSummary; onOpen: () => void }): React.JSX.Element {
+  const counts = AgentCounts({ run })
+  const tokenText = formatTokens(run.tokenUsage?.total)
+  const costText = formatCost(run.tokenUsage?.cost)
+  const terminal = isTerminalRun(run.status)
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="group w-full border-b border-border/70 px-3 py-3 text-left transition-colors last:border-b-0 hover:bg-highlight/50"
+    >
+      <div className="flex items-start gap-2">
+        <RunStatus status={run.status} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-primary">{run.workflowName}</span>
+            <span className={clsx('shrink-0 text-[10px] uppercase tracking-wide', statusClass(run.status))}>
+              {statusLabel(run.status)}
+            </span>
+          </div>
+          <div className="mt-1 flex min-w-0 items-center gap-2 text-[11px] text-dim">
+            <span className="flex min-w-0 items-center gap-1 truncate" title={run.cwd}>
+              <GitBranch size={11} className="shrink-0 text-faint" />
+              {run.workspaceName}
+            </span>
+            <span className="shrink-0 tabular-nums">{counts.done}/{counts.total} agents</span>
+            {counts.running > 0 && <span className="shrink-0 text-accent-fg">· {counts.running} active</span>}
+          </div>
+          <div className="mt-2 h-1 overflow-hidden rounded-full bg-card">
+            <div
+              className={clsx('h-full rounded-full transition-all', terminal ? 'bg-muted' : run.status === 'failed' ? 'bg-error' : 'bg-accent')}
+              style={{ width: `${counts.percent}%` }}
+            />
+          </div>
+          <div className="mt-1.5 flex items-center gap-2 text-[10px] text-faint">
+            {run.currentPhase && <span className={clsx('truncate', terminal ? 'text-faint' : 'text-accent-fg')}>{run.currentPhase}</span>}
+            {tokenText && <span className="shrink-0">{tokenText}</span>}
+            {costText && <span className="shrink-0">{costText}</span>}
+            {run.pauseReason && <span className="truncate text-warning">{run.pauseReason}</span>}
+          </div>
+        </div>
+        <ChevronRight size={15} className="mt-0.5 shrink-0 text-faint transition-transform group-hover:translate-x-0.5 group-hover:text-muted" />
+      </div>
+    </button>
+  )
+}
+
+function CopyButton({ text }: { text: string }): React.JSX.Element {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard.writeText(text).then(() => {
+          setCopied(true)
+          window.setTimeout(() => setCopied(false), 1200)
+        })
+      }}
+      className="rounded p-1.5 text-faint hover:bg-highlight hover:text-primary"
+      title="Copy"
+      aria-label="Copy"
+    >
+      {copied ? <Check size={13} className="text-success" /> : <Copy size={13} />}
+    </button>
+  )
+}
+
+type ResultRecord = Record<string, unknown>
+
+function isResultRecord(value: unknown): value is ResultRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function resultLabel(key: string): string {
+  const label = key.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').trim()
+  return label ? label.charAt(0).toUpperCase() + label.slice(1) : key
+}
+
+function isLongResultText(value: string): boolean {
+  return value.length > 140 || /[\r\n]/.test(value) || /^#{1,6}\s|[*_`]{2}/.test(value)
+}
+
+function ResultScalar({ value }: { value: unknown }): React.JSX.Element {
+  if (typeof value === 'string') {
+    return isLongResultText(value) ? (
+      <div className="text-xs leading-relaxed text-secondary"><MarkdownRenderer content={value} /></div>
+    ) : (
+      <span className="inline-flex max-w-full rounded-md bg-card px-2 py-1 text-xs text-secondary">{value || 'Empty'}</span>
+    )
+  }
+
+  if (value === null || value === undefined) {
+    return <span className="text-xs italic text-faint">None</span>
+  }
+
+  return (
+    <span className={clsx(
+      'inline-flex rounded-md px-2 py-1 text-xs',
+      typeof value === 'boolean'
+        ? value ? 'bg-success-bg text-success' : 'bg-card text-muted'
+        : 'bg-card text-secondary'
+    )}>
+      {typeof value === 'boolean' ? (value ? 'Yes' : 'No') : String(value)}
+    </span>
+  )
+}
+
+const resultIdentityKeys = ['title', 'name', 'label', 'id', 'key', 'slug']
+
+function resultItemTitle(item: ResultRecord, index: number): string {
+  for (const key of resultIdentityKeys) {
+    const value = item[key]
+    if (typeof value === 'string' && value.trim()) return value
+  }
+  return `Item ${index + 1}`
+}
+
+function resultItemFields(item: ResultRecord): Array<[string, unknown]> {
+  return Object.entries(item).filter(([key]) => !resultIdentityKeys.includes(key.toLowerCase()))
+}
+
+function ResultField({ label, value, depth }: { label: string; value: unknown; depth: number }): React.JSX.Element {
+  if (typeof value === 'string' && isLongResultText(value)) {
+    return (
+      <div className="space-y-1.5">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-faint">{resultLabel(label)}</div>
+        <div className="text-xs leading-relaxed text-secondary"><MarkdownRenderer content={value} /></div>
+      </div>
+    )
+  }
+
+  if (!Array.isArray(value) && !isResultRecord(value)) {
+    return (
+      <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border/50 py-1.5 last:border-0">
+        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-faint">{resultLabel(label)}</span>
+        <ResultScalar value={value} />
+      </div>
+    )
+  }
+
+  return (
+    <details className="rounded-lg border border-border/70 bg-card/20">
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 text-xs text-secondary marker:hidden">
+        <span className="font-medium text-primary">{resultLabel(label)}</span>
+        <span className="text-[10px] text-faint">{resultShape(value)}</span>
+      </summary>
+      <div className="border-t border-border/70 px-3 py-2">
+        <ResultValue value={value} depth={depth + 1} />
+      </div>
+    </details>
+  )
+}
+
+function ResultObjectList({ items, depth = 0 }: { items: ResultRecord[]; depth?: number }): React.JSX.Element {
+  const [openItems, setOpenItems] = useState<Record<number, boolean>>((): Record<number, boolean> => depth === 0 ? { 0: true } : {})
+  const shown = items.slice(0, 40)
+  return (
+    <div className="space-y-2">
+      {shown.map((item, index) => {
+        const fields = resultItemFields(item)
+        return (
+          <details
+            key={index}
+            open={openItems[index] ?? false}
+            onToggle={(event) => {
+              const isOpen = event.currentTarget.open
+              setOpenItems((previous) => previous[index] === isOpen ? previous : { ...previous, [index]: isOpen })
+            }}
+            className="overflow-hidden rounded-lg border border-border/80 bg-card/20"
+          >
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2.5 marker:hidden">
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-accent-bg/40 text-[10px] font-semibold tabular-nums text-accent-fg">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-xs font-medium text-primary" title={resultItemTitle(item, index)}>
+                {resultItemTitle(item, index)}
+              </span>
+              <span className="shrink-0 text-[10px] text-faint">
+                {fields.length ? `${fields.length} detail${fields.length === 1 ? '' : 's'}` : 'No details'}
+              </span>
+            </summary>
+            <div className="border-t border-border/70 px-3 pb-3 pt-2.5">
+              {fields.length === 0 ? (
+                <div className="text-xs italic text-faint">No additional details.</div>
+              ) : (
+                <div className="space-y-2">
+                  {fields.map(([key, value]) => (
+                    <ResultField key={key} label={key} value={value} depth={depth} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </details>
+        )
+      })}
+      {items.length > shown.length && <div className="px-1 text-xs italic text-dim">+ {items.length - shown.length} more items</div>}
+    </div>
+  )
+}
+
+function ResultValue({ value, depth = 0 }: { value: unknown; depth?: number }): React.JSX.Element {
+  if (depth >= 6) return <span className="text-xs italic text-faint">Nested details hidden</span>
+  if (!Array.isArray(value) && !isResultRecord(value)) return <ResultScalar value={value} />
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return <span className="text-xs italic text-faint">No items</span>
+    if (value.every(isResultRecord)) return <ResultObjectList items={value} depth={depth} />
+    const shown = value.slice(0, 40)
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {shown.map((item, index) => (
+          isResultRecord(item) || Array.isArray(item) ? (
+            <details key={index} className="w-full rounded-lg border border-border/70 bg-card/20">
+              <summary className="cursor-pointer list-none px-3 py-2 text-xs text-secondary marker:hidden">Item {index + 1}</summary>
+              <div className="border-t border-border/70 px-3 py-2"><ResultValue value={item} depth={depth + 1} /></div>
+            </details>
+          ) : <ResultScalar key={index} value={item} />
+        ))}
+        {value.length > shown.length && <div className="w-full px-1 text-xs italic text-dim">+ {value.length - shown.length} more items</div>}
+      </div>
+    )
+  }
+
+  const entries = Object.entries(value)
+  if (entries.length === 0) return <span className="text-xs italic text-faint">No details</span>
+  return (
+    <div className="space-y-2">
+      {entries.map(([key, item]) => <ResultField key={key} label={key} value={item} depth={depth} />)}
+    </div>
+  )
+}
+
+function resultShape(value: unknown): string {
+  if (Array.isArray(value)) return `${value.length} item${value.length === 1 ? '' : 's'}`
+  if (isResultRecord(value)) {
+    const count = Object.keys(value).length
+    return `${count} field${count === 1 ? '' : 's'}`
+  }
+  if (typeof value === 'string') return `${value.length} character${value.length === 1 ? '' : 's'}`
+  if (value === null || value === undefined) return 'empty'
+  return typeof value
+}
+
+function ResultSection({ label, value }: { label: string; value: unknown }): React.JSX.Element {
+  const isMarkdown = typeof value === 'string' && isLongResultText(value)
+  return (
+    <section className="border-b border-border/70 pb-4 last:border-0 last:pb-0">
+      <div className="mb-2 flex items-center justify-between gap-3 px-1">
+        <h3 className="text-xs font-semibold text-primary">{resultLabel(label)}</h3>
+        <span className="shrink-0 text-[10px] text-faint">{resultShape(value)}</span>
+      </div>
+      {isMarkdown ? (
+        <div className="rounded-lg bg-card/20 px-3 py-3 text-xs leading-relaxed text-secondary">
+          <MarkdownRenderer content={value} />
+        </div>
+      ) : (
+        <ResultValue value={value} />
+      )}
+    </section>
+  )
+}
+
+function WorkflowResult({ text }: { text: string }): React.JSX.Element {
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3 border-b border-border pb-3">
+          <div>
+            <div className="text-xs font-semibold text-primary">Workflow output</div>
+            <div className="mt-0.5 text-[11px] text-dim">Markdown report</div>
+          </div>
+          <CopyButton text={text} />
+        </div>
+        <div className="text-xs leading-relaxed text-secondary"><MarkdownRenderer content={text} /></div>
+      </div>
+    )
+  }
+
+  const entries = isResultRecord(value) ? Object.entries(value) : null
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between gap-3 border-b border-border pb-3">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-accent-bg/50 text-accent-fg">
+            <FileText size={14} />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-xs font-semibold text-primary">Workflow output</h3>
+            <p className="text-[11px] text-dim">
+              {entries ? `${entries.length} section${entries.length === 1 ? '' : 's'}` : resultShape(value)}
+            </p>
+          </div>
+        </div>
+        <CopyButton text={text} />
+      </header>
+
+      {entries ? (
+        entries.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border px-3 py-8 text-center text-xs text-dim">The workflow returned an empty object.</div>
+        ) : (
+          <div className="space-y-5">
+            {entries.map(([key, item]) => <ResultSection key={key} label={key} value={item} />)}
+          </div>
+        )
+      ) : <ResultSection label="Output" value={value} />}
+    </div>
+  )
+}
+
+function PhaseStepper({ run }: { run: WorkflowRunDetail }): React.JSX.Element | null {
+  if (run.phases.length === 0) return null
+  const terminal = isTerminalRun(run.status)
+  return (
+    <div className="flex gap-1 overflow-x-auto pb-1">
+      {run.phases.map((phase, index) => {
+        const agents = run.agents.filter((agent) => agent.phase === phase)
+        const done = agents.filter((agent) => agent.status === 'done' || agent.status === 'skipped').length
+        const active = run.currentPhase === phase
+        const complete = agents.length > 0 && done === agents.length
+        return (
+          <div key={phase} className={clsx('min-w-28 rounded-lg border px-2.5 py-2', active ? 'border-accent-bg/70 bg-accent-bg/15' : 'border-border bg-card/50')}>
+            <div className="flex items-center gap-1.5 text-[10px] text-faint">
+              <span>{index + 1}</span>
+              {complete ? <Check size={11} className="text-success" /> : active && !terminal ? <Loader2 size={11} className="animate-spin text-accent-fg" /> : null}
+            </div>
+            {/* The active border stays on terminal runs — it marks where the run halted —
+                but the name must read as stopped, not in-flight. */}
+            <div className={clsx('mt-1 truncate text-xs font-medium', active ? (terminal ? 'text-secondary' : 'text-accent-fg') : 'text-secondary')} title={phase}>{phase}</div>
+            <div className="mt-0.5 text-[10px] text-faint">{done}/{agents.length || '—'} agents</div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function AgentGrid({ run, onSelect }: { run: WorkflowRunDetail; onSelect: (agent: WorkflowAgentDetail) => void }): React.JSX.Element {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {run.agents.map((agent) => (
+        <button
+          key={`${run.runId}:${agent.id}`}
+          type="button"
+          onClick={() => onSelect(agent)}
+          className="min-w-0 rounded-lg border border-border bg-card/50 p-2.5 text-left transition-colors hover:border-border-strong hover:bg-highlight/50"
+        >
+          <div className="flex items-center gap-2">
+            <AgentStatus status={agent.status} runStatus={run.status} />
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-primary">{agent.label}</span>
+            <ChevronRight size={13} className="shrink-0 text-faint" />
+          </div>
+          <div className="mt-1.5 flex items-center gap-2 truncate text-[10px] text-faint">
+            {agent.phase && <span className="truncate">{agent.phase}</span>}
+            {agent.model && <span className="truncate" title={agent.model}>{agent.model.split('/').pop()}</span>}
+            {agent.tokens ? <span className="shrink-0">{formatTokens(agent.tokens)}</span> : null}
+          </div>
+          {agent.error && <div className="mt-1 truncate text-[10px] text-error" title={agent.error}>{agent.error}</div>}
+          <div className="mt-1.5 text-[10px] text-accent-fg">
+            {agent.hasHistory ? 'Open transcript' : 'No transcript captured'}
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function HistoryEntry({ entry }: { entry: WorkflowHistoryEntry }): React.JSX.Element {
+  const isCode = entry.kind === 'toolCall' || entry.kind === 'toolResult' || entry.kind === 'error'
+  return (
+    <div className={clsx('rounded-lg border p-2.5', entry.isError ? 'border-error/50 bg-error-bg/20' : 'border-border bg-card/40')}>
+      <div className="mb-1.5 flex items-center gap-2 text-[10px] uppercase tracking-wide text-faint">
+        <span>{entry.role}</span>
+        <span>·</span>
+        <span>{entry.kind}</span>
+        {entry.toolName && <span className="truncate normal-case text-accent-fg">{entry.toolName}</span>}
+        {entry.path && <span className="truncate normal-case" title={entry.path}>{entry.path}</span>}
+        {entry.timestamp && <span className="ml-auto shrink-0 normal-case">{new Date(entry.timestamp).toLocaleTimeString()}</span>}
+      </div>
+      {entry.text && (isCode ? (
+        <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded bg-app/70 p-2 font-jetbrains text-[11px] leading-relaxed text-secondary">{entry.text}</pre>
+      ) : (
+        <div className="text-xs leading-relaxed text-secondary"><MarkdownRenderer content={entry.text} /></div>
+      ))}
+      {entry.diff && <pre className="mt-2 max-h-80 overflow-auto whitespace-pre-wrap break-words rounded bg-app/70 p-2 font-jetbrains text-[11px] leading-relaxed text-secondary">{entry.diff}</pre>}
+    </div>
+  )
+}
+
+function AgentTranscript({ agent, onBack }: { agent: WorkflowAgentDetail; onBack: () => void }): React.JSX.Element {
+  const [persistenceMessage, setPersistenceMessage] = useState<string | null>(null)
+  const transcriptText = agent.history.map((entry) => `${entry.role} · ${entry.kind}\n${entry.text}`).join('\n\n')
+  const enablePersistence = async (): Promise<void> => {
+    try {
+      await window.piDesktop.workflows.setPersistAgentSessions(true)
+      setPersistenceMessage('Enabled globally. Reload Pi before the next workflow run.')
+    } catch (error) {
+      setPersistenceMessage(error instanceof Error ? error.message : 'Could not update workflow settings.')
+    }
+  }
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <button type="button" onClick={onBack} className="rounded p-1.5 text-muted hover:bg-highlight hover:text-primary" title="Back to run" aria-label="Back to run"><ArrowLeft size={15} /></button>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-primary">{agent.label}</div>
+          <div className="text-[10px] text-dim">{agent.phase ?? 'workflow step'} · {agent.transcriptSource === 'persisted-session' ? 'full session transcript' : agent.transcriptSource === 'run-history' ? 'captured workflow history' : 'no transcript'}</div>
+        </div>
+        {transcriptText && <CopyButton text={transcriptText} />}
+      </div>
+      {!agent.transcriptComplete && agent.transcriptSource === 'run-history' && (
+        <div className="flex shrink-0 items-start gap-2 border-b border-warning/30 bg-warning-bg/20 px-3 py-2 text-[11px] text-warning">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div>Showing the workflow&apos;s captured history. Future runs can retain every raw Pi message and tool result.</div>
+            {persistenceMessage ? <div className="mt-1 text-success">{persistenceMessage}</div> : <button type="button" onClick={() => void enablePersistence()} className="mt-1 rounded border border-warning/50 px-2 py-1 text-[10px] text-warning hover:bg-warning-bg/30">Enable full transcripts for future runs</button>}
+          </div>
+        </div>
+      )}
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3">
+        {agent.prompt && (
+          <div className="rounded-lg border border-accent-bg/40 bg-accent-bg/10 p-2.5">
+            <div className="mb-1 text-[10px] uppercase tracking-wide text-accent-fg">Step prompt</div>
+            <div className="whitespace-pre-wrap text-xs leading-relaxed text-secondary">{agent.prompt}</div>
+          </div>
+        )}
+        {agent.history.length === 0 ? (
+          <div className="py-8 text-center text-xs text-dim">No transcript was persisted for this step.</div>
+        ) : agent.history.map((entry, index) => <HistoryEntry key={`${entry.id ?? 'entry'}-${index}`} entry={entry} />)}
+        {agent.resultText && (
+          <div className="rounded-lg border border-success/40 bg-success-bg/15 p-2.5">
+            <div className="mb-2 text-[10px] uppercase tracking-wide text-success">Step result</div>
+            <WorkflowResult text={agent.resultText} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+type DetailTab = 'overview' | 'script' | 'logs' | 'result'
+
+function controlFailureText(action: WorkflowControlAction, reason: WorkflowControlReason | undefined): string {
+  switch (reason) {
+    case 'no-pi':
+    case 'pi-not-running':
+      return 'Pi is not running for this workspace, so the run cannot be controlled from here.'
+    case 'extension-missing':
+      return 'The workflows extension is not loaded in this workspace\u2019s Pi process.'
+    case 'status-not-permitted':
+      return action === 'stop'
+        ? 'This run can no longer be aborted in its current state.'
+        : 'This run cannot be resumed in its current state.'
+    case 'timeout':
+      return 'Pi did not respond. The run may have changed state — refresh to see the latest.'
+    case 'dispatch-failed':
+      return 'The control command could not be sent to Pi.'
+    default:
+      return 'The workflow control is unavailable for this workspace right now.'
+  }
+}
+
+function RunDetail({ run, onBack, onRefresh, onSelectAgent }: {
+  run: WorkflowRunDetail
+  onBack: () => void
+  onRefresh: () => void
+  onSelectAgent: (agent: WorkflowAgentDetail) => void
+}): React.JSX.Element {
+  const [tab, setTab] = useState<DetailTab>('overview')
+  const [controlBusy, setControlBusy] = useState<WorkflowControlAction | null>(null)
+  const [controlFeedback, setControlFeedback] = useState<{ kind: 'ok' | 'error'; text: string } | null>(null)
+  const feedbackTimer = useRef<number | null>(null)
+  const counts = AgentCounts({ run })
+
+  const clearFeedback = (): void => {
+    if (feedbackTimer.current !== null) window.clearTimeout(feedbackTimer.current)
+    feedbackTimer.current = null
+    setControlFeedback(null)
+  }
+
+  useEffect(() => () => {
+    if (feedbackTimer.current !== null) window.clearTimeout(feedbackTimer.current)
+  }, [])
+
+  // Dispatch a REAL control to the run's owning workspace Pi process (the
+  // extension's `/workflows stop|resume`). The persisted status flips on disk;
+  // the navigator's poll picks it up. Nothing is faked locally.
+  const runControl = async (action: WorkflowControlAction): Promise<void> => {
+    if (controlBusy) return
+    setControlBusy(action)
+    clearFeedback()
+    try {
+      const result = await window.piDesktop.workflows.control(run.workspaceId, run.runId, action)
+      if (result.ok) {
+        setControlFeedback({
+          kind: 'ok',
+          text: action === 'stop' ? 'Abort requested — stopping the run in its workspace…' : 'Resume requested — restarting the run in its workspace…',
+        })
+        feedbackTimer.current = window.setTimeout(clearFeedback, 4000)
+        // The extension writes the transition to disk; refresh a beat later so
+        // the status flip is visible even before the next poll tick.
+        window.setTimeout(() => void onRefresh(), 1200)
+      } else {
+        setControlFeedback({ kind: 'error', text: controlFailureText(action, result.reason) })
+        feedbackTimer.current = window.setTimeout(clearFeedback, 6000)
+      }
+    } catch {
+      setControlFeedback({ kind: 'error', text: 'Could not reach the workflow control path for this workspace.' })
+      feedbackTimer.current = window.setTimeout(clearFeedback, 6000)
+    } finally {
+      setControlBusy(null)
+    }
+  }
+
+  const abortable = canAbortRun(run.status)
+  const resumable = canResumeRun(run.status)
+  const tabs: Array<{ id: DetailTab; label: string; icon: React.JSX.Element; visible: boolean }> = [
+    { id: 'overview', label: 'Overview', icon: <WorkflowIcon size={12} />, visible: true },
+    { id: 'script', label: 'Script', icon: <Code2 size={12} />, visible: !!run.script },
+    { id: 'logs', label: 'Logs', icon: <ScrollText size={12} />, visible: run.logs.length > 0 },
+    { id: 'result', label: 'Results', icon: <FileText size={12} />, visible: !!run.resultText },
+  ]
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="shrink-0 border-b border-border px-3 py-2.5">
+        <div className="flex items-start gap-2">
+          <button type="button" onClick={onBack} className="rounded p-1.5 text-muted hover:bg-highlight hover:text-primary" title="All workflow runs" aria-label="All workflow runs"><ArrowLeft size={15} /></button>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <RunStatus status={run.status} />
+              <span className="truncate text-sm font-semibold text-primary">{run.workflowName}</span>
+              <span className={clsx('text-[10px] uppercase tracking-wide', statusClass(run.status))}>{statusLabel(run.status)}</span>
+            </div>
+            <div className="mt-1 flex items-center gap-1.5 truncate text-[10px] text-dim" title={run.cwd}><GitBranch size={11} className="shrink-0" />{run.workspaceName} · {run.cwd}</div>
+          </div>
+          {(abortable || resumable) && (
+            <div className="flex shrink-0 items-center gap-1">
+              {abortable && (
+                <button
+                  type="button"
+                  onClick={() => void runControl('stop')}
+                  disabled={controlBusy !== null}
+                  className="flex items-center gap-1 rounded border border-error/40 px-2 py-1 text-[10px] text-error hover:bg-error-bg/30 disabled:cursor-not-allowed disabled:opacity-50"
+                  title="Stop the workflow in its workspace"
+                  aria-label="Abort run"
+                >
+                  {controlBusy === 'stop' ? <Loader2 size={11} className="animate-spin" /> : <Square size={11} />}Abort
+                </button>
+              )}
+              {resumable && (
+                <button
+                  type="button"
+                  onClick={() => void runControl('resume')}
+                  disabled={controlBusy !== null}
+                  className="flex items-center gap-1 rounded border border-success/40 px-2 py-1 text-[10px] text-success hover:bg-success-bg/30 disabled:cursor-not-allowed disabled:opacity-50"
+                  title="Resume the workflow in its workspace"
+                  aria-label="Resume run"
+                >
+                  {controlBusy === 'resume' ? <Loader2 size={11} className="animate-spin" /> : <Play size={11} />}Resume
+                </button>
+              )}
+            </div>
+          )}
+          <button type="button" onClick={onRefresh} className="rounded p-1.5 text-muted hover:bg-highlight hover:text-primary" title="Refresh run" aria-label="Refresh run"><RefreshCw size={13} /></button>
+        </div>
+        {(run.pauseReason || run.resetHint) && <div className="mt-2 rounded border border-warning/40 bg-warning-bg/20 px-2 py-1.5 text-[11px] text-warning">{run.pauseReason ?? 'Paused'}{run.resetHint ? ` · ${run.resetHint}` : ''}</div>}
+        {controlFeedback && (
+          <div className={clsx('mt-2 rounded border px-2 py-1.5 text-[11px]', controlFeedback.kind === 'ok' ? 'border-success/40 bg-success-bg/20 text-success' : 'border-error/40 bg-error-bg/20 text-error')} role="status">
+            {controlFeedback.text}
+          </div>
+        )}
+        <div className="mt-2 grid grid-cols-3 gap-1.5 text-center">
+          <div className="rounded bg-card/60 px-1.5 py-1.5"><div className="text-sm tabular-nums text-primary">{counts.done}/{counts.total}</div><div className="text-[9px] uppercase text-faint">agents</div></div>
+          <div className="rounded bg-card/60 px-1.5 py-1.5"><div className="text-sm tabular-nums text-primary">{formatTokens(run.tokenUsage?.total) || '—'}</div><div className="text-[9px] uppercase text-faint">tokens</div></div>
+          <div className="rounded bg-card/60 px-1.5 py-1.5"><div className="text-sm tabular-nums text-primary">{formatCost(run.tokenUsage?.cost) || formatDuration(run.durationMs) || '—'}</div><div className="text-[9px] uppercase text-faint">cost/time</div></div>
+        </div>
+        <div className="mt-2 flex gap-1 overflow-x-auto">
+          {tabs.filter((item) => item.visible).map((item) => <button key={item.id} type="button" onClick={() => setTab(item.id)} className={clsx('flex shrink-0 items-center gap-1 rounded px-2 py-1 text-[10px]', tab === item.id ? 'bg-accent-bg/30 text-accent-fg' : 'text-muted hover:bg-highlight hover:text-primary')}>{item.icon}{item.label}</button>)}
+        </div>
+      </header>
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        {tab === 'overview' && <div className="space-y-3"><PhaseStepper run={run} /><div><div className="mb-1.5 flex items-center gap-2 text-[10px] uppercase tracking-wide text-faint"><WorkflowIcon size={12} /> Steps</div><AgentGrid run={run} onSelect={onSelectAgent} /></div></div>}
+        {tab === 'script' && run.script && <div className="relative"><div className="absolute right-1 top-1"><CopyButton text={run.script} /></div><pre className="overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-app/70 p-3 pr-10 font-jetbrains text-[11px] leading-relaxed text-secondary">{run.script}</pre></div>}
+        {tab === 'logs' && <pre className="whitespace-pre-wrap break-words rounded-lg border border-border bg-app/70 p-3 font-jetbrains text-[11px] leading-relaxed text-secondary">{run.logs.join('\n')}</pre>}
+        {tab === 'result' && run.resultText && <WorkflowResult text={run.resultText} />}
+      </div>
+    </div>
+  )
+}
+
+export function WorkflowNavigator({ embedded = false }: { embedded?: boolean }): React.JSX.Element | null {
+  const open = useAppStore((state) => state.workflowPanelOpen)
+  const setOpen = useAppStore((state) => state.setWorkflowPanelOpen)
+  const filterSessionId = useAppStore((state) => state.workflowPanelFilter)
+  const scopeWorkspaceId = useAppStore((state) => state.workflowPanelWorkspaceId)
+  const workspaces = useAppStore((state) => state.workspaces)
+  const runs = useAppStore((state) => state.workflowRuns)
+  const refresh = useAppStore((state) => state.refreshWorkflowRuns)
+  const [detail, setDetail] = useState<WorkflowRunDetail | null>(null)
+  const [selectedAgent, setSelectedAgent] = useState<WorkflowAgentDetail | null>(null)
+  const detailRef = useRef<WorkflowRunDetail | null>(null)
+  const selectedAgentRef = useRef<WorkflowAgentDetail | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [maximized, setMaximized] = useState(false)
+  const panelRef = useRef<HTMLElement>(null)
+
+  // A workspace scope pointing at a workspace that was removed would leave a
+  // dead-end empty panel; treat it as global instead (the runs are still in
+  // the journal, just no longer reachable through a project).
+  const workspaceScopeId = useMemo(() => {
+    if (!scopeWorkspaceId) return null
+    return workspaces.some((ws) => ws.id === scopeWorkspaceId) ? scopeWorkspaceId : null
+  }, [scopeWorkspaceId, workspaces])
+
+  useEffect(() => {
+    detailRef.current = detail
+  }, [detail])
+  useEffect(() => {
+    selectedAgentRef.current = selectedAgent
+  }, [selectedAgent])
+  useEffect(() => {
+    // Clicking a session's runs icon or the project-scoped entry can change the
+    // scope while this panel is already open. Do not leave a detail view from
+    // the previous scope visible.
+    setDetail(null)
+    setSelectedAgent(null)
+  }, [filterSessionId, workspaceScopeId])
+
+  const loadRun = async (run: WorkflowRunSummary): Promise<void> => {
+    setLoading(true)
+    setSelectedAgent(null)
+    try {
+      setDetail(await window.piDesktop.workflows.getRun(run.workspaceId, run.runId))
+    } catch {
+      setDetail(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const refreshDetail = useCallback(async (): Promise<void> => {
+    const current = detailRef.current
+    if (!current) return
+    try {
+      const next = await window.piDesktop.workflows.getRun(current.workspaceId, current.runId)
+      setDetail(next)
+      const selected = selectedAgentRef.current
+      if (selected) setSelectedAgent(next.agents.find((agent) => agent.id === selected.id) ?? null)
+    } catch {
+      // Keep the last readable detail if a live run is being atomically persisted.
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!open) {
+      setDetail(null)
+      setSelectedAgent(null)
+      return
+    }
+    const handleOutsidePointer = (event: PointerEvent): void => {
+      const target = event.target
+      if (target instanceof Node && !panelRef.current?.contains(target)) {
+        setMaximized(false)
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', handleOutsidePointer)
+    return () => document.removeEventListener('pointerdown', handleOutsidePointer)
+  }, [open, setOpen])
+
+  useEffect(() => {
+    if (!open) {
+      setDetail(null)
+      setSelectedAgent(null)
+      return
+    }
+    const tick = async (): Promise<void> => {
+      await refresh()
+      await refreshDetail()
+    }
+    void tick()
+    const timer = window.setInterval(() => void tick(), 900)
+    return () => window.clearInterval(timer)
+  }, [open, refresh, refreshDetail])
+
+  const visibleRuns = useMemo(
+    () => filterRunsByWorkspace(filterRunsBySession(runs, filterSessionId), workspaceScopeId),
+    [runs, filterSessionId, workspaceScopeId]
+  )
+  const scopeWorkspace = useMemo(
+    () => (workspaceScopeId ? workspaces.find((ws) => ws.id === workspaceScopeId) ?? null : null),
+    [workspaceScopeId, workspaces]
+  )
+  const activeCount = useMemo(() => visibleRuns.filter((run) => run.status === 'running' || run.status === 'paused').length, [visibleRuns])
+
+  if (!open) return null
+
+  return (
+    <section
+      ref={panelRef}
+      className={clsx(
+        'flex min-h-0 flex-col overflow-hidden border border-border-strong bg-surface/95',
+        embedded
+          ? 'relative h-full w-full rounded-none border-0 bg-surface shadow-none backdrop-blur-none'
+          : 'absolute z-40 shadow-2xl shadow-black/30 backdrop-blur-md',
+        !embedded && (maximized
+          ? 'inset-4 rounded-xl'
+          : 'right-4 top-14 max-h-[calc(100vh-7rem)] w-[30rem] max-w-[calc(100vw-2rem)] rounded-xl')
+      )}
+      aria-label="Workflow runs"
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2.5">
+        <WorkflowIcon size={16} className="text-accent-fg" />
+        <div className="min-w-0 flex-1"><div className="text-sm font-medium text-primary">{selectedAgent ? 'Step transcript' : detail ? 'Workflow detail' : 'Workflow runs'}</div><div className="text-[11px] text-dim">{selectedAgent ? selectedAgent.label : detail ? `${detail.workflowName} · ${detail.workspaceName}` : activeCount > 0 ? `${activeCount} active` : visibleRuns.length ? `${visibleRuns.length} recorded` : filterSessionId ? 'No runs for this session' : workspaceScopeId ? 'No runs for this project' : 'No runs yet'}</div></div>
+        {!detail && <button type="button" onClick={() => void refresh()} className="rounded p-1.5 text-muted hover:bg-highlight hover:text-primary" title="Refresh workflow runs" aria-label="Refresh workflow runs"><RefreshCw size={14} /></button>}
+        {!embedded && <button type="button" onClick={() => setMaximized((value) => !value)} className="rounded p-1.5 text-muted hover:bg-highlight hover:text-primary" title={maximized ? 'Restore workflow navigator' : 'Maximize workflow navigator'} aria-label={maximized ? 'Restore workflow navigator' : 'Maximize workflow navigator'} aria-pressed={maximized}>{maximized ? <Minimize2 size={15} /> : <Maximize2 size={15} />}</button>}
+        <button type="button" onClick={() => { setMaximized(false); setOpen(false) }} className="rounded p-1.5 text-muted hover:bg-highlight hover:text-primary" title="Close workflow runs" aria-label="Close workflow runs"><X size={16} /></button>
+      </header>
+      {selectedAgent && <AgentTranscript agent={selectedAgent} onBack={() => setSelectedAgent(null)} />}
+      {!selectedAgent && detail && <RunDetail run={detail} onBack={() => setDetail(null)} onRefresh={() => void refreshDetail()} onSelectAgent={setSelectedAgent} />}
+      {!selectedAgent && !detail && <div className="min-h-0 flex-1 overflow-y-auto">{loading ? <div className="flex items-center justify-center gap-2 px-5 py-10 text-xs text-dim"><Loader2 size={14} className="animate-spin" />Loading workflow…</div> : visibleRuns.length === 0 ? <div className="px-5 py-10 text-center text-sm text-dim">{filterSessionId ? <><WorkflowIcon size={26} className="mx-auto mb-2 text-faint" />No workflow runs recorded for this session. Runs from older sessions appear in the global list.</> : workspaceScopeId ? <><WorkflowIcon size={26} className="mx-auto mb-2 text-faint" />No workflow runs recorded for {scopeWorkspace?.name ?? 'this project'}. Runs from other projects appear in the global list.</> : <><WorkflowIcon size={26} className="mx-auto mb-2 text-faint" />Run <span className="font-jetbrains text-xs text-secondary">/workflows run …</span> in chat.</>}</div> : visibleRuns.map((run) => <RunCard key={`${run.workspaceId}:${run.runId}`} run={run} onOpen={() => void loadRun(run)} />)}</div>}
+    </section>
+  )
+}

--- a/src/renderer/src/components/workspace-tabs.tsx
+++ b/src/renderer/src/components/workspace-tabs.tsx
@@ -27,6 +27,7 @@ export function WorkspaceTabs(): React.JSX.Element {
   const setWorkflowPanelOpen = useAppStore((state) => state.setWorkflowPanelOpen)
   const activateWorkspace = useAppStore((state) => state.activateWorkspace)
   const switchSession = useAppStore((state) => state.switchSession)
+  const closeSessionTab = useAppStore((state) => state.closeSessionTab)
   const removeWorkspace = useAppStore((state) => state.removeWorkspace)
   const createWorktreeTab = useAppStore((state) => state.createWorktreeTab)
   const createNewSession = useAppStore((state) => state.createNewSession)
@@ -75,6 +76,13 @@ export function WorkspaceTabs(): React.JSX.Element {
         return (
           <div
             key={workspace.id}
+            onAuxClick={(event) => {
+              // DOM button 1 is the middle mouse button. Keep right-click for
+              // the normal context menu and use the middle button as tab-close.
+              if (event.button !== 1) return
+              event.preventDefault()
+              void removeWorkspace(workspace.id)
+            }}
             className={clsx(
               'group flex h-9 min-w-[150px] max-w-[240px] shrink-0 items-center gap-2 rounded-t-md border border-b-0 px-2.5 text-xs transition-colors',
               active
@@ -164,33 +172,51 @@ export function WorkspaceTabs(): React.JSX.Element {
         <Plus size={15} />
       </button>
     </div>
-    {sessionTabs.length > 1 && (
+    {sessionTabs.length > 0 && (
       <div className="flex h-8 shrink-0 items-center gap-1 overflow-x-auto border-b border-border/70 px-2">
         <span className="mr-1 shrink-0 text-[10px] uppercase tracking-wide text-faint">Sessions</span>
         {sessionTabs.map((runtime) => {
           const session = sessionList.find((item) => runtime.sessionPath && pathsEqual(item.path, runtime.sessionPath))
           const active = runtime.runtimeId === activeSessionRuntimeId || runtime.active
           return (
-            <button
+            <div
               key={runtime.runtimeId}
-              type="button"
-              onClick={() => {
-                if (!runtime.sessionPath) return
-                setCurrentView('chat')
-                void switchSession(runtime.sessionPath, activeWorkspace?.path)
+              onAuxClick={(event) => {
+                if (event.button !== 1) return
+                event.preventDefault()
+                void closeSessionTab(runtime.runtimeId)
               }}
               className={clsx(
-                'flex min-w-0 max-w-[220px] shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] transition-colors',
+                'group flex min-w-0 max-w-[240px] shrink-0 items-center gap-0.5 rounded px-1 py-0.5 text-[11px] transition-colors',
                 active ? 'bg-card text-primary' : 'text-muted hover:bg-highlight hover:text-secondary'
               )}
-              title={runtime.sessionPath ?? undefined}
-              aria-current={active ? 'page' : undefined}
             >
-              <SessionRuntimeIndicator runtime={runtime} />
-              <span className="truncate">
-                {session ? getSessionTitle(session.name, session.sessionId, session.preview) : 'New session'}
-              </span>
-            </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (!runtime.sessionPath) return
+                  setCurrentView('chat')
+                  void switchSession(runtime.sessionPath, activeWorkspace?.path)
+                }}
+                className="flex min-w-0 flex-1 items-center gap-1.5 px-1 py-0.5 text-left"
+                title={runtime.sessionPath ?? undefined}
+                aria-current={active ? 'page' : undefined}
+              >
+                <SessionRuntimeIndicator runtime={runtime} />
+                <span className="truncate">
+                  {session ? getSessionTitle(session.name, session.sessionId, session.preview) : 'New session'}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => void closeSessionTab(runtime.runtimeId)}
+                className="shrink-0 rounded p-0.5 text-faint opacity-0 transition-all hover:bg-highlight-strong hover:text-primary group-hover:opacity-100"
+                title="Close session tab"
+                aria-label="Close session tab"
+              >
+                <X size={11} />
+              </button>
+            </div>
           )
         })}
       </div>

--- a/src/renderer/src/components/workspace-tabs.tsx
+++ b/src/renderer/src/components/workspace-tabs.tsx
@@ -44,7 +44,8 @@ export function WorkspaceTabs(): React.JSX.Element {
   const sessionTabs = useMemo(
     () => Object.values(sessionRuntimes)
       .filter((runtime) => runtime.workspaceId === activeWorkspace?.id && runtime.sessionPath)
-      .sort((a, b) => Number(b.active) - Number(a.active)),
+      // Newest runtime first; selecting a tab never changes its position.
+      .reverse(),
     [activeWorkspace?.id, sessionRuntimes]
   )
 

--- a/src/renderer/src/components/workspace-tabs.tsx
+++ b/src/renderer/src/components/workspace-tabs.tsx
@@ -2,6 +2,9 @@ import { useMemo } from 'react'
 import { AlertCircle, CheckCircle2, FolderOpen, GitBranch, Loader2, MessageSquarePlus, PanelLeft, Plus, Settings, X, XCircle } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAppStore } from '../store'
+import { getSessionTitle } from '../utils/session-title'
+import { pathsEqual } from '../../../shared/path-compare'
+import { SessionRuntimeIndicator } from './session-runtime-indicator'
 import type { Workspace } from '../../../shared/ipc-contracts'
 
 function tabLabel(workspace: Workspace): string {
@@ -11,6 +14,9 @@ function tabLabel(workspace: Workspace): string {
 export function WorkspaceTabs(): React.JSX.Element {
   const workspaces = useAppStore((state) => state.workspaces)
   const activeWorkspace = useAppStore((state) => state.activeWorkspace)
+  const sessionList = useAppStore((state) => state.sessionList)
+  const sessionRuntimes = useAppStore((state) => state.sessionRuntimes)
+  const activeSessionRuntimeId = useAppStore((state) => state.activeSessionRuntimeId)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
   const toggleSidebar = useAppStore((state) => state.toggleSidebar)
   const workspaceActivity = useAppStore((state) => state.workspaceActivity)
@@ -19,7 +25,8 @@ export function WorkspaceTabs(): React.JSX.Element {
   const workflowPanelFilter = useAppStore((state) => state.workflowPanelFilter)
   const workflowPanelWorkspaceId = useAppStore((state) => state.workflowPanelWorkspaceId)
   const setWorkflowPanelOpen = useAppStore((state) => state.setWorkflowPanelOpen)
-  const switchWorkspace = useAppStore((state) => state.switchWorkspace)
+  const activateWorkspace = useAppStore((state) => state.activateWorkspace)
+  const switchSession = useAppStore((state) => state.switchSession)
   const removeWorkspace = useAppStore((state) => state.removeWorkspace)
   const createWorktreeTab = useAppStore((state) => state.createWorktreeTab)
   const createNewSession = useAppStore((state) => state.createNewSession)
@@ -34,9 +41,16 @@ export function WorkspaceTabs(): React.JSX.Element {
     () => [...workspaces].sort((a, b) => a.createdAt - b.createdAt),
     [workspaces]
   )
+  const sessionTabs = useMemo(
+    () => Object.values(sessionRuntimes)
+      .filter((runtime) => runtime.workspaceId === activeWorkspace?.id && runtime.sessionPath)
+      .sort((a, b) => Number(b.active) - Number(a.active)),
+    [activeWorkspace?.id, sessionRuntimes]
+  )
 
   return (
-    <div className="flex h-10 shrink-0 items-end gap-1 overflow-x-auto border-b border-border bg-app px-2 pt-1">
+    <div className="flex shrink-0 flex-col bg-app">
+    <div className="flex h-10 items-end gap-1 overflow-x-auto border-b border-border px-2 pt-1">
       {!sidebarOpen && (
         <button
           type="button"
@@ -75,7 +89,7 @@ export function WorkspaceTabs(): React.JSX.Element {
                   setCurrentView('chat')
                   return
                 }
-                void switchWorkspace(workspace.id).then((switched) => {
+                void activateWorkspace(workspace.id).then((switched) => {
                   if (switched) setCurrentView('chat')
                 })
               }}
@@ -148,6 +162,38 @@ export function WorkspaceTabs(): React.JSX.Element {
       >
         <Plus size={15} />
       </button>
+    </div>
+    {sessionTabs.length > 1 && (
+      <div className="flex h-8 shrink-0 items-center gap-1 overflow-x-auto border-b border-border/70 px-2">
+        <span className="mr-1 shrink-0 text-[10px] uppercase tracking-wide text-faint">Sessions</span>
+        {sessionTabs.map((runtime) => {
+          const session = sessionList.find((item) => runtime.sessionPath && pathsEqual(item.path, runtime.sessionPath))
+          const active = runtime.runtimeId === activeSessionRuntimeId || runtime.active
+          return (
+            <button
+              key={runtime.runtimeId}
+              type="button"
+              onClick={() => {
+                if (!runtime.sessionPath) return
+                setCurrentView('chat')
+                void switchSession(runtime.sessionPath, activeWorkspace?.path)
+              }}
+              className={clsx(
+                'flex min-w-0 max-w-[220px] shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] transition-colors',
+                active ? 'bg-card text-primary' : 'text-muted hover:bg-highlight hover:text-secondary'
+              )}
+              title={runtime.sessionPath ?? undefined}
+              aria-current={active ? 'page' : undefined}
+            >
+              <SessionRuntimeIndicator runtime={runtime} />
+              <span className="truncate">
+                {session ? getSessionTitle(session.name, session.sessionId, session.preview) : 'New session'}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    )}
     </div>
   )
 }

--- a/src/renderer/src/components/workspace-tabs.tsx
+++ b/src/renderer/src/components/workspace-tabs.tsx
@@ -1,0 +1,153 @@
+import { useMemo } from 'react'
+import { AlertCircle, CheckCircle2, FolderOpen, GitBranch, Loader2, MessageSquarePlus, PanelLeft, Plus, Settings, X, XCircle } from 'lucide-react'
+import { clsx } from 'clsx'
+import { useAppStore } from '../store'
+import type { Workspace } from '../../../shared/ipc-contracts'
+
+function tabLabel(workspace: Workspace): string {
+  return workspace.name || workspace.path.split(/[\\/]/).filter(Boolean).pop() || workspace.path
+}
+
+export function WorkspaceTabs(): React.JSX.Element {
+  const workspaces = useAppStore((state) => state.workspaces)
+  const activeWorkspace = useAppStore((state) => state.activeWorkspace)
+  const sidebarOpen = useAppStore((state) => state.sidebarOpen)
+  const toggleSidebar = useAppStore((state) => state.toggleSidebar)
+  const workspaceActivity = useAppStore((state) => state.workspaceActivity)
+  const currentView = useAppStore((state) => state.currentView)
+  const workflowPanelOpen = useAppStore((state) => state.workflowPanelOpen)
+  const workflowPanelFilter = useAppStore((state) => state.workflowPanelFilter)
+  const workflowPanelWorkspaceId = useAppStore((state) => state.workflowPanelWorkspaceId)
+  const setWorkflowPanelOpen = useAppStore((state) => state.setWorkflowPanelOpen)
+  const switchWorkspace = useAppStore((state) => state.switchWorkspace)
+  const removeWorkspace = useAppStore((state) => state.removeWorkspace)
+  const createWorktreeTab = useAppStore((state) => state.createWorktreeTab)
+  const createNewSession = useAppStore((state) => state.createNewSession)
+  const setCurrentView = useAppStore((state) => state.setCurrentView)
+
+  const toolView = ['settings', 'packages', 'notes', 'skills', 'diagnostics'] as const
+  const toolsActive =
+    toolView.includes(currentView as (typeof toolView)[number]) ||
+    (workflowPanelOpen && !workflowPanelFilter && workflowPanelWorkspaceId === null)
+
+  const tabs = useMemo(
+    () => [...workspaces].sort((a, b) => a.createdAt - b.createdAt),
+    [workspaces]
+  )
+
+  return (
+    <div className="flex h-10 shrink-0 items-end gap-1 overflow-x-auto border-b border-border bg-app px-2 pt-1">
+      {!sidebarOpen && (
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          className="mb-1 flex h-7 w-7 shrink-0 animate-fade-in items-center justify-center rounded-md border border-border-strong bg-surface text-muted shadow-sm transition-colors hover:bg-surface-hover hover:text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus"
+          title="Show sidebar"
+          aria-label="Show sidebar"
+        >
+          <PanelLeft size={15} />
+        </button>
+      )}
+      {tabs.map((workspace) => {
+        const active = workspace.id === activeWorkspace?.id && !toolsActive
+        const activity = workspaceActivity[workspace.id]
+        const isWorktree = workspace.kind === 'worktree'
+        const isWorking = activity?.state === 'working'
+        const needsApproval = activity?.state === 'needs-approval'
+        const completed = activity?.state === 'completed'
+        const failed = activity?.state === 'failed'
+
+        return (
+          <div
+            key={workspace.id}
+            className={clsx(
+              'group flex h-9 min-w-[150px] max-w-[240px] shrink-0 items-center gap-2 rounded-t-md border border-b-0 px-2.5 text-xs transition-colors',
+              active
+                ? 'border-border bg-surface text-primary'
+                : 'border-transparent text-muted hover:bg-surface/60 hover:text-secondary'
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                setWorkflowPanelOpen(false)
+                if (workspace.id === activeWorkspace?.id) {
+                  setCurrentView('chat')
+                  return
+                }
+                void switchWorkspace(workspace.id).then((switched) => {
+                  if (switched) setCurrentView('chat')
+                })
+              }}
+              className="flex min-w-0 flex-1 items-center gap-2 text-left"
+              title={`${workspace.path}${workspace.branch ? `\n${workspace.branch}` : ''}`}
+            >
+              {isWorktree ? (
+                <GitBranch size={13} className="shrink-0 text-special" />
+              ) : (
+                <FolderOpen size={13} className="shrink-0 text-dim" />
+              )}
+              <span className="min-w-0 flex-1 truncate font-medium">{tabLabel(workspace)}</span>
+              {isWorking && <Loader2 size={12} className="shrink-0 animate-spin text-accent-fg" />}
+              {needsApproval && <AlertCircle size={12} className="shrink-0 text-warning" />}
+              {completed && <CheckCircle2 size={12} className="shrink-0 text-success" />}
+              {failed && <XCircle size={12} className="shrink-0 text-error" />}
+            </button>
+            {tabs.length > 1 && (
+              <button
+                type="button"
+                onClick={() => void removeWorkspace(workspace.id)}
+                className="shrink-0 rounded p-0.5 text-faint opacity-0 transition-all hover:bg-highlight hover:text-primary group-hover:opacity-100"
+                title={isWorktree ? 'Close tab' : 'Remove workspace'}
+                aria-label={isWorktree ? `Close ${tabLabel(workspace)}` : `Remove ${tabLabel(workspace)}`}
+              >
+                <X size={12} />
+              </button>
+            )}
+          </div>
+        )
+      })}
+
+      {toolsActive && (
+        <button
+          type="button"
+          aria-current="page"
+          onClick={() => {
+            if (!toolView.includes(currentView as (typeof toolView)[number])) {
+              setWorkflowPanelOpen(false)
+              setCurrentView('settings')
+            }
+          }}
+          className="group flex h-9 min-w-[110px] shrink-0 items-center gap-2 rounded-t-md border border-b-0 border-border bg-surface px-2.5 text-left text-xs text-primary"
+          title="Tools"
+        >
+          <Settings size={13} className="shrink-0 text-accent-fg" />
+          <span className="truncate font-medium">Tools</span>
+        </button>
+      )}
+
+      <button
+        type="button"
+        onClick={() => {
+          setWorkflowPanelOpen(false)
+          setCurrentView('chat')
+          void createNewSession()
+        }}
+        className="mb-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted hover:bg-surface-hover hover:text-primary transition-colors"
+        title="New session in this project (Ctrl/Cmd+N)"
+        aria-label="New session in this project"
+      >
+        <MessageSquarePlus size={15} />
+      </button>
+      <button
+        type="button"
+        onClick={() => void createWorktreeTab()}
+        className="mb-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted hover:bg-surface-hover hover:text-primary transition-colors"
+        title="New isolated Git tab (requires a Git project)"
+        aria-label="New isolated Git tab"
+      >
+        <Plus size={15} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -11,6 +11,7 @@ export function usePiEvents(): void {
   const handlePiEvent = useAppStore((state) => state.handlePiEvent)
   const handlePendingPromptCounts = useAppStore((state) => state.handlePendingPromptCounts)
   const handleWorkspaceActivity = useAppStore((state) => state.handleWorkspaceActivity)
+  const handleSessionRuntime = useAppStore((state) => state.handleSessionRuntime)
   const recoverPendingPrompts = useAppStore((state) => state.recoverPendingPrompts)
 
   useEffect(() => {
@@ -18,6 +19,7 @@ export function usePiEvents(): void {
     const unsubscribeEvent = window.piDesktop.onEvent(handlePiEvent)
     const unsubscribeCounts = window.piDesktop.onPendingPrompts(handlePendingPromptCounts)
     const unsubscribeActivity = window.piDesktop.onWorkspaceActivity(handleWorkspaceActivity)
+    const unsubscribeSessionRuntime = window.piDesktop.onSessionRuntime(handleSessionRuntime)
 
     // A desktop-notification click hands the renderer the switch intent so the
     // usual streaming/dirty-editor confirms still run; landing on chat shows
@@ -34,7 +36,7 @@ export function usePiEvents(): void {
         if (state.currentView !== 'chat') state.setCurrentView('chat')
         return
       }
-      void state.switchWorkspace(workspaceId).then((switched) => {
+      void state.activateWorkspace(workspaceId).then((switched) => {
         if (switched) useAppStore.getState().setCurrentView('chat')
       })
     }
@@ -64,9 +66,10 @@ export function usePiEvents(): void {
       unsubscribeEvent()
       unsubscribeCounts()
       unsubscribeActivity()
+      unsubscribeSessionRuntime()
       unsubscribeActivate()
     }
-  }, [handlePiEvent, handlePendingPromptCounts, handleWorkspaceActivity, recoverPendingPrompts])
+  }, [handlePiEvent, handlePendingPromptCounts, handleWorkspaceActivity, handleSessionRuntime, recoverPendingPrompts])
 }
 
 /**
@@ -432,6 +435,9 @@ export function useInitialize(): void {
 
       // Workspaces are needed for the shell chrome; land the UI immediately after.
       await loadWorkspaces()
+      void window.piDesktop.session.listRuntimes()
+        .then((runtimes) => runtimes.forEach((runtime) => useAppStore.getState().handleSessionRuntime(runtime)))
+        .catch(() => undefined)
 
       if (openToHome) {
         // Interactive ASAP — do NOT wait on the session-store walk (can be tens
@@ -458,26 +464,12 @@ export function useInitialize(): void {
         return
       }
 
-      // Legacy: boot into Chat and resume the last session. reloadActiveSession
-      // pulls the resumed session's message history (refreshSessionState alone
-      // only loads metadata, leaving the chat empty).
-      await startPi()
-      await useAppStore.getState().reloadActiveSession()
-      await refreshSessionStats()
-
-      // Re-pull the activity snapshot AFTER the boot load: a renderer reload
-      // (Ctrl+R) mid-turn boots idle, the load's teardown clears any attach
-      // the earlier snapshot armed, and broadcasts only fire on transitions —
-      // without this pull the running turn would stream invisibly and its
-      // in-flight message would commit truncated. handleWorkspaceActivity
-      // arms the attach when the active workspace is working.
-      try {
-        useAppStore
-          .getState()
-          .handleWorkspaceActivity(await window.piDesktop.workspace.getActivity())
-      } catch {
-        // Non-fatal: the next activity broadcast catches the renderer up.
-      }
+      // Boot Pi in the background. The shell is already interactive; the
+      // session-runtime running event hydrates Chat when the process is ready.
+      void startPi().then(() => refreshSessionStats()).catch(() => undefined)
+      void window.piDesktop.workspace.getActivity()
+        .then((activity) => useAppStore.getState().handleWorkspaceActivity(activity))
+        .catch(() => undefined)
     }
 
     initialize()

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -388,6 +388,7 @@ export function useCommandCatalog(): { builtins: BuiltinCommand[]; allCommands: 
   const compactContext = useAppStore((s) => s.compactContext)
   const cloneBranch = useAppStore((s) => s.cloneBranch)
   const createNewSession = useAppStore((s) => s.createNewSession)
+  const setTaskLauncherOpen = useAppStore((s) => s.setTaskLauncherOpen)
   const setCurrentView = useAppStore((s) => s.setCurrentView)
 
   const builtins = useMemo<BuiltinCommand[]>(
@@ -395,11 +396,12 @@ export function useCommandCatalog(): { builtins: BuiltinCommand[]; allCommands: 
       { name: 'compact', description: 'Compact the conversation to free up context', run: () => { void compactContext() } },
       { name: 'clone', description: 'Clone the current branch into a new session', run: () => { void cloneBranch() } },
       { name: 'new', description: 'Start a new session', run: () => { void createNewSession() } },
+      { name: 'task', description: 'Launch a task in a new Pi session', run: () => setTaskLauncherOpen(true) },
       { name: 'resume', description: 'Open the Sessions list', run: () => setCurrentView('sessions') },
       { name: 'fork', description: 'Open Branches to fork from a message', run: () => setCurrentView('timeline') },
       { name: 'settings', description: 'Open Settings', run: () => setCurrentView('settings') },
     ],
-    [compactContext, cloneBranch, createNewSession, setCurrentView]
+    [compactContext, cloneBranch, createNewSession, setTaskLauncherOpen, setCurrentView]
   )
 
   const allCommands = useMemo<PiCommand[]>(

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -443,6 +443,10 @@ export function useInitialize(): void {
 
       // Background: session list, tags, notes, models, updates.
       void refreshSessionList()
+      // Load the workflow journal once at boot so the status-bar badge and the
+      // sidebar workflow entries show live runs before the navigator is first
+      // opened (its poll loop keeps it fresh afterwards).
+      void useAppStore.getState().refreshWorkflowRuns()
       void useAppStore.getState().loadTags()
       void useAppStore.getState().loadArchivedSessions()
       void useAppStore.getState().loadNotes()

--- a/src/renderer/src/hooks.ts
+++ b/src/renderer/src/hooks.ts
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useCallback, useState } fr
 import { useAppStore } from './store'
 import { DEFAULT_SETTINGS } from '../../shared/default-settings'
 import { BUILTIN_SOURCE, type PiCommand } from '../../shared/pi-command'
+import type { WorkspaceActivationIntent } from '../../shared/ipc-contracts'
 
 /**
  * Subscribes to Pi events from the main process and routes them to the store.
@@ -24,28 +25,39 @@ export function usePiEvents(): void {
     // A desktop-notification click hands the renderer the switch intent so the
     // usual streaming/dirty-editor confirms still run; landing on chat shows
     // the finished (or waiting) turn the notification was about.
-    const activateWorkspaceIntent = (workspaceId: string): void => {
+    const activateWorkspaceIntent = (intent: WorkspaceActivationIntent): void => {
       const state = useAppStore.getState()
+      const { workspaceId, sessionPath } = intent
       // A stale intent for a removed workspace must not run confirm dialogs
       // for a doomed switch. An empty list means it just hasn't loaded yet
       // (boot) — proceed and let main validate.
-      if (state.workspaces.length > 0 && !state.workspaces.some((ws) => ws.id === workspaceId)) {
-        return
-      }
-      if (state.activeWorkspace?.id === workspaceId) {
-        if (state.currentView !== 'chat') state.setCurrentView('chat')
-        return
-      }
-      void state.activateWorkspace(workspaceId).then((switched) => {
+      if (state.workspaces.length > 0 && !state.workspaces.some((ws) => ws.id === workspaceId)) return
+
+      void (async () => {
+        if (sessionPath) {
+          if (state.activeWorkspace?.id !== workspaceId) {
+            if (!(await state.activateWorkspace(workspaceId, { start: false }))) return
+          }
+          const workspace = useAppStore.getState().activeWorkspace
+          if (!workspace) return
+          await useAppStore.getState().switchSession(sessionPath, workspace.path)
+          useAppStore.getState().setCurrentView('chat')
+          return
+        }
+        if (state.activeWorkspace?.id === workspaceId) {
+          if (state.currentView !== 'chat') state.setCurrentView('chat')
+          return
+        }
+        const switched = await state.activateWorkspace(workspaceId)
         if (switched) useAppStore.getState().setCurrentView('chat')
-      })
+      })()
     }
-    const unsubscribeActivate = window.piDesktop.onActivateWorkspace(({ workspaceId }) => {
+    const unsubscribeActivate = window.piDesktop.onActivateWorkspace((intent) => {
       // Main stashes every click's intent in case this broadcast never lands
       // (boot/reload race). It did land — consume the stash so a later boot
       // cannot replay a long-stale activation.
       void window.piDesktop.workspace.takePendingActivation().catch(() => undefined)
-      activateWorkspaceIntent(workspaceId)
+      activateWorkspaceIntent(intent)
     })
 
     // A reload leaves the dialog slot empty while main still holds the prompt.
@@ -55,8 +67,8 @@ export function usePiEvents(): void {
     // main; deliver it now that the subscriptions above are live.
     void window.piDesktop.workspace
       .takePendingActivation()
-      .then((workspaceId) => {
-        if (workspaceId) activateWorkspaceIntent(workspaceId)
+      .then((intent) => {
+        if (intent) activateWorkspaceIntent(intent)
       })
       .catch(() => {
         // Non-fatal: the user can switch manually.

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -109,6 +109,20 @@
   .chat-center > .border-b { border-bottom-color: var(--color-chat-column-border); }
   .chat-center > .border-t { border-top-color: var(--color-chat-column-border); }
 
+  /* Native Chromium select popups otherwise fall back to the OS light palette
+     even when the app has a dark theme. Keep the popup and its text on the
+     same semantic tokens as the rest of the launcher. */
+  select[data-themed-select] {
+    color-scheme: dark;
+  }
+  html.light select[data-themed-select] {
+    color-scheme: light;
+  }
+  select[data-themed-select] option {
+    background-color: var(--color-surface);
+    color: var(--color-primary);
+  }
+
   /* Reveal the thinking copy button on hover. Plain CSS avoids the nested-group
      ambiguity with the message-level `group` (Tailwind group-hover didn't fire). */
   .thinking-copy-btn {

--- a/src/renderer/src/store-session-transitions.test.ts
+++ b/src/renderer/src/store-session-transitions.test.ts
@@ -357,23 +357,20 @@ test('confirmSessionChange labels the dialog for the action being confirmed', as
   assert.equal(await pending, false)
 })
 
-test('declining the warning leaves the streaming turn untouched', async () => {
+test('switching sessions does not warn or stop the previous process', async () => {
   enterStreamingState()
-  answerConfirm(false)
 
   await useAppStore.getState().switchSession(SESSION_PATH)
 
   const state = useAppStore.getState()
-  assert.deepEqual(calls, [], 'a declined switch must not reach Pi at all')
-  assert.equal(state.isStreaming, true, 'the running turn must survive a declined switch')
-  assert.equal(state.streamingContent, 'partial answer')
-  assert.deepEqual(state.pendingSteering, ['steer me'])
+  assert.equal(calls.includes(`switch:${SESSION_PATH}`), true)
+  assert.equal(state.isStreaming, false, 'the newly selected session starts with a clean local stream')
+  assert.equal(state.streamingContent, '')
+  assert.deepEqual(state.pendingSteering, [])
 })
 
-test('accepting the warning switches and clears the abandoned turn', async () => {
+test('switching sessions clears the local streaming state', async () => {
   enterStreamingState()
-  answerConfirm(true)
-
   await useAppStore.getState().switchSession(SESSION_PATH)
 
   const state = useAppStore.getState()
@@ -407,14 +404,13 @@ test('switchSession clears streaming state even when Pi refuses the switch', asy
   )
 })
 
-test('createNewSession is gated by the same warning', async () => {
+test('createNewSession starts an independent runtime without warning', async () => {
   enterStreamingState()
-  answerConfirm(false)
 
   await useAppStore.getState().createNewSession()
 
-  assert.deepEqual(calls, [], 'a declined new session must not reach Pi')
-  assert.equal(useAppStore.getState().isStreaming, true)
+  assert.equal(calls.includes('createNew'), true)
+  assert.equal(useAppStore.getState().isStreaming, false)
 })
 
 test('createNewSession opens the new conversation in Chat', async () => {
@@ -1477,36 +1473,21 @@ test('the activity map going quiet after an attach stops the indicator and backf
   assert.equal(calls.filter((c) => c === 'getMessages').length, loadsBefore + 1)
 })
 
-test('opening the mid-turn session row skips the killing RPC and re-attaches', async () => {
-  // Return path two: sidebar recents / Sessions tab / quick-switcher row
-  // click into a workspace with a background turn running. The switch_session
-  // RPC aborts an in-flight turn EVEN for the session Pi is already on
-  // (verified against real Pi), so the working-workspace guard must ask Pi
-  // where it is and reload instead of switching.
+test('opening a mid-turn session row leaves the other runtime working', async () => {
   enterWorkspacesWithBackgroundTurn()
   sessionStateResult = sessionStateWith(SESSION_PATH)
 
   await useAppStore.getState().openSessionItem(sessionItemFor(WORKSPACE_TWO))
 
   const state = useAppStore.getState()
-  assert.equal(
-    calls.includes(`switch:${SESSION_PATH}`),
-    false,
-    'switch_session mid-turn kills the running turn — it must not be sent'
-  )
-  assert.equal(calls.includes('getMessages'), true, 'history must still load')
-  assert.equal(state.isStreaming, true)
-  assert.equal(state.reattachedMidTurn, true)
+  assert.equal(calls.includes(`switch:${SESSION_PATH}`), true)
+  assert.equal(calls.includes('getMessages'), true, 'the selected runtime still hydrates history')
+  assert.equal(state.isStreaming, false, 'the selected session starts idle until its own events arrive')
 })
 
-test('opening a DIFFERENT session mid-turn warns, then switches on accept', async () => {
+test('opening a different session mid-turn does not prompt or stop the other runtime', async () => {
   enterWorkspacesWithBackgroundTurn()
-  // Pi reports it is working on another session than the row being opened —
-  // switching kills that background turn, so a warning must gate it (the
-  // renderer's isStreaming is false for background turns, so the ordinary
-  // confirmSessionChange gate stays silent here).
   sessionStateResult = sessionStateWith('/tmp/other-turn-session.jsonl')
-  answerConfirm(true)
 
   await useAppStore.getState().openSessionItem(sessionItemFor(WORKSPACE_TWO))
 
@@ -1514,18 +1495,14 @@ test('opening a DIFFERENT session mid-turn warns, then switches on accept', asyn
   assert.equal(useAppStore.getState().reattachedMidTurn, false)
 })
 
-test('declining the background-turn warning aborts the session switch', async () => {
+test('a background runtime never blocks session navigation with a warning', async () => {
   enterWorkspacesWithBackgroundTurn()
   sessionStateResult = sessionStateWith('/tmp/other-turn-session.jsonl')
-  answerConfirm(false)
 
   await useAppStore.getState().openSessionItem(sessionItemFor(WORKSPACE_TWO))
 
-  assert.equal(
-    calls.includes(`switch:${SESSION_PATH}`),
-    false,
-    'a declined warning must not send the turn-killing switch_session RPC'
-  )
+  assert.equal(calls.includes(`switch:${SESSION_PATH}`), true)
+  assert.equal(useAppStore.getState().confirmRequest, null)
 })
 
 test('a mid-turn message_end keeps the attach armed and restores the indicator', async () => {
@@ -1573,19 +1550,13 @@ test('the boot arm stays out of session-change teardown windows', async () => {
   assert.equal(useAppStore.getState().reattachedMidTurn, false)
 })
 
-test('an attach whose turn ends is settled by the next activity broadcast', async () => {
+test('session navigation does not require workspace re-attachment', async () => {
   enterWorkspacesWithBackgroundTurn()
   sessionStateResult = sessionStateWith(SESSION_PATH)
   await useAppStore.getState().openSessionItem(sessionItemFor(WORKSPACE_TWO))
-  assert.equal(useAppStore.getState().reattachedMidTurn, true)
 
-  // The turn finished; the workspace goes idle in the next broadcast.
-  useAppStore.getState().handleWorkspaceActivity({})
-  await new Promise((resolve) => setTimeout(resolve, 20))
-
-  const state = useAppStore.getState()
-  assert.equal(state.isStreaming, false)
-  assert.equal(state.reattachedMidTurn, false)
+  assert.equal(useAppStore.getState().reattachedMidTurn, false)
+  assert.equal(useAppStore.getState().isStreaming, false)
 })
 
 test('a live on-screen stream is never re-attached over', async () => {

--- a/src/renderer/src/store-session-transitions.test.ts
+++ b/src/renderer/src/store-session-transitions.test.ts
@@ -417,6 +417,21 @@ test('createNewSession is gated by the same warning', async () => {
   assert.equal(useAppStore.getState().isStreaming, true)
 })
 
+test('createNewSession opens the new conversation in Chat', async () => {
+  activeWorkspaceResult = WORKSPACE_ONE
+  workspaceListResult = [WORKSPACE_ONE]
+  useAppStore.setState({
+    activeWorkspace: WORKSPACE_ONE,
+    workspaces: [WORKSPACE_ONE],
+    currentView: 'sessions',
+  })
+
+  await useAppStore.getState().createNewSession()
+
+  assert.equal(calls.includes('createNew'), true)
+  assert.equal(useAppStore.getState().currentView, 'chat')
+})
+
 test('forkFrom is gated by the same warning', async () => {
   enterStreamingState()
   answerConfirm(false)
@@ -427,24 +442,11 @@ test('forkFrom is gated by the same warning', async () => {
   assert.equal(useAppStore.getState().isStreaming, true)
 })
 
-// Regression: the cross-workspace path in the sidebar and session panel switches
-// workspace first, and that calls clearMessages() — which resets `isStreaming`,
-// the very flag the session-change gate reads. The warning has to be raised by
-// switchWorkspace itself, before anything clears state.
-test('switchWorkspace warns before it clears the streaming flag', async () => {
+// Workspace switches are safe because each workspace owns a separate Pi
+// process. Switching tabs must not block on, abort, or warn about the turn that
+// remains active in the background.
+test('switchWorkspace leaves a running Pi in the background without warning', async () => {
   enterStreamingState()
-  answerConfirm(false)
-
-  const proceed = await useAppStore.getState().switchWorkspace(WORKSPACE_ID)
-
-  assert.equal(proceed, false, 'a declined workspace switch must report failure to its caller')
-  assert.deepEqual(calls, [], 'a declined workspace switch must not reach the main process')
-  assert.equal(useAppStore.getState().isStreaming, true, 'the running turn must survive')
-})
-
-test('an accepted workspace switch leaves no stale streaming flag behind', async () => {
-  enterStreamingState()
-  answerConfirm(true)
 
   const proceed = await useAppStore.getState().switchWorkspace(WORKSPACE_ID)
 
@@ -486,19 +488,18 @@ test('an accepted workspace switch clears the held dialog without answering it',
   )
 })
 
-test('a declined workspace switch keeps the dialog on screen', async () => {
-  enterStreamingState()
+test('a workspace switch clears the old dialog without answering it', async () => {
   useAppStore.setState({ extensionUiRequest: EXTENSION_DIALOG })
-  answerConfirm(false)
 
   const proceed = await useAppStore.getState().switchWorkspace(WORKSPACE_ID)
 
-  assert.equal(proceed, false)
-  assert.equal(useAppStore.getState().extensionUiRequest?.id, EXTENSION_DIALOG.id)
+  assert.equal(proceed, true)
+  assert.equal(useAppStore.getState().extensionUiRequest, null)
+  assert.equal(calls.includes(`flushPendingPrompts:${WORKSPACE_ID}`), true)
   assert.equal(
-    calls.some((c) => c.startsWith('flushPendingPrompts')),
+    calls.some((c) => c.startsWith('respond')),
     false,
-    'a declined switch must not replay prompts for a workspace the user never left for'
+    'switching tabs must not synthesize a deny for the background prompt'
   )
 })
 
@@ -733,12 +734,9 @@ test('openFolderAsWorkspace skips switch when the dropped folder is already acti
   assert.equal(useAppStore.getState().currentView, 'chat')
 })
 
-// Regression: a dropped folder that is already a registered (but inactive)
-// workspace must activate through switchWorkspace's confirm gate only. Routing
-// it through createWorkspace lets main activate the duplicate path before the
-// "still working" dialog appears, so declining left main and the sidebar on the
-// new workspace while the chat pane still held the old one.
-test('declining the confirm while dropping an existing workspace leaves everything in place', async () => {
+// A dropped folder that is already registered should use the normal background-safe
+// workspace switch rather than asking the user to stop the old Pi turn.
+test('dropping an existing workspace switches without a streaming confirmation', async () => {
   workspaceListResult = [WORKSPACE_ONE, WORKSPACE_TWO]
   activeWorkspaceResult = WORKSPACE_ONE
   useAppStore.setState({
@@ -747,28 +745,15 @@ test('declining the confirm while dropping an existing workspace leaves everythi
     currentView: 'home',
   })
   enterStreamingState()
-  answerConfirm(false)
 
   const ok = await useAppStore.getState().openFolderAsWorkspace(WORKSPACE_TWO.path)
 
-  assert.equal(ok, false)
-  assert.equal(
-    calls.some((c) => c.startsWith('createWorkspace:')),
-    false,
-    'create activates a duplicate path on main before the confirm can run'
-  )
-  assert.equal(
-    calls.some((c) => c.startsWith('setActiveWorkspace:')),
-    false,
-    'a declined switch must leave the main-side active workspace untouched'
-  )
-  assert.equal(useAppStore.getState().activeWorkspace?.id, WORKSPACE_ONE.id)
-  assert.equal(
-    useAppStore.getState().messages[0]?.id,
-    'm1',
-    'the streaming chat must survive a declined switch'
-  )
-  assert.equal(useAppStore.getState().isStreaming, true)
+  assert.equal(ok, true)
+  assert.equal(calls.some((c) => c.startsWith('createWorkspace:')), false)
+  assert.equal(calls.includes(`setActiveWorkspace:${WORKSPACE_TWO.id}`), true)
+  assert.equal(useAppStore.getState().activeWorkspace?.id, WORKSPACE_TWO.id)
+  assert.equal(useAppStore.getState().messages.length, 0)
+  assert.equal(useAppStore.getState().isStreaming, false)
 })
 
 test('openFolderAsWorkspace preserves surrounding whitespace in the folder path', async () => {
@@ -1118,7 +1103,7 @@ test('a duplicate-path create routes through the full workspace switch', async (
   )
 })
 
-test('a duplicate-path create warns while Pi is streaming', async () => {
+test('a duplicate-path create switches while Pi keeps working in the background', async () => {
   workspaceListResult = [WORKSPACE_ONE, WORKSPACE_TWO]
   activeWorkspaceResult = WORKSPACE_ONE
   useAppStore.setState({
@@ -1126,17 +1111,12 @@ test('a duplicate-path create warns while Pi is streaming', async () => {
     workspaces: [WORKSPACE_ONE, WORKSPACE_TWO],
   })
   enterStreamingState()
-  answerConfirm(false)
 
   await useAppStore.getState().createWorkspace(WORKSPACE_TWO.name, WORKSPACE_TWO.path)
 
   assert.equal(calls.some((c) => c.startsWith('createWorkspace:')), false)
-  assert.equal(
-    calls.some((c) => c.startsWith('setActiveWorkspace:')),
-    false,
-    'declining the still-working warning must abort the activation'
-  )
-  assert.equal(useAppStore.getState().isStreaming, true)
+  assert.equal(calls.includes(`setActiveWorkspace:${WORKSPACE_TWO.id}`), true)
+  assert.equal(useAppStore.getState().isStreaming, false)
 })
 
 test('creating the already-active path is a no-op', async () => {
@@ -1393,7 +1373,7 @@ test('openSessionItem auto-switches to the owning workspace first', async () => 
   assert.equal(useAppStore.getState().currentView, 'chat')
 })
 
-test('a declined streaming warning aborts the whole openSessionItem flow', async () => {
+test('openSessionItem switches tabs before opening the requested session', async () => {
   workspaceListResult = [WORKSPACE_ONE, WORKSPACE_TWO]
   activeWorkspaceResult = WORKSPACE_ONE
   useAppStore.setState({
@@ -1402,13 +1382,12 @@ test('a declined streaming warning aborts the whole openSessionItem flow', async
     currentView: 'sessions',
   })
   enterStreamingState()
-  answerConfirm(false)
 
   await useAppStore.getState().openSessionItem(sessionItemFor(WORKSPACE_TWO))
 
-  assert.equal(calls.some((c) => c.startsWith('setActiveWorkspace')), false)
-  assert.equal(calls.includes(`switch:${SESSION_PATH}`), false)
-  assert.equal(useAppStore.getState().currentView, 'sessions')
+  assert.equal(calls.includes(`setActiveWorkspace:${WORKSPACE_TWO.id}`), true)
+  assert.equal(calls.includes(`switch:${SESSION_PATH}`), true)
+  assert.equal(useAppStore.getState().currentView, 'chat')
 })
 
 test('openSessionItem creates a workspace for an unknown project path', async () => {
@@ -1714,4 +1693,54 @@ test('the notify toast sits above the blocking dialog backdrop', () => {
     NOTIFY_TOAST_Z_INDEX > DIALOG_OVERLAY_Z_INDEX,
     'a toast at or below the backdrop tier turns a toast click into a hard deny'
   )
+})
+
+// ─── View scopes (sessions + workflow panel) ─────────────────────────────────
+
+// The sessions scope is lifted into the store so SessionPanel remounts (every
+// navigation) can't drop it and sidebar entry points can set it explicitly.
+test('setSessionsScope toggles the sessions view scope', () => {
+  assert.equal(useAppStore.getState().sessionsScope, 'all')
+  useAppStore.getState().setSessionsScope('current')
+  assert.equal(useAppStore.getState().sessionsScope, 'current')
+  useAppStore.getState().setSessionsScope('all')
+  assert.equal(useAppStore.getState().sessionsScope, 'all')
+})
+
+test('openWorkflowRunsForWorkspace opens a project scope and clears session scope', () => {
+  useAppStore.getState().openWorkflowRunsForWorkspace(WORKSPACE_ONE.id)
+  const state = useAppStore.getState()
+  assert.equal(state.workflowPanelOpen, true)
+  assert.equal(state.workflowPanelWorkspaceId, WORKSPACE_ONE.id)
+  assert.equal(state.workflowPanelFilter, null)
+})
+
+test('openWorkflowRunsForWorkspace(null) opens the global scope (Tools entry)', () => {
+  useAppStore.getState().openWorkflowRunsForWorkspace(null)
+  const state = useAppStore.getState()
+  assert.equal(state.workflowPanelOpen, true)
+  assert.equal(state.workflowPanelWorkspaceId, null)
+  assert.equal(state.workflowPanelFilter, null)
+})
+
+test('openWorkflowRunsForSession overrides a project scope (session wins)', () => {
+  useAppStore.getState().openWorkflowRunsForWorkspace(WORKSPACE_ONE.id)
+  useAppStore.getState().openWorkflowRunsForSession('01b2b3c4-d5e6-4f70-a8b9-0c1d2e3f4a5b')
+  const state = useAppStore.getState()
+  assert.equal(state.workflowPanelWorkspaceId, null)
+  assert.equal(state.workflowPanelFilter, '01b2b3c4-d5e6-4f70-a8b9-0c1d2e3f4a5b')
+})
+
+test('setWorkflowPanelOpen: direct open clears scope, close preserves it', () => {
+  useAppStore.getState().openWorkflowRunsForWorkspace(WORKSPACE_ONE.id)
+  useAppStore.getState().setWorkflowPanelOpen(false)
+  assert.equal(useAppStore.getState().workflowPanelOpen, false)
+  assert.equal(
+    useAppStore.getState().workflowPanelWorkspaceId,
+    WORKSPACE_ONE.id,
+    'closing must preserve the scope so a reopen stays in the same project'
+  )
+  useAppStore.getState().setWorkflowPanelOpen(true)
+  assert.equal(useAppStore.getState().workflowPanelWorkspaceId, null)
+  assert.equal(useAppStore.getState().workflowPanelFilter, null)
 })

--- a/src/renderer/src/store-session-transitions.test.ts
+++ b/src/renderer/src/store-session-transitions.test.ts
@@ -474,8 +474,10 @@ test('createNewSession opens the new conversation in Chat', async () => {
 
   await useAppStore.getState().createNewSession()
 
+  const state = useAppStore.getState()
   assert.equal(calls.includes('createNew'), true)
-  assert.equal(useAppStore.getState().currentView, 'chat')
+  assert.equal(state.currentView, 'chat')
+  assert.equal(state.sessionLoading, false, 'an empty new session should render immediately')
 })
 
 test('forkFrom is gated by the same warning', async () => {

--- a/src/renderer/src/store-session-transitions.test.ts
+++ b/src/renderer/src/store-session-transitions.test.ts
@@ -1,6 +1,6 @@
 import { test, before, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
-import type { PiExtensionUiRequest, SessionListItem, SessionState, Workspace } from '../../shared/ipc-contracts'
+import type { PiExtensionUiRequest, SessionListItem, SessionRuntimeInfo, SessionState, Workspace } from '../../shared/ipc-contracts'
 import type { PreviewTarget } from './store'
 
 // Each recorded call is appended to `calls`, so tests can assert both that a
@@ -317,6 +317,56 @@ beforeEach(() => {
   // reset itself when the previous test left the flag set, and that push
   // belongs to cleanup, not to the test about to run.
   calls.length = 0
+})
+
+test('a ready new runtime hydrates while the empty session is still loading', async () => {
+  useAppStore.setState({
+    activeWorkspace: WORKSPACE_ONE,
+    workspaces: [WORKSPACE_ONE],
+    activeSessionRuntimeId: 'rt-new',
+    sessionLoading: true,
+    sessionState: null,
+    messages: [],
+  })
+
+  const runtime: SessionRuntimeInfo = {
+    runtimeId: 'rt-new',
+    workspaceId: WORKSPACE_ONE.id,
+    sessionPath: SESSION_PATH,
+    sessionId: 'session-new',
+    status: 'running',
+    pid: 123,
+    error: null,
+    activity: null,
+    active: true,
+  }
+  useAppStore.getState().handleSessionRuntime(runtime)
+  await new Promise<void>((resolve) => setImmediate(resolve))
+
+  assert.equal(calls.includes('getMessages'), true)
+  assert.equal(useAppStore.getState().sessionLoading, false)
+})
+
+test('an active runtime error ends the session loading state', () => {
+  useAppStore.setState({
+    activeSessionRuntimeId: 'rt-failed',
+    sessionLoading: true,
+  })
+
+  useAppStore.getState().handleSessionRuntime({
+    runtimeId: 'rt-failed',
+    workspaceId: WORKSPACE_ONE.id,
+    sessionPath: null,
+    sessionId: null,
+    status: 'error',
+    pid: null,
+    error: 'Pi failed to start',
+    activity: 'failed',
+    active: true,
+  })
+
+  assert.equal(useAppStore.getState().sessionLoading, false)
+  assert.equal(useAppStore.getState().piError, 'Pi failed to start')
 })
 
 test('clearMessages resets every per-turn streaming field', () => {

--- a/src/renderer/src/store-session-transitions.test.ts
+++ b/src/renderer/src/store-session-transitions.test.ts
@@ -191,6 +191,10 @@ const piDesktopStub = {
       calls.push('createNew')
       return { success: true }
     },
+    closeRuntime: async (runtimeId: string) => {
+      calls.push(`closeRuntime:${runtimeId}`)
+      return { runtimeId, workspaceId: WORKSPACE_ONE.id, sessionPath: SESSION_PATH, empty: false, deleted: false }
+    },
     fork: async (entryId: string) => {
       calls.push(`fork:${entryId}`)
       return { success: true }
@@ -367,6 +371,41 @@ test('an active runtime error ends the session loading state', () => {
 
   assert.equal(useAppStore.getState().sessionLoading, false)
   assert.equal(useAppStore.getState().piError, 'Pi failed to start')
+})
+
+test('closed runtime events remove session tabs from renderer state', () => {
+  useAppStore.setState({
+    sessionRuntimes: {
+      'rt-closed': {
+        runtimeId: 'rt-closed',
+        workspaceId: WORKSPACE_ONE.id,
+        sessionPath: SESSION_PATH,
+        sessionId: 'closed-session',
+        status: 'stopped',
+        pid: null,
+        error: null,
+        activity: null,
+        active: true,
+      },
+    },
+    activeSessionRuntimeId: 'rt-closed',
+  })
+
+  useAppStore.getState().handleSessionRuntime({
+    runtimeId: 'rt-closed',
+    workspaceId: WORKSPACE_ONE.id,
+    sessionPath: SESSION_PATH,
+    sessionId: 'closed-session',
+    status: 'stopped',
+    pid: null,
+    error: null,
+    activity: null,
+    active: false,
+    closed: true,
+  })
+
+  assert.equal(useAppStore.getState().sessionRuntimes['rt-closed'], undefined)
+  assert.equal(useAppStore.getState().activeSessionRuntimeId, null)
 })
 
 test('clearMessages resets every per-turn streaming field', () => {

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -53,6 +53,7 @@ import type {
   WorkspaceActivityMap,
   WorkflowRunSummary,
   SessionRuntimeInfo,
+  SessionLaunchTaskOptions,
 } from '../../shared/ipc-contracts'
 
 export type { DisplayAttachment, DisplayMessage } from './message-parsing'
@@ -229,7 +230,7 @@ interface AppState {
   pendingFollowUp: string[]
 
   // UI
-  currentView: 'home' | 'chat' | 'settings' | 'sessions' | 'timeline' | 'packages' | 'diff' | 'notes' | 'skills' | 'diagnostics'
+  currentView: 'home' | 'chat' | 'mission-control' | 'settings' | 'sessions' | 'timeline' | 'packages' | 'diff' | 'notes' | 'skills' | 'diagnostics'
   // Scope for the Sessions view: 'current' shows only the active workspace's
   // sessions, 'all' keeps every project's history visible. Entry points set it
   // (sidebar Sessions = current, View all / command palette = all); the panel's
@@ -358,6 +359,7 @@ interface AppState {
   notes: Note[]
   notePickerOpen: boolean
   commandPaletteOpen: boolean
+  taskLauncherOpen: boolean
   // A prompt queued for insertion into the chat input. The nonce lets the
   // chat input re-apply the same text on repeated inserts.
   pendingInsert: { text: string; nonce: number; replace?: boolean } | null
@@ -398,6 +400,7 @@ interface AppActions {
 
   // Session
   createNewSession: () => Promise<void>
+  launchTask: (options: SessionLaunchTaskOptions) => Promise<boolean>
   switchSession: (path: string, projectPath?: string) => Promise<void>
   /**
    * Open a session row from any surface (sidebar, session panel, quick
@@ -552,6 +555,7 @@ interface AppActions {
   clearPendingInsert: () => void
   setNotePickerOpen: (open: boolean) => void
   setCommandPalette: (open: boolean) => void
+  setTaskLauncherOpen: (open: boolean) => void
   startNoteFromText: (text: string) => void
   clearNoteDraft: () => void
 
@@ -858,6 +862,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   notes: [],
   notePickerOpen: false,
   commandPaletteOpen: false,
+  taskLauncherOpen: false,
   pendingInsert: null,
   noteDraft: null,
   updateInfo: null,
@@ -1216,6 +1221,46 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         content: `New session error: ${err instanceof Error ? err.message : String(err)}`,
         timestamp: Date.now(),
       })
+    }
+  },
+
+  launchTask: async (options) => {
+    const prompt = options.prompt.trim()
+    if (!prompt) return false
+    if (get().activeWorkspace?.id !== options.workspaceId) {
+      if (!(await get().activateWorkspace(options.workspaceId, { start: false }))) return false
+    }
+
+    const gen = ++sessionLoadGeneration
+    try {
+      const runtime = await window.piDesktop.session.launchTask({
+        workspaceId: options.workspaceId,
+        prompt,
+      })
+      if (gen !== sessionLoadGeneration) return false
+      get().clearMessages()
+      set({
+        currentView: 'chat',
+        sessionState: null,
+        sessionStats: null,
+        sessionLoading: true,
+        activeSessionRuntimeId: runtime.runtimeId,
+        piStatus: runtime.status === 'stopped' ? 'starting' : runtime.status,
+        piPid: runtime.pid,
+        piError: runtime.error,
+      })
+      scheduleSessionListRefresh(get)
+      return true
+    } catch (err) {
+      if (gen !== sessionLoadGeneration) return false
+      get().addMessage({
+        id: generateId(),
+        role: 'system',
+        content: `Task launch error: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      })
+      set({ sessionLoading: false })
+      return false
     }
   },
 
@@ -2804,6 +2849,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   setNotePickerOpen: (open) => set({ notePickerOpen: open }),
 
   setCommandPalette: (open) => set({ commandPaletteOpen: open }),
+  setTaskLauncherOpen: (open) => set({ taskLauncherOpen: open }),
 
   startNoteFromText: (text) =>
     set({ noteDraft: text, notePickerOpen: false, currentView: 'notes' }),

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -1233,13 +1233,17 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       if (get().activeWorkspace?.id !== workspaceId) {
         if (!(await get().activateWorkspace(workspaceId, { start: false }))) return false
       }
+      let reusedWorktree = false
       if (options.isolated) {
         const label = prompt.split(/\r?\n/, 1)[0]?.trim().slice(0, 60) || 'Task'
+        const knownWorkspaceIds = new Set(get().workspaces.map((workspace) => workspace.id))
         const workspace = await window.piDesktop.workspace.createTab({
           name: label,
           sourceWorkspaceId: workspaceId,
+          taskPrompt: prompt,
           startPi: false,
         })
+        reusedWorktree = knownWorkspaceIds.has(workspace.id) || workspace.managed === false
         await get().loadWorkspaces()
         if (!(await get().activateWorkspace(workspace.id, { start: false }))) return false
         workspaceId = workspace.id
@@ -1262,6 +1266,14 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         piPid: runtime.pid,
         piError: runtime.error,
       })
+      if (reusedWorktree) {
+        get().addMessage({
+          id: generateId(),
+          role: 'system',
+          content: 'Found the related existing Git worktree and continued the task there.',
+          timestamp: Date.now(),
+        })
+      }
       scheduleSessionListRefresh(get)
       return true
     } catch (err) {
@@ -2458,10 +2470,13 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   removeWorkspace: async (workspaceId) => {
     const workspace = get().workspaces.find((w) => w.id === workspaceId)
     const isWorktree = workspace?.kind === 'worktree'
+    const isManagedWorktree = isWorktree && workspace?.managed !== false
     const confirmed = await get().requestConfirm({
       title: isWorktree ? 'Close tab' : 'Remove workspace',
       message: isWorktree
-        ? `Close "${workspace?.name ?? workspaceId}"? Clean worktrees are removed; tabs with uncommitted changes are preserved on disk.`
+        ? isManagedWorktree
+          ? `Close "${workspace?.name ?? workspaceId}"? Clean worktrees are removed; tabs with uncommitted changes are preserved on disk.`
+          : `Close "${workspace?.name ?? workspaceId}"? This existing worktree and its files remain on disk.`
         : `Remove "${workspace?.name ?? workspaceId}" from the sidebar? Its Pi process stops; files on disk are not touched.`,
       confirmLabel: isWorktree ? 'Close tab' : 'Remove',
       cancelLabel: 'Cancel',

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -2113,7 +2113,6 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   },
 
   handleSessionRuntime: (runtime) => {
-    const state = get()
     set((current) => ({
       sessionRuntimes: { ...current.sessionRuntimes, [runtime.runtimeId]: runtime },
       activeSessionRuntimeId: runtime.active
@@ -2125,14 +2124,20 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         piStatus: runtime.status,
         piPid: runtime.pid,
         piError: runtime.error,
+        ...(runtime.status === 'error' || runtime.status === 'stopped' ? { sessionLoading: false } : {}),
       } : {}),
     }))
+    // A newly-created session is intentionally empty, so its renderer stays
+    // in sessionLoading until Pi reports the generated session path. Hydrate
+    // that expected active runtime even though loading is still true; the old
+    // guard made New Session look stuck forever after Pi was already ready.
+    const current = get()
     if (
       runtime.active &&
       runtime.status === 'running' &&
       runtime.sessionPath &&
-      state.sessionState?.sessionFile !== runtime.sessionPath &&
-      !state.sessionLoading
+      current.sessionState?.sessionFile !== runtime.sessionPath &&
+      (!current.sessionLoading || current.activeSessionRuntimeId === runtime.runtimeId)
     ) {
       void get().reloadActiveSession({ refreshList: false })
     }

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -51,6 +51,7 @@ import type {
   PermissionRulesScope,
   PendingPromptCounts,
   WorkspaceActivityMap,
+  WorkflowRunSummary,
 } from '../../shared/ipc-contracts'
 
 export type { DisplayAttachment, DisplayMessage } from './message-parsing'
@@ -225,6 +226,17 @@ interface AppState {
 
   // UI
   currentView: 'home' | 'chat' | 'settings' | 'sessions' | 'timeline' | 'packages' | 'diff' | 'notes' | 'skills' | 'diagnostics'
+  // Scope for the Sessions view: 'current' shows only the active workspace's
+  // sessions, 'all' keeps every project's history visible. Entry points set it
+  // (sidebar Sessions = current, View all / command palette = all); the panel's
+  // toggle flips it live.
+  sessionsScope: 'all' | 'current'
+  workflowPanelOpen: boolean
+  // When set, the workflow navigator only lists runs recorded for this Pi
+  // session id (run.sessionId). null = no session scope.
+  workflowPanelFilter: string | null
+  // Project/workspace scope for the sidebar Activity entry. null = global.
+  workflowPanelWorkspaceId: string | null
   // Bumped to request the chat scroll jump to the bottom (used when resuming a
   // session/workspace from Home). In-app session switches leave it untouched so
   // the chat restores each session's remembered scroll position instead.
@@ -259,6 +271,8 @@ interface AppState {
   pendingPromptCounts: PendingPromptCounts
   // Per-workspace background activity derived in main (idle entries omitted).
   workspaceActivity: WorkspaceActivityMap
+  // Dynamic workflow runs read from the extension's persisted run journal.
+  workflowRuns: WorkflowRunSummary[]
   // Extension status entries (setStatus fire-and-forget). Keyed by statusKey.
   extensionStatuses: Record<string, string>
   // Live subagent progress from tool_execution_update events (subagent tool).
@@ -411,6 +425,11 @@ interface AppActions {
 
   // UI
   setCurrentView: (view: AppState['currentView']) => void
+  setSessionsScope: (scope: 'all' | 'current') => void
+  setWorkflowPanelOpen: (open: boolean) => void
+  openWorkflowRunsForSession: (sessionId: string) => void
+  openWorkflowRunsForWorkspace: (workspaceId: string | null) => void
+  refreshWorkflowRuns: () => Promise<void>
   requestChatScrollToBottom: () => void
   // Resolves false when a dirty-editor discard was declined (diff pane only).
   setChatSidePanel: (panel: AppState['chatSidePanel']) => Promise<boolean>
@@ -453,14 +472,17 @@ interface AppActions {
   // Workspaces
   loadWorkspaces: () => Promise<void>
   createWorkspace: (name: string, path: string) => Promise<void>
+  /** Create a clean Git worktree and start it as a new independent tab. */
+  createWorktreeTab: () => Promise<void>
   /**
    * Open a folder as a workspace (create if needed, switch into it, show Chat).
    * Used by File → Open Project and by drag-dropping a folder onto the window.
-   * Resolves false if the still-working confirm was declined or switch failed.
+   * Resolves false if the editor discard was declined or the switch failed.
    */
   openFolderAsWorkspace: (folderPath: string) => Promise<boolean>
   /**
-   * Resolves false when the user declined the still-working warning, or the switch failed.
+   * Resolves false when the editor discard was declined or the switch failed.
+   * Workspace tabs keep their Pi processes running in the background.
    * skipSessionLoad: when opening a specific session next, skip resume+history —
    * switchSession will load the target once.
    */
@@ -622,12 +644,37 @@ function adoptMainSideActivation(
   previousActiveId: string | null
 ): void {
   const active = get().activeWorkspace
-  if (!active || active.id === previousActiveId) return
-  // The preview closes for the same reason switchWorkspace closes it: its
-  // file belongs to a workspace that is no longer active, and the new
-  // workspace's file service refuses paths outside its root.
-  set({ extensionUiRequest: null, previewTarget: null, editorDirty: false })
+  if (active?.id === previousActiveId) return
+
+  // The preview and chat belong to the workspace that just disappeared or was
+  // activated by main. Reset them before attaching the replacement manager;
+  // otherwise closing the active tab leaves the old conversation on screen.
+  sessionLoadGeneration += 1
+  set({
+    extensionUiRequest: null,
+    previewTarget: null,
+    editorDirty: false,
+    sessionState: null,
+    sessionStats: null,
+    timelineEvents: [],
+    piStatus: 'stopped',
+    piPid: null,
+    piError: null,
+    ...idleTurnState(),
+  })
+  if (!active) return
+
   void window.piDesktop.ui.flushPendingPrompts(active.id)
+  // A main-side activation is used by workspace removal and first-workspace
+  // creation, neither of which goes through switchWorkspace's normal Pi start.
+  // Start the promoted workspace when there was a previous active workspace;
+  // the first-workspace open flow starts it through its regular switch path.
+  if (previousActiveId !== null) {
+    void get().startPi().then(() => {
+      if (get().activeWorkspace?.id !== active.id || get().piStatus !== 'running') return
+      void get().reloadActiveSession()
+    })
+  }
 }
 
 function scheduleSessionListRefresh(get: () => AppState & AppActions): void {
@@ -747,6 +794,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   // Default to the Home/launcher view; useInitialize switches to 'chat' when
   // the openToHomeOnLaunch setting is off (legacy boot-into-chat behavior).
   currentView: 'home',
+  sessionsScope: 'all',
+  workflowPanelOpen: false,
+  workflowPanelFilter: null,
+  workflowPanelWorkspaceId: null,
   chatScrollBottomNonce: 0,
   chatSidePanel: null,
   sidebarOpen: true,
@@ -761,6 +812,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   extensionNotify: null,
   pendingPromptCounts: {},
   workspaceActivity: {},
+  workflowRuns: [],
   extensionStatuses: {},
   subagentProgress: [],
   confirmRequest: null,
@@ -883,6 +935,15 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   // ─── Prompts ──────────────────────────────────────────────────────────
 
   sendPrompt: async (message, options) => {
+    const trimmed = message.trim().toLowerCase()
+    if (trimmed === '/workflow' || trimmed === '/workflows') {
+      // Route through the action so a session-scoped filter can never leak
+      // into the global view opened from chat.
+      get().setWorkflowPanelOpen(true)
+      return
+    }
+    if (trimmed.startsWith('/workflows run ')) get().setWorkflowPanelOpen(true)
+
     const { piStatus, isStreaming, sessionState, settings } = get()
 
     if (piStatus !== 'running') return
@@ -1082,14 +1143,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
-  // Gate on every action that abandons the live turn. Pi runs one session per
-  // workspace process, and `switch_session`, `new_session`, `fork` and `clone`
-  // all tear the current one down — that disposal aborts the running turn along
-  // with its bash commands, retries and compaction, and detaches the listeners
-  // that would have emitted the rest of its events. A workspace switch spares the
-  // turn but clears the chat rendering it. Either way the user loses the response,
-  // so the loss is made explicit instead of happening on a stray sidebar click.
-  // Returns true when the caller may proceed.
+  // Gate actions that replace the active session in the same Pi process. A
+  // workspace/tab switch is deliberately not included: every workspace owns a
+  // separate Pi process, so leaving it running is safe and is the whole point
+  // of the tab model.
   //
   // Must be consulted BEFORE anything calls clearMessages(): that resets
   // `isStreaming`, which is the signal this gate reads.
@@ -1129,6 +1186,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         return
       }
       get().clearMessages()
+      // Creating a session is a navigation action too: show the new empty
+      // conversation immediately instead of leaving the user in Sessions to
+      // find and click the row Pi just created.
+      set({ currentView: 'chat' })
       await get().refreshSessionState()
       await get().refreshSessionStats()
       if (gen !== sessionLoadGeneration) return
@@ -1340,9 +1401,6 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     if (projectPath && !(activeWorkspace && pathsEqual(activeWorkspace.path, projectPath))) {
       const matchingWs = workspaces.find((w) => pathsEqual(w.path, projectPath))
       if (matchingWs) {
-        // The workspace switch carries the "Pi is still working" warning for
-        // this whole flow; a decline there must stop the session switch too,
-        // or the declined turn gets torn down anyway by the change below.
         if (!(await get().switchWorkspace(matchingWs.id, { skipSessionLoad: true }))) return
       } else {
         await get().createWorkspace(session.projectName, projectPath)
@@ -1352,9 +1410,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
     // switchSession's working-workspace guard covers the live-turn cases from
     // here on: the turn's own session re-attaches instead of switching, and
-    // opening a different session of a mid-turn workspace warns first (the
-    // switchWorkspace gates above only cover a turn whose streaming is on
-    // screen in the departing workspace).
+    // opening a different session of a mid-turn workspace warns first.
     await get().switchSession(session.path)
     // Bring the chat into view (may be on Settings/Notes/etc.). In-app
     // switches keep their remembered scroll position, so no force-to-bottom.
@@ -1415,6 +1471,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
               // or timestamp until the next list refresh supplies a preview.
               preview: null,
               sessionId: sessionState.sessionId,
+              piSessionId: sessionState.sessionId,
               lastModified: Date.now(),
               messageCount: sessionState.messageCount,
               projectPath: activeWorkspace?.path ?? '',
@@ -1550,6 +1607,39 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   // ─── UI ───────────────────────────────────────────────────────────────
 
   setCurrentView: (view) => set({ currentView: view }),
+  // Lifted into the store so the scope survives SessionPanel remounts (it
+  // unmounts on every navigation) and so sidebar entry points can set it.
+  setSessionsScope: (scope) => set({ sessionsScope: scope }),
+  // A direct global entry point (slash command) clears project/session scope.
+  // Closing merely hides the panel and PRESERVES the scope so a reopen stays in
+  // the same project or session.
+  setWorkflowPanelOpen: (open) =>
+    set((state) => ({
+      workflowPanelOpen: open,
+      workflowPanelFilter: open ? null : state.workflowPanelFilter,
+      workflowPanelWorkspaceId: open ? null : state.workflowPanelWorkspaceId,
+    })),
+  openWorkflowRunsForSession: (sessionId) => set({
+    workflowPanelOpen: true,
+    workflowPanelFilter: sessionId,
+    workflowPanelWorkspaceId: null,
+  }),
+  // Project/workspace scope for the sidebar Activity entry. null = global.
+  // The signature is null-widened: the Tools entry opens the global list with
+  // an explicit null (the same value a direct global open falls back to).
+  openWorkflowRunsForWorkspace: (workspaceId: string | null) => set({
+    workflowPanelOpen: true,
+    workflowPanelFilter: null,
+    workflowPanelWorkspaceId: workspaceId,
+  }),
+  refreshWorkflowRuns: async () => {
+    try {
+      const workflowRuns = await window.piDesktop.workflows.list()
+      set({ workflowRuns })
+    } catch {
+      set({ workflowRuns: [] })
+    }
+  },
   requestChatScrollToBottom: () =>
     set((state) => ({ chatScrollBottomNonce: state.chatScrollBottomNonce + 1 })),
   setChatSidePanel: async (panel) => {
@@ -2074,9 +2164,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   createWorkspace: async (name, path) => {
     // Main activates an existing workspace on a duplicate path — inside the
     // create call, with none of the switch teardown. Route the duplicate
-    // through switchWorkspace instead, so every caller gets the still-working
-    // confirm, the dirty-editor ask, the chat clear, and the status resync;
-    // the already-active duplicate needs nothing at all.
+    // through switchWorkspace instead, so every caller gets the dirty-editor
+    // ask, the chat clear, and the status resync; the already-active duplicate
+    // needs nothing at all.
     const duplicate = get().workspaces.find((w) => pathsEqual(w.path, path))
     if (duplicate) {
       if (duplicate.id !== get().activeWorkspace?.id) {
@@ -2094,6 +2184,40 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         id: generateId(),
         role: 'system',
         content: `Create workspace error: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      })
+    }
+  },
+
+  createWorktreeTab: async () => {
+    if (!(await get().confirmDiscardEditorChanges())) return
+    try {
+      // A new tab starts from the repository's HEAD, never by copying the
+      // source tab's dirty files. That makes opening a tab safe while the old
+      // Pi is actively editing its own checkout.
+      const workspace = await window.piDesktop.workspace.createTab()
+      await get().loadWorkspaces()
+      const switched = await get().switchWorkspace(workspace.id)
+      if (switched) {
+        get().setCurrentView('chat')
+        if (workspace.sourceWasDirty) {
+          get().addMessage({
+            id: generateId(),
+            role: 'system',
+            content: 'This tab starts from the last commit. Uncommitted files remain in the source tab.',
+            timestamp: Date.now(),
+          })
+        }
+      }
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      const content = /not a git repository/i.test(detail)
+        ? 'This project is not a Git repository. Use New session for another conversation, or open a Git project for an isolated tab.'
+        : `New isolated tab error: ${detail}`
+      get().addMessage({
+        id: generateId(),
+        role: 'system',
+        content,
         timestamp: Date.now(),
       })
     }
@@ -2157,11 +2281,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     // workspace the user never actually switched to.
     let switchCommitted = false
     try {
-      // Ask first: everything below clears the chat, and `clearMessages()` resets
-      // the `isStreaming` flag that the gate on any follow-up session change reads.
-      // Without this the cross-workspace path in the sidebar and session panel
-      // (switch workspace, then switch session) skipped the warning entirely.
-      if (!(await get().confirmSessionChange('workspace'))) return false
+      // Workspace switches are safe: the old workspace's Pi process keeps
+      // running and the activity tracker continues to observe it. Only the
+      // editor buffer needs a confirmation because it cannot follow the path.
       // The editor buffer belongs to the workspace being left, and the new
       // workspace's file service refuses paths outside its root — unsaved
       // edits would be stranded unsaveable. Ask before committing the switch.
@@ -2238,10 +2360,13 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   removeWorkspace: async (workspaceId) => {
     const workspace = get().workspaces.find((w) => w.id === workspaceId)
+    const isWorktree = workspace?.kind === 'worktree'
     const confirmed = await get().requestConfirm({
-      title: 'Remove workspace',
-      message: `Remove "${workspace?.name ?? workspaceId}" from the sidebar? Its Pi process stops; files on disk are not touched.`,
-      confirmLabel: 'Remove',
+      title: isWorktree ? 'Close tab' : 'Remove workspace',
+      message: isWorktree
+        ? `Close "${workspace?.name ?? workspaceId}"? Clean worktrees are removed; tabs with uncommitted changes are preserved on disk.`
+        : `Remove "${workspace?.name ?? workspaceId}" from the sidebar? Its Pi process stops; files on disk are not touched.`,
+      confirmLabel: isWorktree ? 'Close tab' : 'Remove',
       cancelLabel: 'Cancel',
       danger: true,
     })
@@ -2253,9 +2378,17 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
     const previousActiveId = get().activeWorkspace?.id ?? null
     try {
-      await window.piDesktop.workspace.remove(workspaceId)
+      const result = await window.piDesktop.workspace.remove(workspaceId)
       await get().loadWorkspaces()
       adoptMainSideActivation(get, set, previousActiveId)
+      if (result.preservedWorktreePath) {
+        get().addMessage({
+          id: generateId(),
+          role: 'system',
+          content: `Tab closed, but its uncommitted worktree was preserved at ${result.preservedWorktreePath}`,
+          timestamp: Date.now(),
+        })
+      }
     } catch (err) {
       get().addMessage({
         id: generateId(),

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -1227,14 +1227,27 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   launchTask: async (options) => {
     const prompt = options.prompt.trim()
     if (!prompt) return false
-    if (get().activeWorkspace?.id !== options.workspaceId) {
-      if (!(await get().activateWorkspace(options.workspaceId, { start: false }))) return false
-    }
-
-    const gen = ++sessionLoadGeneration
+    let workspaceId = options.workspaceId
+    let gen = 0
     try {
+      if (get().activeWorkspace?.id !== workspaceId) {
+        if (!(await get().activateWorkspace(workspaceId, { start: false }))) return false
+      }
+      if (options.isolated) {
+        const label = prompt.split(/\r?\n/, 1)[0]?.trim().slice(0, 60) || 'Task'
+        const workspace = await window.piDesktop.workspace.createTab({
+          name: label,
+          sourceWorkspaceId: workspaceId,
+          startPi: false,
+        })
+        await get().loadWorkspaces()
+        if (!(await get().activateWorkspace(workspace.id, { start: false }))) return false
+        workspaceId = workspace.id
+      }
+
+      gen = ++sessionLoadGeneration
       const runtime = await window.piDesktop.session.launchTask({
-        workspaceId: options.workspaceId,
+        workspaceId,
         prompt,
       })
       if (gen !== sessionLoadGeneration) return false
@@ -1252,7 +1265,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       scheduleSessionListRefresh(get)
       return true
     } catch (err) {
-      if (gen !== sessionLoadGeneration) return false
+      if (gen !== 0 && gen !== sessionLoadGeneration) return false
       get().addMessage({
         id: generateId(),
         role: 'system',

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -1202,10 +1202,13 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         currentView: 'chat',
         sessionState: null,
         sessionStats: null,
-        sessionLoading: runtime?.status !== 'running',
+        // A new session has no history to wait for. Show the empty chat
+        // immediately; the runtime event hydrates its generated session path
+        // when Pi is ready, while piStatus still communicates startup.
+        sessionLoading: false,
         ...(runtime ? {
           activeSessionRuntimeId: runtime.runtimeId,
-          piStatus: runtime.status,
+          piStatus: runtime.status === 'stopped' ? 'starting' : runtime.status,
           piPid: runtime.pid,
           piError: runtime.error,
         } : {}),

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -158,6 +158,10 @@ export function formatPromptsWaiting(count: number): string {
   return `${count} Pi prompt${count === 1 ? '' : 's'} waiting`
 }
 
+function councilErrorMessage(error: unknown): string {
+  return `Council failed: ${error instanceof Error ? error.message : String(error)}`
+}
+
 /**
  * The per-turn state left behind once a turn is over. `isStreaming` otherwise
  * only clears on `agent_end` / `turn_end`, so any path that ends a turn without
@@ -1059,74 +1063,78 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
     set({ councilRun: { phase: 'detecting', request, results: [] } })
 
-    const detectResult = await window.piDesktop.council.detect()
-    const detected = { pi: false, claude: false, codex: false } as Record<CouncilAgentId, boolean>
-    for (const a of detectResult.agents) detected[a.id] = a.found
-
-    const resolution = resolveActiveMembers(config, detected)
-    if (!resolution.canRun) {
-      set({ councilRun: { phase: 'refused', request, results: [], reason: resolution.reason } })
-      return
-    }
-
-    set({
-      councilRun: {
-        phase: 'consulting',
-        request,
-        results: [],
-        members: resolution.active,
-        partials: {},
-        startedAt: Date.now(),
-      },
-    })
-
-    // Stream live consultant output into councilRun.partials while consulting.
-    const unsubscribe = window.piDesktop.council.onProgress(({ id, chunk }) => {
-      const run = get().councilRun
-      if (!run || run.phase !== 'consulting') return
-      const partials = { ...(run.partials ?? {}) }
-      partials[id] = (partials[id] ?? '') + chunk
-      set({ councilRun: { ...run, partials } })
-    })
-
-    let results
     try {
-      ;({ results } = await window.piDesktop.council.runConsultants({
-        request,
-        members: resolution.active,
-        timeoutSeconds: config.timeoutSeconds,
-        consensusMode: config.consensusMode,
-      }))
-    } finally {
-      unsubscribe()
-    }
+      const detectResult = await window.piDesktop.council.detect()
+      const detected = { pi: false, claude: false, codex: false } as Record<CouncilAgentId, boolean>
+      for (const a of detectResult.agents) detected[a.id] = a.found
 
-    if (!hasQuorum(results)) {
+      const resolution = resolveActiveMembers(config, detected)
+      if (!resolution.canRun) {
+        set({ councilRun: { phase: 'refused', request, results: [], reason: resolution.reason } })
+        return
+      }
+
       set({
         councilRun: {
-          phase: 'refused',
+          phase: 'consulting',
           request,
-          results,
-          reason: 'No consultant produced a plan (all timed out or errored). Council aborted.',
+          results: [],
+          members: resolution.active,
+          partials: {},
+          startedAt: Date.now(),
         },
       })
-      return
-    }
 
-    // The arbiter runs in an isolated read-only Pi subprocess. Consultant plans
-    // are untrusted input, so they are never fed to the live (writable) session —
-    // only the vetted consensus plan is, and only after the user approves it.
-    const merged = await runArbiterStep(
-      { kind: 'merge', request, results, timeoutSeconds: config.timeoutSeconds },
-      { request, results },
-      get,
-      set,
-    )
-    if (merged.error) {
-      set({ councilRun: { phase: 'refused', request, results, reason: merged.error } })
-      return
+      // Stream live consultant output into councilRun.partials while consulting.
+      const unsubscribe = window.piDesktop.council.onProgress(({ id, chunk }) => {
+        const run = get().councilRun
+        if (!run || run.phase !== 'consulting') return
+        const partials = { ...(run.partials ?? {}) }
+        partials[id] = (partials[id] ?? '') + chunk
+        set({ councilRun: { ...run, partials } })
+      })
+
+      let results: ConsultantResult[]
+      try {
+        ;({ results } = await window.piDesktop.council.runConsultants({
+          request,
+          members: resolution.active,
+          timeoutSeconds: config.timeoutSeconds,
+          consensusMode: config.consensusMode,
+        }))
+      } finally {
+        unsubscribe()
+      }
+
+      if (!hasQuorum(results)) {
+        set({
+          councilRun: {
+            phase: 'refused',
+            request,
+            results,
+            reason: 'No consultant produced a plan (all timed out or errored). Council aborted.',
+          },
+        })
+        return
+      }
+
+      // The arbiter runs in an isolated read-only Pi subprocess. Consultant plans
+      // are untrusted input, so they are never fed to the live (writable) session —
+      // only the vetted consensus plan is, and only after the user approves it.
+      const merged = await runArbiterStep(
+        { kind: 'merge', request, results, timeoutSeconds: config.timeoutSeconds },
+        { request, results },
+        get,
+        set,
+      )
+      if (merged.error) {
+        set({ councilRun: { phase: 'refused', request, results, reason: merged.error } })
+        return
+      }
+      set({ councilRun: { phase: 'awaiting-approval', request, results, consensus: merged.plan } })
+    } catch (error) {
+      set({ councilRun: { phase: 'refused', request, results: [], reason: councilErrorMessage(error) } })
     }
-    set({ councilRun: { phase: 'awaiting-approval', request, results, consensus: merged.plan } })
   },
 
   approveCouncilPlan: async () => {

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -52,6 +52,7 @@ import type {
   PendingPromptCounts,
   WorkspaceActivityMap,
   WorkflowRunSummary,
+  SessionRuntimeInfo,
 } from '../../shared/ipc-contracts'
 
 export type { DisplayAttachment, DisplayMessage } from './message-parsing'
@@ -196,6 +197,9 @@ interface AppState {
   sessionState: SessionState | null
   sessionStats: SessionStats | null
   sessionList: SessionListItem[]
+  // Live Pi runtimes keyed by runtime id. Several can share one project cwd.
+  sessionRuntimes: Record<string, SessionRuntimeInfo>
+  activeSessionRuntimeId: string | null
   forkMessages: ForkPoint[]
 
   // Messages
@@ -394,12 +398,12 @@ interface AppActions {
 
   // Session
   createNewSession: () => Promise<void>
-  switchSession: (path: string) => Promise<void>
+  switchSession: (path: string, projectPath?: string) => Promise<void>
   /**
    * Open a session row from any surface (sidebar, session panel, quick
    * switcher): auto-switches or creates the owning workspace first, then
-   * switches to the session and shows Chat. A declined "Pi is still working"
-   * confirm aborts the whole flow.
+   * switches to the session and shows Chat. The previous session runtime keeps
+   * running in the background while the new one hydrates.
    */
   openSessionItem: (session: SessionListItem) => Promise<void>
   reloadActiveSession: (options?: { refreshList?: boolean }) => Promise<void>
@@ -449,6 +453,7 @@ interface AppActions {
   handlePiEvent: (event: PiRpcEvent) => void
   handlePendingPromptCounts: (counts: PendingPromptCounts) => void
   handleWorkspaceActivity: (map: WorkspaceActivityMap) => void
+  handleSessionRuntime: (runtime: SessionRuntimeInfo) => void
   /**
    * Boot/reload recovery: the dialog slot and the counts are renderer memory
    * only, while main keeps every held prompt. Pulls the counts snapshot and
@@ -486,6 +491,7 @@ interface AppActions {
    * skipSessionLoad: when opening a specific session next, skip resume+history —
    * switchSession will load the target once.
    */
+  activateWorkspace: (workspaceId: string, options?: { start?: boolean }) => Promise<boolean>
   switchWorkspace: (
     workspaceId: string,
     options?: { skipSessionLoad?: boolean }
@@ -656,6 +662,7 @@ function adoptMainSideActivation(
     editorDirty: false,
     sessionState: null,
     sessionStats: null,
+    activeSessionRuntimeId: null,
     timelineEvents: [],
     piStatus: 'stopped',
     piPid: null,
@@ -777,6 +784,8 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   sessionState: null,
   sessionStats: null,
   sessionList: [],
+  sessionRuntimes: {},
+  activeSessionRuntimeId: null,
   forkMessages: [],
 
   messages: [],
@@ -1143,10 +1152,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
-  // Gate actions that replace the active session in the same Pi process. A
-  // workspace/tab switch is deliberately not included: every workspace owns a
-  // separate Pi process, so leaving it running is safe and is the whole point
-  // of the tab model.
+  // Gate destructive actions that still replace or discard work in the active
+  // runtime. Session navigation itself is deliberately not included: every
+  // session owns a separate Pi process, so leaving it running is safe.
   //
   // Must be consulted BEFORE anything calls clearMessages(): that resets
   // `isStreaming`, which is the signal this gate reads.
@@ -1169,30 +1177,36 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   createNewSession: async () => {
     const gen = ++sessionLoadGeneration
     try {
-      if (!(await get().confirmSessionChange('new'))) return
-      const result = await window.piDesktop.session.createNew() as { success?: boolean; error?: string } | null
+      // A new session owns a new Pi process. Never stop or warn about the
+      // session the user is leaving; it continues working in the background.
+      const result = await window.piDesktop.session.createNew() as SessionRuntimeInfo | { success?: boolean; error?: string } | null
       if (gen !== sessionLoadGeneration) return
-      if (result && result.success === false) {
+      if (result && 'success' in result && result.success === false) {
         get().addMessage({
           id: generateId(),
           role: 'system',
-          content: result.error ?? 'Cannot create session — Pi not running',
+          content: result.error ?? 'Cannot create session',
           timestamp: Date.now(),
         })
-        // The session did not change, so the chat still belongs here and must be
-        // kept. Only the turn is written off: Pi is not running to finish it, and
-        // its closing events will never arrive.
         set(idleTurnState())
         return
       }
       get().clearMessages()
-      // Creating a session is a navigation action too: show the new empty
-      // conversation immediately instead of leaving the user in Sessions to
-      // find and click the row Pi just created.
-      set({ currentView: 'chat' })
-      await get().refreshSessionState()
-      await get().refreshSessionStats()
-      if (gen !== sessionLoadGeneration) return
+      const runtime = result && 'runtimeId' in result ? result : null
+      set({
+        currentView: 'chat',
+        sessionState: null,
+        sessionStats: null,
+        sessionLoading: runtime?.status !== 'running',
+        ...(runtime ? {
+          activeSessionRuntimeId: runtime.runtimeId,
+          piStatus: runtime.status,
+          piPid: runtime.pid,
+          piError: runtime.error,
+        } : {}),
+      })
+      // The runtime start is intentionally asynchronous. Its runtime event
+      // hydrates this empty chat once Pi is ready.
       scheduleSessionListRefresh(get)
     } catch (err) {
       if (gen !== sessionLoadGeneration) return
@@ -1205,11 +1219,10 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
-  switchSession: async (path) => {
-    // Already on this session — avoid a full history reload. Only when its
-    // history is actually on screen: a skipSessionLoad workspace switch clears
-    // the chat while sessionState may already name this session, and skipping
-    // then would leave an empty chat and a dead session click.
+  switchSession: async (path, projectPath) => {
+    // Already on this session — avoid a full history reload. The explicit
+    // sessionLoading check still handles a fast workspace switch that cleared
+    // the view before the target runtime was bound.
     if (
       get().sessionState?.sessionFile === path &&
       !get().sessionLoading &&
@@ -1218,14 +1231,9 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       return
     }
 
-    // Gate first — must read isStreaming before clearMessages/idleTurnState.
-    if (!(await get().confirmSessionChange('switch'))) return
-
-    // Coalesce rapid clicks after the user has confirmed: only the last path runs.
+    // Coalesce rapid clicks: only the last target starts hydration.
     pendingSwitchPath = path
     const gen = ++sessionLoadGeneration
-
-    // Supersede any prior coalesce wait so its promise does not leak.
     if (switchCoalesceTimer) {
       clearTimeout(switchCoalesceTimer)
       switchCoalesceTimer = null
@@ -1241,85 +1249,49 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         switchCoalesceTimer = null
         switchCoalesceResolve = null
         resolve()
-      }, 80)
+      }, 40)
     })
-
-    // Superseded by a newer click.
     if (gen !== sessionLoadGeneration || pendingSwitchPath !== path) return
 
-    // Serialize against other in-flight switches so Pi never gets N concurrent
-    // get_messages (each multi‑MB IPC clone freezes the app).
     const run = async (): Promise<void> => {
       if (gen !== sessionLoadGeneration || pendingSwitchPath !== path) return
       try {
-        // A live turn in this workspace: the switch_session RPC ABORTS it —
-        // Pi treats the command as a session change even when the target is
-        // the very session it is already on (verified live: the in-flight
-        // response is discarded and never reaches the session file). When the
-        // activity map says this workspace is working, ask Pi which session
-        // it is on (get_state answers mid-turn): the turn's own session
-        // re-attaches instead of switching; anything else — including a
-        // failed/stale get_state, which must fail CLOSED — warns before
-        // killing a turn whose streaming was never on screen.
-        const activeId = get().activeWorkspace?.id
-        const activity = activeId ? get().workspaceActivity[activeId]?.state : undefined
-        if (activity === 'working' || activity === 'needs-approval') {
-          await get().refreshSessionState()
-          if (gen !== sessionLoadGeneration) return
-          if (get().sessionState?.sessionFile === path) {
-            set({ sessionLoading: true })
-            get().clearMessages()
-            await get().reloadActiveSession({ refreshList: false })
-            if (gen !== sessionLoadGeneration) return
-            scheduleSessionListRefresh(get)
-            // The reload only shows persisted messages; arm the attach so the
-            // working banner shows and turn boundaries backfill. Re-check the
-            // map first: the turn may have ended during the reload, and its
-            // disarming broadcast may already be behind us.
-            const still = activeId ? get().workspaceActivity[activeId]?.state : undefined
-            if (still === 'working' || still === 'needs-approval') {
-              set({ isStreaming: true, reattachedMidTurn: true })
-            }
-            return
-          }
-          // A different session (or an unconfirmable one): switching kills
-          // the background turn. When its streaming is on screen the
-          // confirmSessionChange gate above already warned; a background
-          // turn's isStreaming is false, so warn here before the teardown.
-          if (!get().isStreaming) {
-            const confirmed = await get().requestConfirm({
-              title: 'Pi is still working',
-              message:
-                'Pi has not finished responding in another session of this ' +
-                'workspace. Opening this session stops it: whatever Pi already ' +
-                'wrote to that session is kept, but the rest of the response ' +
-                'is discarded.',
-              confirmLabel: 'Switch anyway',
-              danger: true,
-            })
-            if (!confirmed || gen !== sessionLoadGeneration) return
-          }
-        }
-
-        set({ sessionLoading: true })
+        // Binding a different session is safe: its Pi process continues in the
+        // background. Render the new target immediately; only hydration waits.
+        set({
+          sessionLoading: true,
+          sessionState: null,
+          sessionStats: null,
+          activeSessionRuntimeId: null,
+        })
         get().clearMessages()
-        const result = (await window.piDesktop.session.switch(path)) as {
-          success?: boolean
-          error?: string
-        } | null
+        const result = await window.piDesktop.session.switch(path, projectPath) as SessionRuntimeInfo | { success?: boolean; error?: string } | null
         if (gen !== sessionLoadGeneration) return
-        if (result && result.success === false) {
+        if (result && 'success' in result && result.success === false) {
           set({ sessionLoading: false, ...idleTurnState() })
           get().addMessage({
             id: generateId(),
             role: 'system',
-            content: result.error ?? 'Cannot switch session — Pi not running',
+            content: result.error ?? 'Cannot activate session',
             timestamp: Date.now(),
           })
           return
         }
-        await get().reloadActiveSession({ refreshList: false })
-        if (gen !== sessionLoadGeneration) return
+        const runtime = result && 'runtimeId' in result ? result : null
+        if (get().activeWorkspace?.id) void window.piDesktop.ui.flushPendingPrompts(get().activeWorkspace!.id)
+        set({
+          currentView: 'chat',
+          sessionLoading: runtime?.status !== 'running',
+          ...(runtime ? {
+            activeSessionRuntimeId: runtime.runtimeId,
+            piStatus: runtime.status,
+            piPid: runtime.pid,
+            piError: runtime.error,
+          } : {}),
+        })
+        // If the runtime is already ready this starts hydration now. If it is
+        // still starting, handleSessionRuntime retries on its running event.
+        void get().reloadActiveSession({ refreshList: false })
         scheduleSessionListRefresh(get)
       } catch (err) {
         if (gen !== sessionLoadGeneration) return
@@ -1401,17 +1373,17 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     if (projectPath && !(activeWorkspace && pathsEqual(activeWorkspace.path, projectPath))) {
       const matchingWs = workspaces.find((w) => pathsEqual(w.path, projectPath))
       if (matchingWs) {
-        if (!(await get().switchWorkspace(matchingWs.id, { skipSessionLoad: true }))) return
+        if (!(await get().activateWorkspace(matchingWs.id, { start: false }))) return
       } else {
         await get().createWorkspace(session.projectName, projectPath)
         const newWs = get().workspaces.find((w) => pathsEqual(w.path, projectPath))
-        if (newWs && !(await get().switchWorkspace(newWs.id, { skipSessionLoad: true }))) return
+        if (newWs && !(await get().activateWorkspace(newWs.id, { start: false }))) return
       }
     }
     // switchSession's working-workspace guard covers the live-turn cases from
     // here on: the turn's own session re-attaches instead of switching, and
     // opening a different session of a mid-turn workspace warns first.
-    await get().switchSession(session.path)
+    await get().switchSession(session.path, projectPath)
     // Bring the chat into view (may be on Settings/Notes/etc.). In-app
     // switches keep their remembered scroll position, so no force-to-bottom.
     get().setCurrentView('chat')
@@ -2070,6 +2042,32 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     set({ workspaceActivity: map })
   },
 
+  handleSessionRuntime: (runtime) => {
+    const state = get()
+    set((current) => ({
+      sessionRuntimes: { ...current.sessionRuntimes, [runtime.runtimeId]: runtime },
+      activeSessionRuntimeId: runtime.active
+        ? runtime.runtimeId
+        : current.activeSessionRuntimeId === runtime.runtimeId
+          ? null
+          : current.activeSessionRuntimeId,
+      ...(runtime.active ? {
+        piStatus: runtime.status,
+        piPid: runtime.pid,
+        piError: runtime.error,
+      } : {}),
+    }))
+    if (
+      runtime.active &&
+      runtime.status === 'running' &&
+      runtime.sessionPath &&
+      state.sessionState?.sessionFile !== runtime.sessionPath &&
+      !state.sessionLoading
+    ) {
+      void get().reloadActiveSession({ refreshList: false })
+    }
+  },
+
   recoverPendingPrompts: async () => {
     // Isolated: the activity snapshot is cosmetic and must never block the
     // prompt flush below, which recovers a held blocking dialog.
@@ -2170,7 +2168,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     const duplicate = get().workspaces.find((w) => pathsEqual(w.path, path))
     if (duplicate) {
       if (duplicate.id !== get().activeWorkspace?.id) {
-        await get().switchWorkspace(duplicate.id)
+        await get().activateWorkspace(duplicate.id)
       }
       return
     }
@@ -2197,7 +2195,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       // Pi is actively editing its own checkout.
       const workspace = await window.piDesktop.workspace.createTab()
       await get().loadWorkspaces()
-      const switched = await get().switchWorkspace(workspace.id)
+      const switched = await get().activateWorkspace(workspace.id)
       if (switched) {
         get().setCurrentView('chat')
         if (workspace.sourceWasDirty) {
@@ -2260,7 +2258,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         ws = get().workspaces.find((w) => pathsEqual(w.path, folderPath))
         if (!ws) return false
       }
-      const switched = await get().switchWorkspace(ws.id)
+      const switched = await get().activateWorkspace(ws.id)
       if (switched) get().setCurrentView('chat')
       return switched
     } catch (err) {
@@ -2268,6 +2266,47 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         id: generateId(),
         role: 'system',
         content: `Open folder error: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      })
+      return false
+    }
+  },
+
+  // Fast workspace activation commits the project pointer immediately. Pi
+  // startup and session hydration continue in the background.
+  activateWorkspace: async (workspaceId, options) => {
+    if (get().activeWorkspace?.id === workspaceId) {
+      if (options?.start !== false && get().piStatus !== 'running') void get().startPi()
+      return true
+    }
+    if (!(await get().confirmDiscardEditorChanges())) return false
+    try {
+      const workspace = await window.piDesktop.workspace.setActive(workspaceId)
+      sessionLoadGeneration += 1
+      get().clearMessages()
+      set((state) => ({
+        workspaces: state.workspaces.some((item) => item.id === workspace.id)
+          ? state.workspaces.map((item) => item.id === workspace.id ? workspace : item)
+          : [...state.workspaces, workspace],
+        activeWorkspace: workspace,
+        sessionState: null,
+        sessionStats: null,
+        sessionLoading: true,
+        piStatus: 'starting',
+        piPid: null,
+        piError: null,
+        extensionUiRequest: null,
+        previewTarget: null,
+        editorDirty: false,
+      }))
+      void window.piDesktop.ui.flushPendingPrompts(workspace.id)
+      if (options?.start !== false) void get().startPi()
+      return true
+    } catch (err) {
+      get().addMessage({
+        id: generateId(),
+        role: 'system',
+        content: `Switch workspace error: ${err instanceof Error ? err.message : String(err)}`,
         timestamp: Date.now(),
       })
       return false

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -401,6 +401,7 @@ interface AppActions {
   // Session
   createNewSession: () => Promise<void>
   launchTask: (options: SessionLaunchTaskOptions) => Promise<boolean>
+  closeSessionTab: (runtimeId: string) => Promise<void>
   switchSession: (path: string, projectPath?: string) => Promise<void>
   /**
    * Open a session row from any surface (sidebar, session panel, quick
@@ -1292,6 +1293,66 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
     }
   },
 
+  closeSessionTab: async (runtimeId) => {
+    const runtime = get().sessionRuntimes[runtimeId]
+    if (!runtime) return
+
+    if (runtime.activity === 'working' || runtime.activity === 'needs-approval') {
+      const confirmed = await get().requestConfirm({
+        title: 'Close session tab?',
+        message: 'Pi is still working in this session. Closing the tab stops its runtime; saved messages remain available from Sessions.',
+        confirmLabel: 'Close tab',
+        cancelLabel: 'Keep working',
+        danger: true,
+      })
+      if (!confirmed) return
+    }
+
+    const wasActive = runtimeId === get().activeSessionRuntimeId || runtime.active
+    try {
+      const result = await window.piDesktop.session.closeRuntime(runtimeId)
+      if (!result) return
+
+      // The main process broadcasts the closed marker, but remove locally too
+      // so a renderer that races that event cannot leave a ghost tab behind.
+      set((state) => {
+        const { [runtimeId]: _closed, ...remaining } = state.sessionRuntimes
+        return {
+          sessionRuntimes: remaining,
+          ...(state.activeSessionRuntimeId === runtimeId ? { activeSessionRuntimeId: null } : {}),
+        }
+      })
+
+      if (wasActive) {
+        const replacement = Object.values(get().sessionRuntimes)
+          .filter((candidate) => candidate.workspaceId === result.workspaceId && candidate.sessionPath)
+          .reverse()[0]
+        if (replacement?.sessionPath) {
+          await get().switchSession(replacement.sessionPath, get().activeWorkspace?.path)
+        } else {
+          get().clearMessages()
+          set({
+            sessionState: null,
+            sessionStats: null,
+            sessionLoading: false,
+            activeSessionRuntimeId: null,
+            piStatus: 'stopped',
+            piPid: null,
+            piError: null,
+          })
+        }
+      }
+      void get().refreshSessionList()
+    } catch (err) {
+      get().addMessage({
+        id: generateId(),
+        role: 'system',
+        content: `Close session error: ${err instanceof Error ? err.message : String(err)}`,
+        timestamp: Date.now(),
+      })
+    }
+  },
+
   switchSession: async (path, projectPath) => {
     // Already on this session — avoid a full history reload. The explicit
     // sessionLoading check still handles a fast workspace switch that cleared
@@ -1500,13 +1561,14 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
       const list = await window.piDesktop.session.list()
       const sessionState = get().sessionState
       const activeWorkspace = get().activeWorkspace
-      const hasActiveSession = sessionState?.sessionFile
+      const activeHasContent = (sessionState?.messageCount ?? 0) > 0
+      const hasActiveSession = activeHasContent && sessionState?.sessionFile
         ? list.some((item) => item.path === sessionState.sessionFile || item.sessionId === sessionState.sessionId)
         : false
 
       const sessionList = hasActiveSession
         ? list
-        : sessionState?.sessionFile
+        : activeHasContent && sessionState?.sessionFile
         ? [
             {
               path: sessionState.sessionFile,
@@ -2116,6 +2178,16 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
   },
 
   handleSessionRuntime: (runtime) => {
+    if (runtime.closed) {
+      set((current) => {
+        const { [runtime.runtimeId]: _closed, ...remaining } = current.sessionRuntimes
+        return {
+          sessionRuntimes: remaining,
+          ...(current.activeSessionRuntimeId === runtime.runtimeId ? { activeSessionRuntimeId: null } : {}),
+        }
+      })
+      return
+    }
     set((current) => ({
       sessionRuntimes: { ...current.sessionRuntimes, [runtime.runtimeId]: runtime },
       activeSessionRuntimeId: runtime.active

--- a/src/renderer/src/store.ts
+++ b/src/renderer/src/store.ts
@@ -575,6 +575,18 @@ function generateId(): string {
   return `msg-${Date.now()}-${++messageCounter}`
 }
 
+function normalizePiCommands(raw: unknown): PiCommand[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .filter((command): command is Record<string, unknown> => typeof command === 'object' && command !== null)
+    .map((command) => ({
+      name: String(command.name ?? ''),
+      description: String(command.description ?? ''),
+      source: typeof command.source === 'string' ? command.source : 'extension',
+    }))
+    .filter((command) => command.name.length > 0)
+}
+
 // Bumps on every session switch / explicit reload so in-flight getMessages
 // results from a previous switch are dropped instead of fighting the UI.
 let sessionLoadGeneration = 0
@@ -1831,18 +1843,7 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
 
   loadCommands: async () => {
     try {
-      const raw = await window.piDesktop.piCommands.list()
-      const commands: PiCommand[] = Array.isArray(raw)
-        ? raw
-            .filter((c): c is Record<string, unknown> => typeof c === 'object' && c !== null)
-            .map((c) => ({
-              name: String(c.name ?? ''),
-              description: String(c.description ?? ''),
-              source: typeof c.source === 'string' ? c.source : 'extension',
-            }))
-            .filter((c) => c.name.length > 0)
-        : []
-      set({ commands })
+      set({ commands: normalizePiCommands(await window.piDesktop.piCommands.list()) })
     } catch {
       set({ commands: [] })
     }
@@ -2048,9 +2049,37 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
         })
         break
 
+      case 'available_commands_update':
+        set({ commands: normalizePiCommands((event as { commands?: unknown }).commands) })
+        break
+
+      case 'command_output': {
+        const text = (event as { text?: unknown }).text
+        if (typeof text === 'string' && text.trim()) {
+          get().addMessage({ id: generateId(), role: 'system', content: text, timestamp: Date.now() })
+        }
+        break
+      }
+
+      case 'prompt_result':
+        if (!(event as { agentInvoked?: unknown }).agentInvoked) {
+          set({ isStreaming: false })
+          void get().refreshSessionState()
+        }
+        break
+
+      case 'config_update':
+        void get().refreshSessionState()
+        break
+
       case 'extension_ui_request': {
         const uiEvent = event as PiExtensionUiRequest
-        if (uiEvent.method === 'setWidget') {
+        if (uiEvent.method === 'open_url') {
+          const url = uiEvent.launchUrl ?? uiEvent.url
+          if (url) void window.piDesktop.system.openExternal(url)
+        } else if (uiEvent.method === 'cancel') {
+          set((state) => state.extensionUiRequest?.id === uiEvent.targetId ? { extensionUiRequest: null } : state)
+        } else if (uiEvent.method === 'setWidget') {
           // Fire-and-forget: no renderer surface consumes widget lines yet.
         } else if (uiEvent.method === 'setStatus') {
           set((state) => {
@@ -2072,24 +2101,30 @@ export const useAppStore = create<AppState & AppActions>((set, get) => ({
           // Toast slot: kept apart from the dialog slot so a notification can
           // never clobber an unanswered blocking prompt.
           set({ extensionNotify: uiEvent })
-        } else {
-          // Blocking dialog methods (select, confirm, input, editor).
+        } else if (uiEvent.method === 'select' || uiEvent.method === 'confirm' || uiEvent.method === 'input' || uiEvent.method === 'editor') {
           set({ extensionUiRequest: uiEvent })
         }
         break
       }
 
-      case 'session_info_changed': {
+      case 'session_info_changed':
+      case 'session_info_update': {
         // Live title update (auto-title extension, /name, or our rename).
         // Apply the new name directly to the active session's state + list row
         // so both the Current Session panel and its Recent row update instantly,
         // with no file read or RPC round-trip.
-        const newName = (typeof event.name === 'string' && event.name.trim()) || null
+        const info = event as { name?: unknown; title?: unknown; sessionId?: unknown }
+        const rawName = info.name ?? info.title
+        const newName = (typeof rawName === 'string' && rawName.trim()) || null
         set((state) => {
           const activeFile = state.sessionState?.sessionFile ?? null
           return {
             sessionState: state.sessionState
-              ? { ...state.sessionState, sessionName: newName }
+              ? {
+                  ...state.sessionState,
+                  sessionName: newName,
+                  ...(typeof info.sessionId === 'string' ? { sessionId: info.sessionId } : {}),
+                }
               : state.sessionState,
             sessionList: activeFile
               ? state.sessionList.map((s) => (s.path === activeFile ? { ...s, name: newName } : s))

--- a/src/renderer/src/utils/workflow-runs.test.ts
+++ b/src/renderer/src/utils/workflow-runs.test.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  canAbortRun,
+  canResumeRun,
+  filterRunsBySession,
+  filterRunsByWorkspace,
+  isTerminalRun,
+  resolveRunSessionId,
+  runActiveAgentCount,
+} from './workflow-runs'
+import type { WorkflowAgentStatus, WorkflowRunStatus, WorkflowRunSummary } from '../../../shared/ipc-contracts'
+
+const HEADER_UUID = '01a01a28-f010-7b29-8312-21ba523d9edf'
+const STEM = `2026-08-19T13-14-45-648Z_${HEADER_UUID}`
+
+function run(sessionId: string | undefined, workspaceId = 'ws'): WorkflowRunSummary {
+  return {
+    workspaceId,
+    workspaceName: 'ws',
+    cwd: '/tmp',
+    runId: sessionId ?? 'no-session',
+    workflowName: 'w',
+    sessionId,
+    status: 'completed',
+    phases: ['plan'],
+    startedAt: '2026-08-19T13:00:00.000Z',
+    updatedAt: '2026-08-19T13:10:00.000Z',
+    agents: [],
+  }
+}
+
+test('resolveRunSessionId prefers Pi header UUID over the filename stem', () => {
+  assert.equal(resolveRunSessionId(HEADER_UUID, STEM), HEADER_UUID)
+})
+
+test('resolveRunSessionId derives the UUID from the stem suffix when the header is missing', () => {
+  assert.equal(resolveRunSessionId(undefined, STEM), HEADER_UUID)
+})
+
+test('resolveRunSessionId never returns the raw stem (tags/archive key)', () => {
+  // A stem without the timestamp_ prefix has no derivable UUID.
+  assert.equal(resolveRunSessionId(undefined, 'not-a-uuid'), null)
+  assert.equal(resolveRunSessionId('', 'not-a-uuid'), null)
+})
+
+test('filterRunsBySession keeps only the requested session across different session IDs', () => {
+  const otherUuid = '01b2b3c4-d5e6-4f70-a8b9-0c1d2e3f4a5b'
+  const runs = [run(HEADER_UUID), run(otherUuid), run(HEADER_UUID), run(undefined)]
+  const filtered = filterRunsBySession(runs, HEADER_UUID)
+  assert.equal(filtered.length, 2)
+  assert.ok(filtered.every((r) => r.sessionId === HEADER_UUID))
+})
+
+test('filterRunsBySession with null is the global list', () => {
+  const runs = [run(HEADER_UUID), run('01b2b3c4-d5e6-4f70-a8b9-0c1d2e3f4a5b')]
+  assert.equal(filterRunsBySession(runs, null).length, 2)
+})
+
+test('filterRunsByWorkspace keeps only runs recorded in the requested workspace', () => {
+  const runs = [run(HEADER_UUID, 'ws-a'), run(HEADER_UUID, 'ws-b'), run(undefined, 'ws-a')]
+  const filtered = filterRunsByWorkspace(runs, 'ws-a')
+  assert.equal(filtered.length, 2)
+  assert.ok(filtered.every((r) => r.workspaceId === 'ws-a'))
+})
+
+test('filterRunsByWorkspace with null is the global list', () => {
+  const runs = [run(HEADER_UUID, 'ws-a'), run(HEADER_UUID, 'ws-b')]
+  assert.equal(filterRunsByWorkspace(runs, null).length, 2)
+})
+
+// ─── Terminal presentation ───────────────────────────────────────────────────
+
+test('isTerminalRun covers the finished statuses only', () => {
+  for (const status of ['completed', 'failed', 'aborted'] as WorkflowRunStatus[]) {
+    assert.equal(isTerminalRun(status), true, status)
+  }
+  for (const status of ['pending', 'running', 'paused'] as WorkflowRunStatus[]) {
+    assert.equal(isTerminalRun(status), false, status)
+  }
+})
+
+test('runActiveAgentCount reports zero active agents on terminal runs even with stale running agents', () => {
+  const agents = [
+    { status: 'running' as WorkflowAgentStatus },
+    { status: 'running' as WorkflowAgentStatus },
+    { status: 'done' as WorkflowAgentStatus },
+  ]
+  for (const status of ['completed', 'failed', 'aborted'] as WorkflowRunStatus[]) {
+    assert.equal(runActiveAgentCount(agents, status), 0, status)
+  }
+})
+
+test('runActiveAgentCount counts running agents only while the run is live', () => {
+  const agents = [
+    { status: 'running' as WorkflowAgentStatus },
+    { status: 'running' as WorkflowAgentStatus },
+    { status: 'done' as WorkflowAgentStatus },
+  ]
+  assert.equal(runActiveAgentCount(agents, 'running'), 2)
+  assert.equal(runActiveAgentCount(agents, 'paused'), 2)
+  assert.equal(runActiveAgentCount(agents, 'pending'), 2)
+})
+
+// ─── Control eligibility (mirrors the extension's allowedActions) ───────────
+
+test('canAbortRun is true only for running/paused', () => {
+  for (const status of ['running', 'paused'] as WorkflowRunStatus[]) {
+    assert.equal(canAbortRun(status), true, status)
+  }
+  for (const status of ['pending', 'completed', 'failed', 'aborted'] as WorkflowRunStatus[]) {
+    assert.equal(canAbortRun(status), false, status)
+  }
+})
+
+test('canResumeRun is true only for paused/failed/pending — never completed/aborted', () => {
+  for (const status of ['paused', 'failed', 'pending'] as WorkflowRunStatus[]) {
+    assert.equal(canResumeRun(status), true, status)
+  }
+  for (const status of ['running', 'completed', 'aborted'] as WorkflowRunStatus[]) {
+    assert.equal(canResumeRun(status), false, status)
+  }
+})

--- a/src/renderer/src/utils/workflow-runs.ts
+++ b/src/renderer/src/utils/workflow-runs.ts
@@ -1,0 +1,89 @@
+import type { WorkflowAgentStatus, WorkflowRunStatus, WorkflowRunSummary } from '../../../shared/ipc-contracts'
+
+/**
+ * Resolve the Pi session identifier used to scope workflow runs.
+ *
+ * Persisted runs carry `run.sessionId` = Pi's header UUID (e.g.
+ * `01a01a28-f010-7b29-8312-21ba523d9edf`), so a session-scoped filter must
+ * compare UUIDs. When a session row's header is unreadable, `piSessionId`
+ * is missing; the session filename stem (`<timestamp>_<uuid>`) is still a
+ * valid source because its suffix IS the UUID. The raw stem — the registry
+ * key used by tags/archive — never matches a run's `sessionId`.
+ *
+ * Returns null when no UUID can be derived (defensive; session files are
+ * always named `<timestamp>_<uuid>.jsonl`).
+ */
+export function resolveRunSessionId(
+  piSessionId: string | undefined,
+  sessionId: string
+): string | null {
+  if (piSessionId) return piSessionId
+  const underscore = sessionId.indexOf('_')
+  if (underscore <= 0 || underscore >= sessionId.length - 1) return null
+  return sessionId.slice(underscore + 1)
+}
+
+/**
+ * The single filter used by the workflow navigator. Global mode (`null`)
+ * returns every run; session mode matches `run.sessionId` exactly, so a
+ * scoped panel can never show another session's runs.
+ */
+export function filterRunsBySession(
+  runs: readonly WorkflowRunSummary[],
+  sessionId: string | null
+): WorkflowRunSummary[] {
+  return sessionId ? runs.filter((run) => run.sessionId === sessionId) : [...runs]
+}
+
+/**
+ * The workspace-scope filter for the sidebar's Activity → Workflows entry.
+ * Global mode (`null`) returns every run; workspace mode matches
+ * `run.workspaceId` exactly, so a scoped panel can never show another
+ * project's runs. Applied AFTER the session filter (session scope wins).
+ */
+export function filterRunsByWorkspace(
+  runs: readonly WorkflowRunSummary[],
+  workspaceId: string | null
+): WorkflowRunSummary[] {
+  return workspaceId ? runs.filter((run) => run.workspaceId === workspaceId) : [...runs]
+}
+
+// ─── Terminal presentation ───────────────────────────────────────────────────
+// Persisted runs can freeze in-flight agents and currentPhase when a run is
+// aborted/failed mid-flight. These helpers are presentation-only: the
+// persisted agent statuses are never rewritten, they just stop looking active.
+
+/** Run-level statuses that are finished; nothing below them is still spinning. */
+export const TERMINAL_RUN_STATUSES: ReadonlySet<WorkflowRunStatus> = new Set([
+  'completed',
+  'failed',
+  'aborted',
+])
+
+export function isTerminalRun(status: WorkflowRunStatus): boolean {
+  return TERMINAL_RUN_STATUSES.has(status)
+}
+
+/**
+ * Agents that should render as actively working. On a terminal run a stale
+ * persisted `running` agent is frozen, not active — count it as idle.
+ */
+export function runActiveAgentCount(
+  agents: ReadonlyArray<{ status: WorkflowAgentStatus }>,
+  runStatus: WorkflowRunStatus
+): number {
+  if (isTerminalRun(runStatus)) return 0
+  return agents.filter((agent) => agent.status === 'running').length
+}
+
+// ─── Control eligibility (mirrors the extension's allowedActions) ────────────
+
+/** Abort (`stop`) is meaningful only while the run can still be stopped. */
+export function canAbortRun(status: WorkflowRunStatus): boolean {
+  return status === 'running' || status === 'paused'
+}
+
+/** Resume is meaningful only where the extension actually supports it. */
+export function canResumeRun(status: WorkflowRunStatus): boolean {
+  return status === 'paused' || status === 'failed' || status === 'pending'
+}

--- a/src/shared/council-config.test.ts
+++ b/src/shared/council-config.test.ts
@@ -191,6 +191,11 @@ test('consultant command uses read-only flags per agent', () => {
   assert.ok(codex.args.includes('exec'))
 })
 
+test('OMP consultant command uses its native read-only tool allowlist', () => {
+  const omp = buildConsultantCommand('pi', 'omp', 'omp')
+  assert.deepEqual(omp.args, ['-p', '--mode', 'json', '--no-session', '--tools', 'read,grep,glob'])
+})
+
 test('consultant command never puts the prompt in argv (stdin-only delivery)', () => {
   // Untrusted prompt text must not reach the command line — on Windows the args
   // pass through cmd.exe and would be open to shell-metacharacter injection.

--- a/src/shared/council-config.ts
+++ b/src/shared/council-config.ts
@@ -225,9 +225,12 @@ export function buildDebatePrompt(
  * on the command line would allow shell-metacharacter injection. Keeping only
  * static flags in argv closes that vector.
  */
+export type CouncilPiEngine = 'pi' | 'omp'
+
 export function buildConsultantCommand(
   id: CouncilAgentId,
   executable: string,
+  engine: CouncilPiEngine = 'pi',
 ): { file: string; args: string[] } {
   switch (id) {
     case 'pi':
@@ -237,7 +240,10 @@ export function buildConsultantCommand(
       // keeps it ephemeral.
       return {
         file: executable,
-        args: ['-p', '--mode', 'json', '--no-session', '--exclude-tools', 'bash,edit,write'],
+        args:
+          engine === 'omp'
+            ? ['-p', '--mode', 'json', '--no-session', '--tools', 'read,grep,glob']
+            : ['-p', '--mode', 'json', '--no-session', '--exclude-tools', 'bash,edit,write'],
       }
     case 'claude':
       // stream-json + partial messages let us render Claude's plan live as it

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -83,6 +83,12 @@ export const IPC_CHANNELS = {
   // Activity
   ACTIVITY_GET_STATS: 'activity:get-stats',
 
+  // Workflow run monitoring
+  WORKFLOW_LIST: 'workflow:list',
+  WORKFLOW_GET_RUN: 'workflow:get-run',
+  WORKFLOW_CONTROL: 'workflow:control',
+  WORKFLOW_SET_PERSISTENCE: 'workflow:set-persistence',
+
   // Diagnostics
   DIAGNOSTICS_GET: 'diagnostics:get',
 
@@ -97,6 +103,7 @@ export const IPC_CHANNELS = {
   WORKSPACE_PATH_EXISTS: 'workspace:path-exists',
   WORKSPACE_START_PI: 'workspace:start-pi',
   WORKSPACE_STOP_PI: 'workspace:stop-pi',
+  WORKSPACE_CREATE_TAB: 'workspace:create-tab',
   WORKSPACE_ACTIVITY_GET: 'workspace:activity',
   WORKSPACE_TAKE_PENDING_ACTIVATION: 'workspace:take-pending-activation',
 
@@ -193,10 +200,13 @@ export interface PiStartOptions {
   provider?: string
   sessionPath?: string
   noSession?: boolean
-  // When true (and neither sessionPath nor noSession is set), Pi is launched
-  // with --continue so it resumes the most recent session for the cwd instead
-  // of creating a fresh one.
+  // When true (and neither sessionPath, forkSessionPath nor noSession is set),
+  // Pi is launched with --continue so it resumes the most recent session for
+  // the cwd instead of creating a fresh one.
   continueSession?: boolean
+  // Start a new session by forking this existing Pi session file. The new
+  // session is created in the supplied cwd.
+  forkSessionPath?: string
   args?: string[]
   env?: Record<string, string>
 }
@@ -377,6 +387,117 @@ export interface WorkspaceActivity {
 /** Keyed by workspace id; idle workspaces are omitted. */
 export type WorkspaceActivityMap = Record<string, WorkspaceActivity>
 
+// ─── Workflow monitoring ────────────────────────────────────────────────────
+
+export type WorkflowRunStatus = 'pending' | 'running' | 'paused' | 'completed' | 'failed' | 'aborted'
+export type WorkflowAgentStatus = 'queued' | 'running' | 'done' | 'error' | 'skipped'
+
+export interface WorkflowAgentSummary {
+  id: number
+  callId?: string
+  label: string
+  phase?: string
+  status: WorkflowAgentStatus
+  error?: string
+  errorCode?: string
+  recoverable?: boolean
+  hasHistory: boolean
+  resultPreview?: string
+  tokens?: number
+  model?: string
+  startedAt?: string
+  endedAt?: string
+  tokenUsage?: {
+    input: number
+    output: number
+    total: number
+    cost?: number
+    cacheRead?: number
+    cacheWrite?: number
+  }
+}
+
+/**
+ * Control action dispatched to the run's owning workspace Pi process. `stop`
+ * maps to the extension's `/workflows stop <id>` (marks the run aborted),
+ * `resume` to `/workflows resume <id>` (paused/failed/pending only).
+ */
+export type WorkflowControlAction = 'stop' | 'resume'
+
+export type WorkflowControlReason =
+  | 'no-pi'
+  | 'pi-not-running'
+  | 'extension-missing'
+  | 'status-not-permitted'
+  | 'dispatch-failed'
+  | 'timeout'
+
+/** Result of a workflow control dispatch (never a fake local status change). */
+export interface WorkflowControlResult {
+  action: WorkflowControlAction
+  runId: string
+  ok: boolean
+  reason?: WorkflowControlReason
+  /** True only when the extension command was actually handed to Pi. */
+  dispatched?: boolean
+}
+
+/** Safe, renderer-sized projection of a dynamic-workflow persisted run. */
+export interface WorkflowRunSummary {
+  workspaceId: string
+  workspaceName: string
+  cwd: string
+  runId: string
+  workflowName: string
+  sessionId?: string
+  status: WorkflowRunStatus
+  pauseReason?: string
+  resetHint?: string
+  phases: string[]
+  currentPhase?: string
+  agents: WorkflowAgentSummary[]
+  startedAt: string
+  updatedAt: string
+  durationMs?: number
+  tokenUsage?: {
+    input: number
+    output: number
+    total: number
+    cost?: number
+    cacheRead?: number
+    cacheWrite?: number
+  }
+}
+
+export interface WorkflowHistoryEntry {
+  id?: string
+  timestamp?: string
+  role: string
+  kind: string
+  text: string
+  toolName?: string
+  path?: string
+  diff?: string
+  isError?: boolean
+}
+
+export interface WorkflowAgentDetail extends WorkflowAgentSummary {
+  prompt?: string
+  resultText?: string
+  history: WorkflowHistoryEntry[]
+  transcriptSource: 'persisted-session' | 'run-history' | 'none'
+  transcriptComplete: boolean
+}
+
+/** Lazy-loaded detail for one run; large fields never travel in list polling. */
+export interface WorkflowRunDetail extends WorkflowRunSummary {
+  script?: string
+  argsText?: string
+  resultText?: string
+  logs: string[]
+  agents: WorkflowAgentDetail[]
+}
+
 export interface PiMessageStartEvent {
   type: 'message_start'
   message: Record<string, unknown>
@@ -489,7 +610,10 @@ export interface SessionListItem {
   name: string | null
   /** Preview of the session's first user message, or null if it has none. */
   preview: string | null
+  /** Filename stem used by GUI registries (tags/archive), e.g. timestamp_uuid. */
   sessionId: string
+  /** Pi's header UUID, used to correlate workflow runs with this session. */
+  piSessionId?: string
   lastModified: number
   messageCount: number
   projectPath: string
@@ -813,6 +937,22 @@ export interface UpdateCheckResult {
 
 // ─── Workspace Types ────────────────────────────────────────────────────────
 
+export type WorkspaceKind = 'folder' | 'worktree'
+
+/** Options for creating an isolated tab from the active Git workspace. */
+export interface WorkspaceTabOptions {
+  name?: string
+  sourceWorkspaceId?: string
+  /** Optional Pi session to fork into the new worktree. */
+  forkSessionPath?: string
+}
+
+/** Result of closing a workspace tab. Dirty worktrees are preserved. */
+export interface WorkspaceRemoveResult {
+  worktreeRemoved?: boolean
+  preservedWorktreePath?: string
+}
+
 export interface Workspace {
   id: string
   name: string
@@ -820,6 +960,16 @@ export interface Workspace {
   createdAt: number
   lastActiveAt: number
   color: string
+  /** Optional for backward compatibility with older workspaces.json files. */
+  kind?: WorkspaceKind
+  /** Main repository root for managed worktrees. */
+  repoRoot?: string
+  /** Branch checked out by a managed worktree. */
+  branch?: string
+  /** Commit used as the worktree base. */
+  baseRef?: string
+  /** The source tab had local changes that were intentionally not copied. */
+  sourceWasDirty?: boolean
 }
 
 // ─── Notes Types ────────────────────────────────────────────────────────────

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -26,6 +26,7 @@ export const IPC_CHANNELS = {
   // Session management
   SESSION_NEW: 'session:new',
   SESSION_SWITCH: 'session:switch',
+  SESSION_LIST_RUNTIMES: 'session:list-runtimes',
   SESSION_FORK: 'session:fork',
   SESSION_CLONE: 'session:clone',
   SESSION_LIST: 'session:list',
@@ -177,6 +178,7 @@ export const IPC_CHANNELS = {
   EVENT_PI: 'event:pi',
   EVENT_PENDING_PROMPTS: 'event:pending-prompts',
   EVENT_WORKSPACE_ACTIVITY: 'event:workspace-activity',
+  EVENT_SESSION_RUNTIME: 'event:session-runtime',
   EVENT_ACTIVATE_WORKSPACE: 'event:activate-workspace',
   EVENT_FILE_CHANGE: 'event:file-change',
   EVENT_TERMINAL_DATA: 'event:terminal-data',
@@ -192,6 +194,18 @@ export interface PiStatus {
   status: PiProcessStatus
   pid: number | null
   error: string | null
+}
+
+export type SessionRuntimeActivity = 'working' | 'needs-approval' | 'completed' | 'failed'
+
+/** Live runtime for one Pi session. Multiple runtimes may share one workspace cwd. */
+export interface SessionRuntimeInfo extends PiStatus {
+  runtimeId: string
+  workspaceId: string
+  sessionPath: string | null
+  sessionId: string | null
+  activity: SessionRuntimeActivity | null
+  active: boolean
 }
 
 export interface PiStartOptions {

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -1003,6 +1003,8 @@ export interface WorkspaceTabOptions {
   sourceWorkspaceId?: string
   /** Optional Pi session to fork into the new worktree. */
   forkSessionPath?: string
+  /** Original task text used to reuse the same worktree on a later launch. */
+  taskPrompt?: string
   /** Skip the default runtime when another action will launch a task there. */
   startPi?: boolean
 }
@@ -1030,6 +1032,10 @@ export interface Workspace {
   baseRef?: string
   /** The source tab had local changes that were intentionally not copied. */
   sourceWasDirty?: boolean
+  /** False for an existing user worktree adopted by the app; never delete it on close. */
+  managed?: boolean
+  /** Original task text when the app created or adopted this worktree. */
+  taskPrompt?: string
 }
 
 // ─── Notes Types ────────────────────────────────────────────────────────────

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -26,6 +26,7 @@ export const IPC_CHANNELS = {
   // Session management
   SESSION_NEW: 'session:new',
   SESSION_LAUNCH_TASK: 'session:launch-task',
+  SESSION_CLOSE_RUNTIME: 'session:close-runtime',
   SESSION_SWITCH: 'session:switch',
   SESSION_LIST_RUNTIMES: 'session:list-runtimes',
   SESSION_FORK: 'session:fork',
@@ -211,6 +212,17 @@ export interface SessionRuntimeInfo extends PiStatus {
   sessionId: string | null
   activity: SessionRuntimeActivity | null
   active: boolean
+  /** Main emitted marker telling the renderer to remove this closed tab. */
+  closed?: boolean
+}
+
+export interface SessionRuntimeCloseResult {
+  runtimeId: string
+  workspaceId: string
+  sessionPath: string | null
+  /** Header-only sessions are disposable and are deleted when closed. */
+  empty: boolean
+  deleted: boolean
 }
 
 export interface SessionLaunchTaskOptions {

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -14,6 +14,7 @@ export const IPC_CHANNELS = {
   PI_STOP: 'pi:stop',
   PI_RESTART: 'pi:restart',
   PI_STATUS: 'pi:status',
+  PI_DETECT_INSTALLATIONS: 'pi:detect-installations',
 
   // Pi commands
   PI_PROMPT: 'pi:prompt',
@@ -988,6 +989,16 @@ export interface PermissionRulesWorkspaceStatus {
   // Whether the workspace rules file actually contains any allow rules — the
   // only case where trust changes behavior.
   hasAllowRules: boolean
+}
+
+export interface AgentInstallation {
+  kind: 'pi' | 'omp'
+  path: string
+  source: string
+}
+
+export interface AgentInstallationsResult {
+  installations: AgentInstallation[]
 }
 
 export interface AppSettings {

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -25,6 +25,7 @@ export const IPC_CHANNELS = {
 
   // Session management
   SESSION_NEW: 'session:new',
+  SESSION_LAUNCH_TASK: 'session:launch-task',
   SESSION_SWITCH: 'session:switch',
   SESSION_LIST_RUNTIMES: 'session:list-runtimes',
   SESSION_FORK: 'session:fork',
@@ -206,6 +207,11 @@ export interface SessionRuntimeInfo extends PiStatus {
   sessionId: string | null
   activity: SessionRuntimeActivity | null
   active: boolean
+}
+
+export interface SessionLaunchTaskOptions {
+  workspaceId: string
+  prompt: string
 }
 
 export interface PiStartOptions {

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -141,6 +141,10 @@ export const IPC_CHANNELS = {
   FILE_STAGED_DIFF: 'file:staged-diff',
   GIT_STATUS: 'git:status',
   GIT_BRANCH: 'git:branch',
+  GIT_CONVEYOR_STATUS: 'git:conveyor-status',
+  GIT_CONVEYOR_COMMIT: 'git:conveyor-commit',
+  GIT_CONVEYOR_PUSH: 'git:conveyor-push',
+  GIT_CONVEYOR_CREATE_PR: 'git:conveyor-create-pr',
 
   // Terminal
   TERMINAL_START: 'terminal:start',
@@ -212,6 +216,33 @@ export interface SessionRuntimeInfo extends PiStatus {
 export interface SessionLaunchTaskOptions {
   workspaceId: string
   prompt: string
+  isolated?: boolean
+}
+
+export interface GitConveyorStatus {
+  branch: string | null
+  head: string
+  lastCommitMessage: string | null
+  dirtyFiles: number
+  ahead: number
+  behind: number
+  hasUpstream: boolean
+  remoteUrl: string | null
+}
+
+export interface GitConveyorCommitOptions {
+  message: string
+}
+
+export interface GitConveyorPullRequestOptions {
+  title: string
+  body: string
+  draft?: boolean
+}
+
+export interface GitConveyorPullRequestResult {
+  url: string | null
+  output: string
 }
 
 export interface PiStartOptions {
@@ -406,6 +437,13 @@ export interface WorkspaceActivity {
 
 /** Keyed by workspace id; idle workspaces are omitted. */
 export type WorkspaceActivityMap = Record<string, WorkspaceActivity>
+
+/** Target carried by a desktop-notification click. */
+export interface WorkspaceActivationIntent {
+  workspaceId: string
+  sessionPath?: string
+  runtimeId?: string
+}
 
 // ─── Workflow monitoring ────────────────────────────────────────────────────
 
@@ -965,6 +1003,8 @@ export interface WorkspaceTabOptions {
   sourceWorkspaceId?: string
   /** Optional Pi session to fork into the new worktree. */
   forkSessionPath?: string
+  /** Skip the default runtime when another action will launch a task there. */
+  startPi?: boolean
 }
 
 /** Result of closing a workspace tab. Dirty worktrees are preserved. */

--- a/src/shared/ipc-contracts.ts
+++ b/src/shared/ipc-contracts.ts
@@ -413,7 +413,7 @@ export interface PiResponseEvent {
 export interface PiExtensionUiRequest {
   type: 'extension_ui_request'
   id: string
-  method: 'select' | 'confirm' | 'input' | 'editor' | 'notify' | 'setStatus' | 'setWidget' | 'setTitle' | 'set_editor_text'
+  method: 'select' | 'confirm' | 'input' | 'editor' | 'notify' | 'setStatus' | 'setWidget' | 'setTitle' | 'set_editor_text' | 'open_url' | 'cancel'
   title?: string
   message?: string
   options?: string[]
@@ -426,6 +426,10 @@ export interface PiExtensionUiRequest {
   widgetLines?: string[]
   widgetPlacement?: string
   timeout?: number
+  url?: string
+  launchUrl?: string
+  instructions?: string
+  targetId?: string
 }
 
 /**
@@ -593,6 +597,39 @@ export interface PiSessionInfoChangedEvent {
   name?: string | null
 }
 
+/** OMP's RPC spelling for a live session title update. */
+export interface PiSessionInfoUpdateEvent {
+  type: 'session_info_update'
+  title?: string | null
+  sessionId?: string
+}
+
+/** OMP emits this when its slash-command catalog changes. */
+export interface PiAvailableCommandsUpdateEvent {
+  type: 'available_commands_update'
+  commands: unknown[]
+}
+
+/** Output from a local-only OMP slash command. */
+export interface PiCommandOutputEvent {
+  type: 'command_output'
+  text: string
+}
+
+/** Completion signal for an accepted prompt that did not invoke the agent. */
+export interface PiPromptResultEvent {
+  type: 'prompt_result'
+  id?: string
+  agentInvoked: boolean
+}
+
+/** OMP config changes that should cause the renderer to re-read get_state. */
+export interface PiConfigUpdateEvent {
+  type: 'config_update'
+  model?: unknown
+  thinkingLevel?: string
+}
+
 export type PiRpcEvent =
   | PiAgentStartEvent
   | PiAgentEndEvent
@@ -614,6 +651,11 @@ export type PiRpcEvent =
   | PiExtensionUiRequest
   | PiStatusChangeEvent
   | PiSessionInfoChangedEvent
+  | PiSessionInfoUpdateEvent
+  | PiAvailableCommandsUpdateEvent
+  | PiCommandOutputEvent
+  | PiPromptResultEvent
+  | PiConfigUpdateEvent
 
 // ─── Model Types ────────────────────────────────────────────────────────────
 
@@ -632,6 +674,11 @@ export interface ModelInfo {
     output: number
     cacheRead: number
     cacheWrite: number
+  }
+  /** OMP exposes the effort values supported by the active model. */
+  thinking?: {
+    mode?: string
+    efforts?: string[]
   }
 }
 


### PR DESCRIPTION
## Overview

This PR is the full Pi Desktop workflow/navigation and multi-session runtime pass. It fixes Windows project discovery, adds real workflow monitoring and controls, and reorganizes the UI around the selected project without creating fake workspaces or duplicate Pi processes.

## Marathon goals delivered

### Fast navigation

- Project activation commits the selected workspace immediately instead of waiting for Pi startup or full chat hydration.
- Session activation commits the selected conversation immediately and hydrates its history in the background.
- Pi startup, session-state reads, message hydration, session-list refreshes, and worktree Pi startup are asynchronous from the navigation path.
- Cached shell state/file services remain usable while the selected runtime changes from `starting` to `running`.

### One Pi process per live session

- Added in-memory session runtimes underneath each project workspace.
- Every live session gets its own `PiRpcManager`, stdin/stdout channel, PID, session file, and activity state.
- Multiple sessions can share the same project cwd without sharing a Pi process.
- Switching sessions never sends destructive `switch_session` to the old process; the old session keeps working in the background.
- Existing session files attach with Pi's `--session <session-file>` startup option.
- New sessions start fresh runtimes without inheriting the previous session's `--continue` behavior.
- Runtime state is exposed to the renderer with process status, PID, active binding, and working/approval/completed/failed indicators.
- Session tabs appear above the project content when multiple live sessions exist; sidebar/session rows show the same indicators.
- Blocking extension prompts are queued per Pi process, not per workspace, so two sessions in one project cannot receive each other's approval dialog.
- Workflow controls route to the Pi process associated with the workflow's session when that runtime is available.

## Other changes

### Project and workspace architecture

- Added isolated Git worktree tabs with deterministic workspace IDs and real worktree lifecycle handling.
- Kept normal **New session** separate from `+ New isolated Git tab`.
- Added clear non-Git handling instead of pretending an isolated tab can be created.
- Preserved one file service per registered workspace and aggregate background workspace activity.
- Added project opening from the sidebar and drag/drop workspace flow support.

### Correct project and session discovery

- Session JSONL header `cwd` is authoritative for project identity.
- Removed reliance on lossy Windows session-directory decoding that turned:
  `E:\Projects\AI\pi-desktop` into `E:\Projects\AI\pi\desktop`.
- Preserved registered workspace IDs while healing stale/phantom paths in memory.
- Added bounded/cached workflow project discovery.
- Unknown workflow projects are exposed through read-only projections rather than persisted as GUI workspaces.
- Workflow/session correlation uses Pi header UUIDs, never filename stems.

### Workflow monitoring and controls

- Added main-process workflow discovery/monitoring and IPC/preload contracts.
- Added live polling of persisted workflow runs with project, session, and global filtering.
- Added structured run list/detail UI: phases, progress, agent status/counts/models/tokens, logs, scripts, transcripts, prompts, and results.
- Added real extension-backed Abort/Resume controls; the UI never fakes terminal states.
- Normalized terminal statuses so stopped/failed runs do not show stale active spinners.
- Added exact-session filtering for session-row workflow actions and global All Workflows browsing.

### Navigation and project-scoped UX

- Rebuilt the sidebar around the selected project and path.
- Added compact Home access beside Pi Desktop and kept sidebar reopening visible when hidden.
- Project-scoped Sessions defaults to the selected project; Current Only is flat/non-collapsible.
- All Sessions remains available through the explicit scope toggle/View all action.
- Activity workflows show only the selected project's runs.
- All Workflows is in the final Tools slot and remains global.
- Tools open in a distinct Tools tab instead of leaving a project workspace tab looking active.
- Global workflows render in the Tools surface; project/session workflow panels dismiss on outside click.
- New sessions switch directly to Chat after creation.

### Workflow Results UX

- Overview remains focused on execution state: phases, agent progress, counts, and transcript entry points.
- Results is a flat report view rather than a recursive JSON inspector:
  - compact workflow-output header with copy action
  - top-level result sections
  - numbered collapsible audit/report items titled from `id`, `name`, `title`, or `label`
  - long implementation, verification, and report text rendered full-width as Markdown
  - deeper objects shown only through disclosure sections
  - no card-inside-card nesting or raw JSON by default
  - disclosure state survives live polling refreshes

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Targeted workflow/session/runtime suites: 143 passing.
- Full Node suite on Windows: 825 passed, with 10 platform-specific failures in Linux-path/autostart, agent-detection, Pi-binary-resolution, and packaged renderer-origin assumptions.

## Guardrails

- No new dependencies.
- No fake workspaces or fake Pi managers.
- No raw workflow JSON rendered as the primary UI.
- Runtime processes are intentionally in-memory; session files remain Pi's durable source of truth.
- Same-cwd sessions can edit the same files, so Git worktree tabs remain available as the isolation option when file conflicts matter.


## Productivity control plane

- Added **Mission Control**, a global background-session and workflow inbox across projects.
- Added **New Task**, available from Home, the sidebar, Ctrl/Cmd+K (`task`), and Mission Control.
- New Task selects a project, creates a dedicated Pi runtime, and sends the issue directly to that runtime. It does not route through whichever session happens to be active, so switching away during startup is safe.
- Mission Control links live session state and workflow journal state to the existing project/session navigation without introducing a second task state machine.
- Added a focused `session:launch-task` IPC contract with boundary validation.

The current slice deliberately leaves worktree selection and commit/PR automation to the next step; the existing isolated-tab flow remains the safe file-isolation option.


Mission Control also exposes a real one-click **Proceed** action for paused merge-readiness workflows (and Retry for resumable failed/pending runs), so the common “proceed” prompt no longer requires opening the run and manually pinging Pi.


## Branding, notifications, and full conveyor

- Renderer favicon, Electron window identity, Windows AppUserModelId, macOS dock, tray, packaged icon, and desktop notifications now use the shared orange Pi artwork.
- Completion/failure notifications carry the exact runtime session path when available. Clicking one activates the correct project and session, including the hidden-window/reload path; older aggregate notifications still fall back to the workspace.
- Task Launcher can create a clean isolated Git worktree without spawning a throwaway Pi process, then launches the task in its own runtime.
- Diff Review now provides explicit Commit → Push → PR actions. Git commands are spawned without a shell, paths stay bound to the active workspace, and PR creation uses the upstream GitHub remote when configured, with the created URL opened externally.
- The conveyor is intentionally approval-gated: no implicit commit, push, or PR creation.


## Task worktree reuse

- The Task Launcher selector uses the active theme's dark/light color scheme for native dropdowns.
- When isolated work is requested, Pi Desktop first checks saved task metadata, explicit local branch references, and GitHub PR URLs.
- PR URLs resolve their head branch through `gh pr view`; matching local worktrees are reused, while ambiguous matches fall back to a new worktree.
- Existing user-created worktrees are adopted as non-managed tabs and are never deleted when the tab closes.
- Reuse keeps the checkout and branch, but starts a separate Pi runtime/session; it never attaches one JSONL session to two live processes.


## Follow-up polish

- New Session now hydrates as soon as its active runtime reports the generated session path, instead of leaving the empty-session spinner active; startup errors also end loading and surface the error state.
- Diff Review uses a dedicated action row, keeps the title and utility controls stable, and prevents the Commit/Push/PR buttons from wrapping around the header at narrow widths.



## Tab lifecycle

- Project tabs and session tabs close with their visible close controls or the middle mouse button (DOM button 1); right-click remains available for context menus.
- Closing a session tab stops only that runtime and preserves non-empty sessions for later resume.
- Header-only empty sessions are deleted on close and filtered from Sessions/Recent, preventing stale `session:switch` targets and the existing-session-file error.


Inactive abandoned empty runtimes are also pruned during session/runtime refresh, so merely opening New Session and leaving it unused no longer leaves a stale tab behind.


## OMP engine support

- Added first-class `omp` resolution (including OMP-only auto-detection and the Windows `%LOCALAPPDATA%\omp\omp.exe` / Bun install locations).
- OMP runs through the same independent desktop runtime, with sessions pinned to Desktop's existing JSONL store.
- Negotiates OMP RPC protocol v2 for lossless large frames, maps OMP's read-only tools and plugin verbs, and consumes OMP command/title/local-output/config events.
- Thinking effort choices now follow the active model's advertised values, including `max`.

- Agent Configuration now scans common PATH, Bun, npm-global, and platform install locations, offers detected Pi/OMP choices, and retains a custom executable/install-directory picker.
